### PR TITLE
Added 360 interactive crop tool.

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -36832,6 +36832,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "alankent",
+            "title": "OA 360 Clip",
+            "reference": "https://github.com/alankent/ComfyUI-OA-360-Clip",
+            "files": [
+                "https://github.com/alankent/ComfyUI-OA-360-Clip"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI node for extracting perspective views from 360 degree equirectangular images with an interactive drag-and-drop crop interface."
         }
     ]
 }


### PR DESCRIPTION
Its still pretty new, so fine if I should resubmit later. But it allows an interactive drag to pick crop out of a 360 image. Its like Olm-DragCrop in that it is interactive. But this only works with 360 images, removing curvature. This is useful for backgrounds where you want the camera shot to be from different angles with consistency. 360 images allow any rotation of the camera wanted for the start image.
