### PR TITLE
Add a Save Image (Dir) node to list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -34835,6 +34835,22 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+  			"author": "Owl-V",
+  			"title": "ComfyUI-Owlv_Nodes",
+  			"id": "comfyui-owlv_nodes",
+  			"reference": "OwlvChirotha/ComfyUI-Owlv_Nodes",
+  			"files": [
+    		  {
+      		    "url": "https://github.com/OwlvChirotha/ComfyUI-Owlv_Nodes",
+      		    "dest": "custom_nodes/ComfyUI-Owlv_Nodes",
+      		    "method": "clone"
+    		  }
+  			],
+  			"install_type": "git-clone",
+  			"description": "A collection of custom utility nodes for ComfyUI, providing a variety of practical mini-tools with multiple functions.",
+  			"tags": ["utility"]
+		}
     ]
 }


### PR DESCRIPTION
- Extends the official save_image node
- Allows users to save images to any custom directory
- Maintains panel preview functionally via temporary copies
- Auto-cleans temp files on each run