### PR TITLE
adding thought bubble custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -125,6 +125,17 @@
             "description": "Nodes: ColorBlend, ControlLoraSave, GetImageSize. NOTE: Control-LoRA recolor example uses these nodes."
         },
         {
+            "author": "matthewfriedrichs",
+            "title": "Thought Bubble",
+            "id": "thoughtbubble_interactivecanvas",
+            "reference": "https://github.com/matthewfriedrichs/ComfyUI-ThoughtBubble",
+            "files": [
+                "https://github.com/matthewfriedrichs/ComfyUI-ThoughtBubble"
+            ],
+            "install_type": "git-clone",
+            "description": "ThoughtBubble is a custom node for ComfyUI that provides an interactive canvas to build and manage your prompts in a more visual and organized way. Think of it as a whiteboard for your ideas, allowing you to link different concepts, create conditional logic, and dynamically generate prompts using a powerful set of commands."
+        },
+        {
             "author": "Fannovel16",
             "title": "ComfyUI's ControlNet Auxiliary Preprocessors",
             "id": "comfyui_controlnet_aux",


### PR DESCRIPTION
I made a neat node that has a modular infinite canvas interface for creating more complex prompts. The node also has a minimal language for conditionals, wild cards, and a few other text parsing tricks. Please let me know if there are any issues you need fixed before you add this node to the manager. Please feel free to move this node listing to anywhere in the custom-node-list.json. I just put it in what looked like the top available spot for ease of use on my end.