### PR TITLE
Retry  Add Majoor Assets Manager Extension to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -39298,6 +39298,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+            "author": "MajoorWaldi",
+            "title": "Majoor Assets Manager",
+			"id": "ComfyUI-Majoor-AssetsManager",
+            "reference": "https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager",
+            "files": [
+				"https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager"
+			],
+            "install_type": "git-clone",
+            "description": "An advanced Assets manager for ComfyUI outputs with gallery, metadata inspection, ratings, and tags.",
+            "tags": ["Assets manager", "gallery", "metadata", "workflow", "utility","comfy","manager"]
+		}
     ]
 }


### PR DESCRIPTION
Fast asset browser for ComfyUI outputs with ratings/tags stored in native OS metadata (and optional sidecars).
Majoor Assets Manager is a UI extension (no custom nodes) to browse, inspect, and organize images, videos.... without leaving ComfyUI.