### PR TITLE
Add HALXP-Comfy to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37728,8 +37728,7 @@
             "title": "HALXP-Comfy",
             "reference": "https://github.com/hal-xp/halxp-comfy",
             "files": [
-                "https://github.com/HAL-XP/halxp-comfy/blob/main/__init__.py",
-                "https://github.com/HAL-XP/halxp-comfy/blob/main/js/halxp-focus.js"
+                "https://github.com/hal-xp/halxp-comfy",
             ],
             "install_type": "git-clone",
             "description": "A UI suite for ComfyUI including Focus mode and layout enhancements."

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37722,6 +37722,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "HAL-XP",
+            "title": "HALXP-Comfy",
+            "reference": "https://github.com/hal-xp/halxp-comfy",
+            "files": [
+                "https://github.com/HAL-XP/halxp-comfy/blob/main/__init__.py",
+                "https://github.com/HAL-XP/halxp-comfy/blob/main/js/halxp-focus.js"
+            ],
+            "install_type": "git-clone",
+            "description": "A UI suite for ComfyUI including Focus mode and layout enhancements."
         }
     ]
 }


### PR DESCRIPTION
Created a button to autofocus the view on the current running node, added to custom node lists.
<img width="133" height="65" alt="image" src="https://github.com/user-attachments/assets/4275ffd4-661e-4e76-a911-095306bef572" />
