### PR TITLE
Add 4 downloader plugins (LoRA, UNet, Plugin, Upscaler) to ComfyUI Manager

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38193,15 +38193,16 @@
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         },
-       {
+        {
             "author": "huihuihuiz",
             "title": "LoRA Downloader for ComfyUI",
             "id": "lora_downloader",
             "reference": "https://github.com/huihuihuiz/lora_downloader",
-            "repo_url": "https://github.com/huihuihuiz/lora_downloader",
+            "files": [
+                "https://github.com/huihuihuiz/lora_downloader"
+            ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
-
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -39829,6 +39829,39 @@
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
+        },
+        {
+            "author": "huihuihuiz",
+            "title": "UNet Downloader for ComfyUI",
+            "id": "unet_downloader",
+            "reference": "https://github.com/huihuihuiz/unet_downloader",
+            "files": [
+                "https://github.com/huihuihuiz/unet_downloader"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node for downloading and managing UNet/Diffusion models (FLUX, SD3, etc.) directly within the UI."
+        },
+        {
+            "author": "huihuihuiz",
+            "title": "Plugin Downloader for ComfyUI",
+            "id": "plugin_downloader",
+            "reference": "https://github.com/huihuihuiz/plugin_downloader",
+            "files": [
+                "https://github.com/huihuihuiz/plugin_downloader"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node for downloading and backing up all custom nodes/plugins as ZIP files."
+        },
+        {
+            "author": "huihuihuiz",
+            "title": "Upscaler Downloader for ComfyUI",
+            "id": "upscaler_downloader",
+            "reference": "https://github.com/huihuihuiz/upscaler_downloader",
+            "files": [
+                "https://github.com/huihuihuiz/upscaler_downloader"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node for downloading and managing upscaler/super-resolution models directly within the UI."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38192,6 +38192,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+       {
+            "author": "huihuihuiz",
+            "title": "LoRA Downloader for ComfyUI",
+            "id": "lora_downloader",
+            "reference": "https://github.com/huihuihuiz/lora_downloader",
+            "repo_url": "https://github.com/huihuihuiz/lora_downloader",
+            "install_type": "git",
+            "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
+
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38199,7 +38199,7 @@
             "id": "lora_downloader",
             "reference": "https://github.com/huihuihuiz/lora_downloader",
             "repo_url": "https://github.com/huihuihuiz/lora_downloader",
-            "install_type": "git",
+            "install_type": "git-clone",
             "description": "A ComfyUI custom node for downloading and managing LoRA models directly within the UI."
         }
 

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -51865,5 +51865,13 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
+    ],
+    "https://raw.githubusercontent.com/huihuihuiz/lora_downloader/main/lora_downloader.py": [
+        [
+            "Lora_Downloader"
+        ],
+        {
+            "title_aux": "lora_downloader"
+        }
     ]
 }

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -51865,13 +51865,5 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
-    ],
-    "https://raw.githubusercontent.com/huihuihuiz/lora_downloader/main/lora_downloader.py": [
-        [
-            "Lora_Downloader"
-        ],
-        {
-            "title_aux": "lora_downloader"
-        }
     ]
 }


### PR DESCRIPTION
## Description
Add 4 downloader plugins for ComfyUI Manager (including 1 existing and 3 new plugins).

## Plugins Included

### ✅ Already Exists (from previous commits)
1. **LoRA Downloader for ComfyUI**
   - Repository: https://github.com/huihuihuiz/lora_downloader
   - Description: Download and manage LoRA models directly within ComfyUI interface
   - Install Type: git-clone

### 🆕 New Plugins Added
2. **UNet Downloader for ComfyUI**
   - Repository: https://github.com/huihuihuiz/unet_downloader
   - Description: Download and manage UNet/Diffusion models (FLUX, SD3, etc.) within UI
   - Install Type: git-clone

3. **Plugin Downloader for ComfyUI**
   - Repository: https://github.com/huihuihuiz/plugin_downloader
   - Description: Download and backup all custom nodes/plugins as ZIP files
   - Install Type: git-clone

4. **Upscaler Downloader for ComfyUI**
   - Repository: https://github.com/huihuihuiz/upscaler_downloader
   - Description: Download and manage upscaler/super-resolution models
   - Install Type: git-clone

## Changes Made
- Added 3 new plugin entries to `custom-node-list.json`
- Updated existing LoRA Downloader entry
- Updated configuration files as needed

## Plugin Series Overview
These 4 plugins form a complete model management suite:
- **LoRA Downloader**: For LoRA models
- **UNet Downloader**: For diffusion models (SD3, FLUX, etc.)
- **Upscaler Downloader**: For super-resolution models
- **Plugin Downloader**: For plugin/extension management

## Checklist
- [x] All repositories are publicly accessible
- [x] All plugins follow ComfyUI node structure
- [x] No duplicate entries
- [x] Install types correctly specified
- [x] Descriptions are clear

---

**Note**: This PR completes the 4-plugin downloader series for ComfyUI.