### PR TITLE
feat: Add IAMCCS-nodes repository (WANAnimate LoRA Loader Fix)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -34411,4 +34411,17 @@
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         }
     ]
+},
+{
+            "author": "IAMCCS",
+            "title": "IAMCCS-nodes",
+            "id": "iamccs-nodes",
+            "reference": "https://github.com/IAMCCS/IAMCCS-nodes",
+            "files": [
+                "https://github.com/IAMCCS/IAMCCS-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes by IAMCCS, including a critical fix for LoRA loading in native WANAnimate workflows, especially useful for advanced models like FLUX and WAN 2.1. This bypasses the need for the WanVideoWrapper for LoRA functionality."
+        }
+    ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -34409,10 +34409,8 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
-    ]
-},
-{
+        },
+        {
             "author": "IAMCCS",
             "title": "IAMCCS-nodes",
             "id": "iamccs-nodes",


### PR DESCRIPTION
This repo adds a node fixing LoRA loading in native WANAnimate workflows without using WanVideoWrapper. Critical for WAN 2.1/2.2/Animate users.