### PR TITLE
Fix: correct author & ID for ComfyUI-LikeSpiderAI-SaveMP3

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -26677,19 +26677,16 @@
             "description": "Addon for ComfyUI that adds 'Fix node (recreate + keep inputs)' context menu option"
         },
         {
-    "name": "ComfyUI-LikeSpiderAI-SaveMP3",
-    "url": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
-    "author": "Pigidiy",
-    "title": "ComfyUI-LikeSpiderAI-SaveMP3",
-    "id": "likeSpiderMP3",
-    "reference": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
-    "files": [
-        "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3"
-    ],
-    "install_type": "git-clone",
-    "version": "v1.0.0",
-    "description": "A custom ComfyUI node that saves input AUDIO as .mp3 using ffmpeg."
-},
+            "author": "Pigidiy",
+            "title": "ComfyUI-LikeSpiderAI-SaveMP3",
+            "id": "likeSpiderMP3",
+            "reference": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
+            "files": [
+                "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3"
+            ],
+            "install_type": "git-clone",
+            "description": "A custom ComfyUI node that saves input AUDIO as .mp3 using ffmpeg."
+        },
         {
             "author": "violet0927",
             "title": "Hugging Face LoRA Uploader",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -26677,16 +26677,19 @@
             "description": "Addon for ComfyUI that adds 'Fix node (recreate + keep inputs)' context menu option"
         },
         {
-            "author": "aimingfail",
-            "title": "ComfyUI-LikeSpiderAI-SaveMP3",
-            "id": "img2halftone",
-            "reference": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
-            "files": [
-                "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3"
-            ],
-            "install_type": "git-clone",
-            "description": "A custom ComfyUI node that saves input AUDIO as .mp3 using ffmpeg."
-        },
+    "name": "ComfyUI-LikeSpiderAI-SaveMP3",
+    "url": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
+    "author": "Pigidiy",
+    "title": "ComfyUI-LikeSpiderAI-SaveMP3",
+    "id": "likeSpiderMP3",
+    "reference": "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3",
+    "files": [
+        "https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3"
+    ],
+    "install_type": "git-clone",
+    "version": "v1.0.0",
+    "description": "A custom ComfyUI node that saves input AUDIO as .mp3 using ffmpeg."
+},
         {
             "author": "violet0927",
             "title": "Hugging Face LoRA Uploader",


### PR DESCRIPTION
This PR corrects the metadata for the ComfyUI-LikeSpiderAI-SaveMP3 node:

Changes author from aimingfail → Pigidiy

Adds missing version field: v1.0.0

Updates id from img2halftone → likeSpiderMP3

The previous metadata was mistakenly duplicated from another node.

Project repo: https://github.com/Pigidiy/ComfyUI-LikeSpiderAI-SaveMP3