### PR TITLE
Add TTS WebUI API nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -35468,6 +35468,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+		{
+            "author": "rsxdalv",
+            "title": "TTS WebUI API nodes for ComfyUI",
+            "id": "tts-webui",
+            "reference": "https://github.com/rsxdalv/ComfyUI-TTS-Webui",
+            "files": [
+                "https://github.com/rsxdalv/ComfyUI-TTS-Webui"
+            ],
+            "install_type": "git-clone",
+            "description": "Nodes: TTS WebUI Kokoro, TTS WebUI Chatterbox, TTS WebUI StyleTTS2, TTS WebUI Kitten TTS, TTS WebUI F5-TTS, TTS WebUI Preset\nAdd API key to environment variable 'TTS_WEBUI_OPENAI_API_KEY'\nAlternatively you can write your API key to file 'tts_api_key.txt'\nYou can also use and/or override the above by entering your API key in the 'api_key' field of each node."
         }
     ]
 }


### PR DESCRIPTION
This adds integrations to connect to TTS WebUI via API (TTS WebUI and the models often require python 3.10 etc, so a direct install is not the best idea)

<img width="1009" height="743" alt="image" src="https://github.com/user-attachments/assets/2e2f24b6-b7d2-4ed0-91b5-12f67c99d45a" />
