### PR TITLE
Custom nodes for Google's Genmedia models

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -39963,6 +39963,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+  			"author": "gushob21",
+  			"title": "comfyui-google-genmedia-custom-nodes",
+			"id": "Google",
+  			"reference": "https://github.com/GoogleCloudPlatform/comfyui-google-genmedia-custom-nodes",
+  			"files": ["https://github.com/GoogleCloudPlatform/comfyui-google-genmedia-custom-nodes"],
+  			"install_type": "git-clone",
+  			"description": "A suite of experimental custom nodes that allows access to Google's 1P models like Veo, Imagen, Nano Banana, Gemini, Virtual-try-on, Lyria"
+		}
     ]
 }


### PR DESCRIPTION
Adding a suite of experimental custom nodes that allows access to Google's 1P models like Veo, Imagen, Nano Banana, Gemini, Virtual-try-on, Lyria