### PR TITLE
feat: add ComfyUI-MultiTranslator (replaces ComfyUI-Translator)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -35783,11 +35783,10 @@
         },
         {
             "author": "Owl-V",
-            "title": "ComfyUI-Translator",
-            "reference": "https://github.com/OwlvChirotha/ComfyUI-Translator",
-            "files": [
-                "https://github.com/OwlvChirotha/ComfyUI-Translator"
-            ],
+            "title": "ComfyUI-MultiTranslator",
+			"id": "comfyui-multitranslator-owlv",
+            "reference": "https://github.com/OwlvChirotha/ComfyUI-MultiTranslator",
+            "files":["https://github.com/OwlvChirotha/ComfyUI-MultiTranslator"]
             "install_type": "git-clone",
             "description": "ComfyUI plug-in collection of basic translator, LLM translator and a series of LLM Service Connectors.",
             "tags": ["translation", "llm", "ai", "connector", "utility"]


### PR DESCRIPTION
This PR addresses two issues with the previous ComfyUI-Translator entry:

Missing id field — caused the plugin to be invisible in ComfyUI-Manager's Install tab. Naming conflict — the original name ComfyUI-Translator overlaps with other translation plugins, leading to user confusion. The repository has been renamed to ComfyUI-MultiTranslator to better reflect its multi-engine capability and avoid conflicts.

This PR removes the old entry and adds a new, fully compliant one with a unique id.