### PR TITLE
Add CNtranslator Node for Chinese user.

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -17650,6 +17650,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+        {
+            "author": "SleeeepyZhou",
+            "title": "CNtranslator",
+            "id": "cn-translator",
+            "reference": "https://github.com/SleeeepyZhou/ComfyUI-CNtranslator",
+            "files": [
+                "https://github.com/SleeeepyZhou/ComfyUI-CNtranslator"
+            ],
+            "install_type": "git-clone",
+            "description": "A translation node for users in Chinese Mainland. (Because of the network firewall in Chinese Mainland, many translation APIs cannot be used normally.)"
+        },
     ]
 }


### PR DESCRIPTION
Because of the network firewall in Chinese Mainland, many translation APIs cannot be used normally. Therefore, this node has been made to facilitate users in Chinese Mainland.

Thank you for reviewing !!!