### PR TITLE
Add ComfyUI-LinkModeToggle custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -36121,6 +36121,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+  			"name": "LinkModeToggle",
+  			"author": "Mike Simone",
+  			"url": "https://github.com/YOUR_GITHUB_USERNAME/LinkModeToggle",
+  			"branch": "main",
+  			"tags": ["ui", "ux", "canvas", "links"],
+  			"description": "F8/Ctrl+K hotkeys and a bottom-right toolbar button to cycle link render modes (Spline/Linear/Straight) with persistence.",
+  			"python": false,
+  			"pip": [],
+  			"license": "MIT"
+		}
+
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -36123,15 +36123,15 @@
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
 		{
-  			"name": "ComfyUI-LinkModeToggle",
   			"author": "mikesimone",
   			"title": "Link Mode Toggle",
+            "reference": "https://github.com/mikesimone/ComfyUI-LinkModeToggle",
+            "files": [
+                "https://github.com/mikesimone/ComfyUI-LinkModeToggle"
+            ],
+            "install_type": "git-clone",
   			"description": "Adds hotkeys (F8 / Ctrl+K) and a toolbar button to cycle node link styles (Spline / Linear / Straight).",
-  			"repo": "https://github.com/mikesimone/ComfyUI-LinkModeToggle",
-  			"tags": ["ui", "hotkey", "canvas"],
-  			"branch": "main"
+  			"tags": ["ui", "hotkey", "canvas"]
 		}
-
-
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -36123,16 +36123,15 @@
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
 		{
-  			"name": "LinkModeToggle",
-  			"author": "Mike Simone",
-  			"url": "https://github.com/YOUR_GITHUB_USERNAME/LinkModeToggle",
-  			"branch": "main",
-  			"tags": ["ui", "ux", "canvas", "links"],
-  			"description": "F8/Ctrl+K hotkeys and a bottom-right toolbar button to cycle link render modes (Spline/Linear/Straight) with persistence.",
-  			"python": false,
-  			"pip": [],
-  			"license": "MIT"
+  			"name": "ComfyUI-LinkModeToggle",
+  			"author": "mikesimone",
+  			"title": "Link Mode Toggle",
+  			"description": "Adds hotkeys (F8 / Ctrl+K) and a toolbar button to cycle node link styles (Spline / Linear / Straight).",
+  			"repo": "https://github.com/mikesimone/ComfyUI-LinkModeToggle",
+  			"tags": ["ui", "hotkey", "canvas"],
+  			"branch": "main"
 		}
+
 
     ]
 }


### PR DESCRIPTION
Adds LinkModeToggle — a simple utility that lets users cycle ComfyUI’s link rendering mode (Spline / Linear / Straight) with a single hotkey (F8 or Ctrl+K) or a toolbar button.  

- Persists last-used mode between sessions  
- Non-intrusive, works with all recent ComfyUI forks  
- Designed for clarity when editing dense workflows  

Repository: https://github.com/mikesimone/LinkModeToggle  
License: MIT  