### PR TITLE
Add Dehypnotic Save nodes to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -22783,6 +22783,16 @@
             "install_type": "git-clone",
             "description": "ComfyUI nodes for face based filtering plus image batch merging."
         },
+		{
+            "author": "Dehypnotic",
+            "title": "Dehypnotic Save nodes",
+            "reference": "https://github.com/Dehypnotic/comfyui-dehypnotic-save-nodes",
+            "files": [
+                "https://github.com/Dehypnotic/comfyui-dehypnotic-save-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Save toolkit for audio, image, and video: MP3 audio export with VBR/CBR options, multi-format image saving with workflow/thumbnail metadata, and video + frame encoding (MP4/MKV/WEBM/MOV) — all sharing whitelist-safe paths and rich placeholder templating."
+        },
         {
             "author": "feixuetuba",
             "title": "Spleeter",


### PR DESCRIPTION
I requested name, folders and description changed about a week ago after adding two nodes to the existing one. It was merged to main but soon after removed and placed in the legacy-channel tagged as removed. The old record was placed in dev tagged as unsafe with the explanation: "This nodepack contains a node that has a vulnerability allowing write to arbitrary file paths.". 

I have now retested them all and none of them write to arbitrary file paths without having them in the offline whitelist that I was told to create the first time I submitted the Save MP3-node. Isn't this considered safe anymore? 