### PR TITLE
Add HackAfterDark nodes, including resolution presets for film/cinema

### DIFF
--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -1,6 +1,18 @@
 {
     "custom_nodes": [
         {
+            "author": "HackAfterDark",
+            "title": "AfterDark Film AR Selector",
+            "id": "ComfyUI-HackAfterDark-Nodes",
+            "reference": "https://github.com/hackafterdark/ComfyUI-HackAfterDark-Nodes",
+            "files": [
+                "https://github.com/hackafterdark/ComfyUI-HackAfterDark-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "A collection of utility nodes for ComfyUI, including resolution presets for film and photography aspect ratios.",
+            "tags": ["utility", "presets", "aspect ratio", "film"]
+        },
+        {
             "author": "jeankassio",
             "title": "ComfyUI_MusicTools",
             "id": "ComfyUI_MusicTools",


### PR DESCRIPTION
Hi! I've never found a resolution preset utility that I liked and I do a lot of image generation for photography/film so there's been rather obscure resolutions that I absolutely have never seen before. So I figured I would submit my first utility custom node. I'm hoping others find these useful too.

This custom node provides resolution presets for various film and photography sizes; 35mm, 70mm, medium format film, Xpan, Cinemascope, MGM 65, etc.