### PR TITLE
Fix: Gracefully handle errors during pip package enumeration

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -2664,9 +2664,13 @@ def check_state_of_git_node_pack_single(item, do_fetch=False, do_update_check=Tr
 
 
 def get_installed_pip_packages():
-    # extract pip package infos
-    cmd = manager_util.make_pip_cmd(['freeze'])
-    pips = subprocess.check_output(cmd, text=True).split('\n')
+    try:
+        # extract pip package infos
+        cmd = manager_util.make_pip_cmd(['freeze'])
+        pips = subprocess.check_output(cmd, text=True).split('\n')
+    except Exception as e:
+        logging.warning("[ComfyUI-Manager] Could not enumerate pip packages for snapshot: %s", e)
+        return {}
 
     res = {}
     for x in pips:


### PR DESCRIPTION
### Issue

#2248 

### Changes

Modified get_installed_pip_packages() to suppress (squeeze) exceptions in order to prevent unexpected system shutdowns.

### Notes

- An environment-dependent issue. If you prefer to let the system crash early to catch such issues sooner, feel free to close this PR.
- Please share any suggestions on how this exception should be handled if you have specific requirements.