### PR TITLE
Add LTX-Video ICLoRA models for depth, pose, and canny control

### DIFF
--- a/model-list.json
+++ b/model-list.json
@@ -5159,6 +5159,39 @@
       "size": "1.33GB"
     },
     {
+      "name": "LTX-Video ICLoRA Depth 13B v0.9.7",
+      "type": "lora",
+      "base": "LTX-Video",
+      "save_path": "loras",
+      "description": "In-Context LoRA (IC LoRA) for depth-controlled video-to-video generation with precise depth conditioning.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-depth-13b-0.9.7",
+      "filename": "ltxv-097-ic-lora-depth-control-comfyui.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-depth-13b-0.9.7/resolve/main/ltxv-097-ic-lora-depth-control-comfyui.safetensors",
+      "size": "81.9MB"
+    },
+    {
+      "name": "LTX-Video ICLoRA Pose 13B v0.9.7",
+      "type": "lora",
+      "base": "LTX-Video",
+      "save_path": "loras",
+      "description": "In-Context LoRA (IC LoRA) for pose-controlled video-to-video generation with precise pose conditioning.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-pose-13b-0.9.7",
+      "filename": "ltxv-097-ic-lora-pose-control-comfyui.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-pose-13b-0.9.7/resolve/main/ltxv-097-ic-lora-pose-control-comfyui.safetensors",
+      "size": "151MB"
+    },
+    {
+      "name": "LTX-Video ICLoRA Canny 13B v0.9.7",
+      "type": "lora",
+      "base": "LTX-Video",
+      "save_path": "loras",
+      "description": "In-Context LoRA (IC LoRA) for canny edge-controlled video-to-video generation with precise edge conditioning.",
+      "reference": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-canny-13b-0.9.7",
+      "filename": "ltxv-097-ic-lora-canny-control-comfyui.safetensors",
+      "url": "https://huggingface.co/Lightricks/LTX-Video-ICLoRA-canny-13b-0.9.7/resolve/main/ltxv-097-ic-lora-canny-control-comfyui.safetensors",
+      "size": "81.9MB"
+    },
+    {
       "name": "Latent Bridge Matching for Image Relighting",
       "type": "diffusion_model",
       "base": "LBM",


### PR DESCRIPTION
- Add LTX-Video ICLoRA Depth 13B v0.9.7 (81.9MB)
- Add LTX-Video ICLoRA Pose 13B v0.9.7 (151MB)
- Add LTX-Video ICLoRA Canny 13B v0.9.7 (81.9MB)

These In-Context LoRA models enable precise control for video-to-video generation with depth, pose, and canny edge conditioning respectively.