### PR TITLE
Add new custom node: lora_downloader

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38193,15 +38193,16 @@
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
-       {
+        {
             "author": "huihuihuiz",
             "title": "LoRA Downloader for ComfyUI",
             "id": "lora_downloader",
             "reference": "https://github.com/huihuihuiz/lora_downloader",
-            "repo_url": "https://github.com/huihuihuiz/lora_downloader",
+            "files": [
+                "https://github.com/huihuihuiz/lora_downloader"
+            ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
-
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38192,6 +38192,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+       {
+            "author": "huihuihuiz",
+            "title": "LoRA Downloader for ComfyUI",
+            "id": "lora_downloader",
+            "reference": "https://github.com/huihuihuiz/lora_downloader",
+            "repo_url": "https://github.com/huihuihuiz/lora_downloader",
+            "install_type": "git",
+            "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
+
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38199,7 +38199,7 @@
             "id": "lora_downloader",
             "reference": "https://github.com/huihuihuiz/lora_downloader",
             "repo_url": "https://github.com/huihuihuiz/lora_downloader",
-            "install_type": "git",
+            "install_type": "git-clone",
             "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
 

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -51865,5 +51865,13 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
+    ],
+    "https://raw.githubusercontent.com/huihuihuiz/lora_downloader/main/lora_downloader.py": [
+        [
+            "Lora_Downloader"
+        ],
+        {
+            "title_aux": "lora_downloader"
+        }
     ]
 }

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -51865,13 +51865,5 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
-    ],
-    "https://raw.githubusercontent.com/huihuihuiz/lora_downloader/main/lora_downloader.py": [
-        [
-            "Lora_Downloader"
-        ],
-        {
-            "title_aux": "lora_downloader"
-        }
     ]
 }


### PR DESCRIPTION
This PR adds the custom node plugin "lora_downloader".

GitHub repo:
https://github.com/huihuihuiz/lora_downloader

description: 
A custom node for downloading, organizing, and managing LoRA models directly inside ComfyUI.
