### PR TITLE
Remove AF - Edit Generated Prompt node entry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -32233,16 +32233,6 @@
             "description": "High-utility nodes for ComfyUI with a focus on Flux 1 Dev workflows and Ultimate SD Upscale enhancement loops."
         },
         {
-            "author": "alFrame",
-            "title": "AF - Edit Generated Prompt",
-            "reference": "https://github.com/alFrame/ComfyUI-AF-EditGeneratedPrompt",
-            "files": [
-                "https://github.com/alFrame/ComfyUI-AF-EditGeneratedPrompt"
-            ],
-            "install_type": "git-clone",
-            "description": "A ComfyUI custom node that allows you to pipe a generated prompt and either pass it as is, or copy and edit it manually. Or you can use the lower input field like any regular text input filed. The content of the lower text field will always dominate the output of the node."
-        },
-        {
             "author": "joanna910225",
             "title": "HouseKeeper",
             "reference": "https://github.com/joanna910225/comfyui-housekeeper",


### PR DESCRIPTION
Removed 'AF - Edit Generated Prompt' node entry from the custom node list, as it's being migrated to a node pack and then re-summitted via official registry