### PR TITLE
fix(manager-v4): ensure cache updates even when installed via pip until cacheless implementation is complete

### DIFF
--- a/comfyui_manager/common/cnr_utils.py
+++ b/comfyui_manager/common/cnr_utils.py
@@ -11,6 +11,7 @@ from . import manager_util
 
 import requests
 import toml
+import logging
 
 base_url = "https://api.comfy.org"
 
@@ -23,7 +24,7 @@ async def get_cnr_data(cache_mode=True, dont_wait=True):
     try:
         return await _get_cnr_data(cache_mode, dont_wait)
     except asyncio.TimeoutError:
-        print("A timeout occurred during the fetch process from ComfyRegistry.")
+        logging.info("A timeout occurred during the fetch process from ComfyRegistry.")
         return await _get_cnr_data(cache_mode=True, dont_wait=True)  # timeout fallback
 
 async def _get_cnr_data(cache_mode=True, dont_wait=True):
@@ -79,12 +80,12 @@ async def _get_cnr_data(cache_mode=True, dont_wait=True):
                 full_nodes[x['id']] = x
 
             if page % 5 == 0:
-                print(f"FETCH ComfyRegistry Data: {page}/{sub_json_obj['totalPages']}")
+                logging.info(f"FETCH ComfyRegistry Data: {page}/{sub_json_obj['totalPages']}")
 
             page += 1
             time.sleep(0.5)
 
-        print("FETCH ComfyRegistry Data [DONE]")
+        logging.info("FETCH ComfyRegistry Data [DONE]")
 
         for v in full_nodes.values():
             if 'latest_version' not in v:
@@ -100,7 +101,7 @@ async def _get_cnr_data(cache_mode=True, dont_wait=True):
             if cache_state == 'not-cached':
                 return {}
             else:
-                print("[ComfyUI-Manager] The ComfyRegistry cache update is still in progress, so an outdated cache is being used.")
+                logging.info("[ComfyUI-Manager] The ComfyRegistry cache update is still in progress, so an outdated cache is being used.")
                 with open(manager_util.get_cache_path(uri), 'r', encoding="UTF-8", errors="ignore") as json_file:
                     return json.load(json_file)['nodes']
 
@@ -114,7 +115,7 @@ async def _get_cnr_data(cache_mode=True, dont_wait=True):
         return json_obj['nodes']
     except Exception:
         res = {}
-        print("Cannot connect to comfyregistry.")
+        logging.warning("Cannot connect to comfyregistry.")
     finally:
         if cache_mode:
             is_cache_loading = False
@@ -240,7 +241,7 @@ def generate_cnr_id(fullpath, cnr_id):
             with open(cnr_id_path, "w") as f:
                 return f.write(cnr_id)
     except Exception:
-        print(f"[ComfyUI Manager] unable to create file: {cnr_id_path}")
+        logging.error(f"[ComfyUI Manager] unable to create file: {cnr_id_path}")
 
 
 def read_cnr_id(fullpath):

--- a/comfyui_manager/glob/manager_core.py
+++ b/comfyui_manager/glob/manager_core.py
@@ -1003,7 +1003,6 @@ class UnifiedManager:
         """
 
         result = ManagedResult('enable')
-
         if 'comfyui-manager' in node_id.lower():
             return result.fail(f"ignored: enabling '{node_id}'")
 

--- a/comfyui_manager/glob/manager_server.py
+++ b/comfyui_manager/glob/manager_server.py
@@ -2045,10 +2045,7 @@ async def default_cache_update():
             )
             traceback.print_exc()
 
-    if (
-        core.get_config()["network_mode"] != "offline"
-        and not manager_util.is_manager_pip_package()
-    ):
+    if core.get_config()["network_mode"] != "offline":
         a = get_cache("custom-node-list.json")
         b = get_cache("extension-node-map.json")
         c = get_cache("model-list.json")


### PR DESCRIPTION
fixed: Bug fix in glob/manager_server.py that prevented cache updates when installed via pip.

Until the cacheless implementation is fully applied, the cache must always be updated — otherwise, various parts of the system will malfunction.

Revert following condition:
https://github.com/Comfy-Org/ComfyUI-Manager/blob/e0640e701441e38ec4ae155cfb0aead102b9f122/comfyui_manager/glob/manager_server.py#L2050