### PR TITLE
Add Keybinding Extra (keyboard shortcut extension)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -4,7 +4,7 @@
     		"title": "Keybinding Extra",
     		"repo": "https://github.com/akawana/ComfyUI-Keybinding-extra",
     		"author": "akawana",
-    		"description": "Adds configurable keyboard shortcuts to the ComfyUI frontend. Comment line (Ctrl+/).",
+    		"description": "Adds shortcuts for commenting and deleting lines of text, with a configurable comment symbol. Includes a node that cleans comments from text and splits content using tags for Regional Prompting.",
     		"tags": ["frontend", "shortcut", "utility"]
 		}
         {

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,12 +1,5 @@
 {
     "custom_nodes": [
-		{
-    		"title": "Keybinding Extra",
-    		"repo": "https://github.com/akawana/ComfyUI-Keybinding-extra",
-    		"author": "akawana",
-    		"description": "Adds shortcuts for commenting and deleting lines of text, with a configurable comment symbol. Includes a node that cleans comments from text and splits content using tags for Regional Prompting.",
-    		"tags": ["frontend", "shortcut", "utility"]
-		}
         {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI-Manager",
@@ -37389,6 +37382,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+    		"author": "akawana",
+    		"title": "Keybinding Extra",
+    		"reference": "https://github.com/akawana/ComfyUI-Keybinding-extra",
+            "files": [
+                "https://github.com/akawana/ComfyUI-Keybinding-extra"
+            ],
+			"install_type": "git-clone",
+    		"description": "Adds shortcuts for commenting and deleting lines of text, with a configurable comment symbol. Includes a node that cleans comments from text and splits content using tags for Regional Prompting.",
+    		"tags": ["frontend", "shortcut", "utility"]
+		}		
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,5 +1,12 @@
 {
     "custom_nodes": [
+		{
+    		"title": "Keybinding Extra",
+    		"repo": "https://github.com/akawana/ComfyUI-Keybinding-extra",
+    		"author": "akawana",
+    		"description": "Adds configurable keyboard shortcuts to the ComfyUI frontend. Comment line (Ctrl+/).",
+    		"tags": ["frontend", "shortcut", "utility"]
+		}
         {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI-Manager",


### PR DESCRIPTION
Added a new custom node for Keybinding Extra with settings. Currently provides only one shortcut for line comment with optional symbol by using CTRL+/ buttons,