### PR TITLE
Add Emissive-Color Node to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32105,6 +32105,14 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "PollyCreative",
+            "title": "Emissive-Color Node",
+            "id": "emissive-color",
+            "reference": "https://github.com/polly-creative/emissive-color",
+            "description": "A custom ComfyUI node that extracts the dominant color from an image to use as an emissive texture",
+            "tags": ["emissive", "color", "effect"]
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32111,6 +32111,10 @@
             "title": "Emissive-Color Node",
             "id": "emissive-color",
             "reference": "https://github.com/polly-creative/emissive-color",
+            "files": [
+                "https://github.com/polly-creative/emissive-color"
+            ],
+            "install_type": "git-clone",
             "description": "A custom ComfyUI node that extracts the dominant color from an image to use as an emissive texture",
             "tags": ["emissive", "color", "effect"]
         }


### PR DESCRIPTION

<img width="1534" height="566" alt="emissive-color" src="https://github.com/user-attachments/assets/ded401f6-b5b4-4d29-b051-9136eacf1d58" />



A custom ComfyUI node which extracts the dominant color from an image to use as an emissive texture