### PR TITLE
Add pg nodesAdd "PG Nodes" to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -33613,6 +33613,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+		{
+            "title": "PG Nodes",
+            "author": "GizmoR13",
+            "description": "Pragmatic utilities for ComfyUI: Lazy Prompt (history + randomizer), Unified Loader (+ mini), Just Save Image (+ passthrough).",
+            "reference": "https://github.com/GizmoR13/PG-Nodes",
+            "install_type": "git-clone",
+            "pip": [],
+            "tags": ["prompt", "loader", "io", "utilities"]
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -33615,13 +33615,15 @@
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
 		{
+			"author": "GizmoR13",
             "title": "PG Nodes",
-            "author": "GizmoR13",
-            "description": "Pragmatic utilities for ComfyUI: Lazy Prompt (history + randomizer), Unified Loader (+ mini), Just Save Image (+ passthrough).",
+			"id": "PG",
             "reference": "https://github.com/GizmoR13/PG-Nodes",
-            "install_type": "git-clone",
-            "pip": [],
-            "tags": ["prompt", "loader", "io", "utilities"]
+			"files": [
+                "https://github.com/GizmoR13/PG-Nodes"
+            ],
+			"install_type": "git-clone",
+			"description": "Pragmatic utilities for ComfyUI: Lazy Prompt (history + randomizer), Unified Loader (+ mini), Just Save Image (+ passthrough)."
         }
     ]
 }


### PR DESCRIPTION
Adds PG Nodes to the Manager catalog.

id: "PG"
reference: https://github.com/GizmoR13/PG-Nodes
install_type: "git-clone"

Tested locally with DB: Local — entry renders correctly.
Package contains pyproject.toml with name "comfyui-PG-nodes" to ensure target folder name.
No extra pip deps required.