### PR TITLE
use configured db_mode instead of hardcoded 'remote' at startup

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -809,7 +809,7 @@ class UnifiedManager:
             dont_wait = True
 
         # reload 'cnr_map' and 'repo_cnr_map'
-        cnrs = await cnr_utils.get_cnr_data(cache_mode=cache_mode=='cache', dont_wait=dont_wait)
+        cnrs = await cnr_utils.get_cnr_data(cache_mode=True, dont_wait=dont_wait)
 
         for x in cnrs:
             self.cnr_map[x['id']] = x

--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -1754,9 +1754,10 @@ async def default_cache_update():
         if core.get_config()['network_mode'] == 'private':
             logging.info("[ComfyUI-Manager] The private comfyregistry is not yet supported in `network_mode=private`.")
         else:
-            # load at least once
-            await core.unified_manager.reload('remote', dont_wait=False)
-            await core.unified_manager.get_custom_nodes(channel_url, 'remote')
+            # use configured db_mode for startup data loading
+            db_mode = core.get_config()['db_mode']
+            await core.unified_manager.reload(db_mode, dont_wait=False)
+            await core.unified_manager.get_custom_nodes(channel_url, db_mode)
 
     logging.info("[ComfyUI-Manager] All startup tasks have been completed.")
 


### PR DESCRIPTION
The current behavior forces a fetch every startup even if the mode is set to cache - this makes startup slow for no reason.