### PR TITLE
Workflow Importer

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37670,18 +37670,6 @@
             "install_type": "git-clone",
             "description": "A logic engine for ComfyUI prompts that transforms static prompts into dynamic, context-aware workflows with persistent variables, conditional logic, native LoRA loading, and external data fetching. (Description by CC)"
         },
-        {
-            "author": "Matthew-X",
-            "title": "Workflow Importer",
-            "id": "comfyui-workflow_importer",
-            "reference": "https://github.com/Matthew-X/comfyui-workflow_importer",
-            "files": [
-                "https://github.com/Matthew-X/comfyui-workflow_importer"
-            ],
-            "install_type": "git-clone",
-            "js_path": "workflow_importer",
-            "description": "Import ComfyUI workflows from images with embedded metadata. Adds a toolbar Import button, drag-and-drop dialog and Ctrl+Shift+I shortcut. Supports legacy and new UIs, common image formats, opens each image in a new workflow tab."
-        },
 
 
 
@@ -38105,6 +38093,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+        {
+            "author": "Matthew-X",
+            "title": "Workflow Importer",
+            "id": "comfyui-workflow_importer",
+            "reference": "https://github.com/Matthew-X/comfyui-workflow_importer",
+            "files": [
+                "https://github.com/Matthew-X/comfyui-workflow_importer"
+            ],
+            "install_type": "git-clone",
+            "js_path": "workflow_importer",
+            "description": "Import ComfyUI workflows from images with embedded metadata. Adds a toolbar Import button, drag-and-drop dialog and Ctrl+Shift+I shortcut. Supports legacy and new UIs, common image formats, opens each image in a new workflow tab."
+        }		
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37706,6 +37706,7 @@
 
 
 
+
         {
             "author": "Ser-Hilary",
             "title": "SDXL_sizing",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37670,7 +37670,18 @@
             "install_type": "git-clone",
             "description": "A logic engine for ComfyUI prompts that transforms static prompts into dynamic, context-aware workflows with persistent variables, conditional logic, native LoRA loading, and external data fetching. (Description by CC)"
         },
-
+        {
+            "author": "Matthew-X",
+            "title": "Workflow Importer",
+            "id": "comfyui-workflow_importer",
+            "reference": "https://github.com/Matthew-X/comfyui-workflow_importer",
+            "files": [
+                "https://github.com/Matthew-X/comfyui-workflow_importer"
+            ],
+            "install_type": "git-clone",
+            "js_path": "workflow_importer",
+            "description": "Import ComfyUI workflows from images with embedded metadata. Adds a toolbar Import button, drag-and-drop dialog and Ctrl+Shift+I shortcut. Supports legacy and new UIs, common image formats, opens each image in a new workflow tab."
+        },
 
 
 


### PR DESCRIPTION
Due to ComfyUI breaking something that images generated from odler version of ComfyUI no longer have their workflows imported when dragging and dropping it into the comfyUI window. Well it does imports the workflow but it's no logner the original workflow that image had which is what my extension fixes.

This extension provides a new button which will open a drag and drop window allowing users to import their workflows form older verrsions of ComfyUI.

<img width="337" height="54" alt="ImportButtonExample" src="https://github.com/user-attachments/assets/eb652820-39a2-4eb5-9ba0-7663f405402f" />
<img width="2559" height="1390" alt="ImportWorkflowFromImageExample" src="https://github.com/user-attachments/assets/05855b86-71ce-4aae-9ff5-cd791f208091" />


