### PR TITLE
BUG: Remove `file` argument from `logging.error` in `manager_server.py`

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -589,7 +589,7 @@ async def task_worker():
                 return 'success'
 
         except Exception as e:
-            logging.error(f"[ComfyUI-Manager] ERROR: {e}", file=sys.stderr)
+            logging.error(f"[ComfyUI-Manager] ERROR: {e}")
 
         return f"Model installation error: {model_url}"
 


### PR DESCRIPTION
Otherwise this results in:
```python
TypeError: Logger._log() got an unexpected keyword argument 'file' 
```