### PR TITLE
ComfyUI version listing + nightly current fix

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -3395,10 +3395,23 @@ def get_comfyui_versions(repo=None):
     except Exception:
         exact_tag = ''
 
+    head_is_default = False
+    remote_name = get_remote_name(repo)
+    if remote_name:
+        try:
+            default_head_ref = repo.refs[f'{remote_name}/HEAD']
+            default_commit = default_head_ref.reference.commit
+            head_is_default = repo.head.commit == default_commit
+        except Exception:
+            head_is_default = False
+
     nearest_semver = normalize_describe(described)
     exact_semver = exact_tag if parse_semver(exact_tag) else None
 
-    current_tag = exact_tag or described or 'nightly'
+    if head_is_default and not exact_tag:
+        current_tag = 'nightly'
+    else:
+        current_tag = exact_tag or described or 'nightly'
 
     # Prepare semver list for display: top 4 plus the current/nearest semver if missing
     display_semver_tags = semver_tags[:4]

--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -2538,7 +2538,7 @@ def update_to_stable_comfyui(repo_path):
             return "skip", None
         else:
             logging.info(f"[ComfyUI-Manager] Updating ComfyUI: {current_tag} -> {latest_tag}")
-            repo.git.checkout(tag_ref)
+            repo.git.checkout(tag_ref.name)
             execute_install_script("ComfyUI", repo_path, instant_execution=False, no_deps=False)
             return 'updated', latest_tag
     except:
@@ -3364,9 +3364,10 @@ async def restore_snapshot(snapshot_path, git_helper_extras=None):
 def get_comfyui_versions(repo=None):
     repo = repo or git.Repo(comfy_path)
 
+    remote_name = None
     try:
-        remote = get_remote_name(repo)
-        repo.remotes[remote].fetch()
+        remote_name = get_remote_name(repo)
+        repo.remotes[remote_name].fetch()
     except:
         logging.error("[ComfyUI-Manager] Failed to fetch ComfyUI")
 
@@ -3402,7 +3403,6 @@ def get_comfyui_versions(repo=None):
         exact_tag = ''
 
     head_is_default = False
-    remote_name = get_remote_name(repo)
     if remote_name:
         try:
             default_head_ref = repo.refs[f'{remote_name}/HEAD']


### PR DESCRIPTION
## Summary
- parse and sort ComfyUI semver tags descending, expose a capped list of versions (nightly + current describe + top semvers), and derive `latest_tag` from the highest semver
- treat the default-branch HEAD as `nightly` for the current label when it is not exactly on a tag, while preserving exact tags as the current label
- stable updates now look up the latest tag ref, skip if already on that commit, and log when the tag ref cannot be found

