### PR TITLE
Add ComfyUI-RunpodDirect to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37009,6 +37009,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Madiator2011",
+            "title": "ComfyUI RunpodDirect",
+            "id": "runpoddirect",
+            "reference": "https://github.com/MadiatorLabs/ComfyUI-RunpodDirect",
+            "files": [
+                "https://github.com/MadiatorLabs/ComfyUI-RunpodDirect"
+            ],
+            "install_type": "git-clone",
+            "description": "Direct model downloads to your Runod pod with blazing-fast multi-connection support. No more downloading models to your local machine and re-uploading!"
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyUI-RunpodDirect - a server-side model downloader for Runpod deployments that enables direct downloads to pods with multi-connection support (8 parallel connections), eliminating the need to download models locally and re-upload. (works also on normal ComfyUI instalations)

- Repository: https://github.com/MadiatorLabs/ComfyUI-RunpodDirect
- Install type: git-clone
- Version: 1.0.5
- License: GPL v3

<img width="1537" height="196" alt="image" src="https://github.com/user-attachments/assets/666054ad-f4ff-4b60-9a23-6ec0ec734da2" />

<img width="1195" height="877" alt="image" src="https://github.com/user-attachments/assets/1895a774-4004-4d05-b9fe-921228dab3b3" />

Tested locally with "DB: Local" mode - loads without errors.