### PR TITLE
Fixed aria2 download issues and Added aria2 resumable download

### DIFF
--- a/glob/manager_downloader.py
+++ b/glob/manager_downloader.py
@@ -80,10 +80,7 @@ def aria2_download_url(model_url: str, model_dir: str, filename: str):
     import tqdm
     import time
 
-    if model_dir.startswith(core.comfy_path):
-        model_dir = model_dir[len(core.comfy_path) :]
-
-    download_dir = model_dir if model_dir.startswith('/') else os.path.join('/models', model_dir)
+    download_dir = model_dir
 
     download = aria2_find_task(download_dir, filename)
     if download is None:


### PR DESCRIPTION
When I was downloading using aria2, I noticed that the files were being downloaded to the wrong location. 
The download path for the model files was truncated here by the ComfyUI installation path, but it wasn't restored afterward. I couldn't find a reason for this action, so I think it's a bug and I removed this truncation operation. 
Could you please help check if this is correct? Thank you.

Then I added the .downloading suffix to the unfinished download files of aria2 to support aria2's resumable download function. 
At the same time, if the download interface is terminated unexpectedly now, it will no longer display check mark but will instead show the "install" button again.