### PR TITLE
Add ComfyUI_FrontEndCleanup to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -40024,6 +40024,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
+		{
+            "author": "brucew4yn3rp",
+            "title": "Frontend Cleanup Node",
+            "id": "ComfyUI_FrontEndCleanup",
+            "reference": "https://github.com/brucew4yn3rp/ComfyUI_FrontEndCleanup",
+            "files": [
+                "https://github.com/brucew4yn3rp/ComfyUI_FrontEndCleanup"
+            ],
+            "install_type": "git-clone",
+            "description": "This node customizes the ComfyUI frontend by relocating the action bar into the top bar and hiding selected UI elements to reduce visual clutter."	
     ]
 }


### PR DESCRIPTION
# ComfyUI_FrontEndCleanup
This node customizes the ComfyUI frontend by relocating the action bar into the top bar and optionally hiding selected UI elements to reduce visual clutter.

## Before

<img width="1585" height="772" alt="image" src="https://github.com/user-attachments/assets/95b26011-f52d-4bd7-be17-7c57e0222f9a" />


## After

<img width="1914" height="942" alt="image" src="https://github.com/user-attachments/assets/fc468173-5892-4300-a519-2c0b092aea79" />

## Optional Settings Toggles to Hide Subgraph Breadcrumbs or Progress Menu

<img width="1505" height="864" alt="image" src="https://github.com/user-attachments/assets/4c92641e-91f0-401b-860a-b7b4874a6ad3" />
