### PR TITLE
Add ComfyUI_FMJ_SaveImageVersions node entry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41129,5 +41129,17 @@
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         }
+		{
+  			"author": "bulldog68",
+  			"title": "ComfyUI_FMJ_SaveImageVersions",
+  			"description": "Sauvegarde d’images avec métadonnées complètes (prompt, seed, versions logicielles) + chargement intelligent.",
+  			"reference": "https://github.com/bulldog68/ComfyUI_FMJ_SaveImageVersions",
+  			"files": [
+    			"https://github.com/bulldog68/ComfyUI_FMJ_SaveImageVersions.git"
+  			],
+  			"install_type": "git-clone",
+  			"tags": ["save image", "metadonne"],
+  			"license": "GNU V3"
+}
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41128,7 +41128,7 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
 		{
   			"author": "bulldog68",
   			"title": "ComfyUI_FMJ_SaveImageVersions",
@@ -41140,6 +41140,6 @@
   			"install_type": "git-clone",
   			"tags": ["save image", "metadonne"],
   			"license": "GNU V3"
-}
+		}
     ]
 }


### PR DESCRIPTION
Save images with full metadata (prompt, workflow, software versions, commit)

This repository provides ComfyUI nodes to:
- Save PNG images with embedded metadata (positive / negative prompts and other JSON fields),
- Generate and copy a snapshot describing the environment (commits, versions, GPU, etc.),
- Load an image and restore information from its metadata.

Important: this project runs a local script `snapshot.py` to capture the state of ComfyUI and custom nodes. Only run it in trusted environments.