### PR TITLE
fix: set logging to silent to remove annoying shell scrolling

### DIFF
--- a/glob/cnr_utils.py
+++ b/glob/cnr_utils.py
@@ -25,7 +25,7 @@ async def get_cnr_data(cache_mode=True, dont_wait=True):
         print("A timeout occurred during the fetch process from ComfyRegistry.")
         return await _get_cnr_data(cache_mode=True, dont_wait=True)  # timeout fallback
 
-async def _get_cnr_data(cache_mode=True, dont_wait=True):
+async def _get_cnr_data(cache_mode=True, dont_wait=True, silent=True):
     global is_cache_loading
 
     uri = f'{base_url}/nodes'
@@ -78,12 +78,14 @@ async def _get_cnr_data(cache_mode=True, dont_wait=True):
                 full_nodes[x['id']] = x
 
             if page % 5 == 0:
-                print(f"FETCH ComfyRegistry Data: {page}/{sub_json_obj['totalPages']}")
+                if not silent:
+                    print(f"FETCH ComfyRegistry Data: {page}/{sub_json_obj['totalPages']}")
 
             page += 1
             time.sleep(0.5)
 
-        print("FETCH ComfyRegistry Data [DONE]")
+        if not silent:
+            print("FETCH ComfyRegistry Data [DONE]")
 
         for v in full_nodes.values():
             if 'latest_version' not in v:

--- a/glob/manager_util.py
+++ b/glob/manager_util.py
@@ -178,7 +178,7 @@ def is_file_created_within_one_day(file_path):
     return time_difference <= 86400
 
 
-async def get_data(uri, silent=False):
+async def get_data(uri, silent=True):
     if not silent:
         print(f"FETCH DATA from: {uri}", end="")
 
@@ -225,7 +225,7 @@ def get_cache_state(uri):
     return "expired"
 
 
-def save_to_cache(uri, json_obj, silent=False):
+def save_to_cache(uri, json_obj, silent=True):
     cache_uri = get_cache_path(uri)
 
     with cache_lock:
@@ -235,7 +235,7 @@ def save_to_cache(uri, json_obj, silent=False):
                 logging.info(f"[ComfyUI-Manager] default cache updated: {uri}")
 
 
-async def get_data_with_cache(uri, silent=False, cache_mode=True, dont_wait=False, dont_cache=False):
+async def get_data_with_cache(uri, silent=True, cache_mode=True, dont_wait=False, dont_cache=False):
     cache_uri = get_cache_path(uri)
 
     if cache_mode and dont_wait:


### PR DESCRIPTION
This PR sets `silent=True` to avoid annoyance by the shell scrolling when you're trying to read errors.

For those who want this functionality now rather than later (v4) you can run this command (assumes you cloned the repo):
`git fetch origin pull/2491/head:pr-2491 && git checkout pr-2491`

Fixes
https://github.com/Comfy-Org/ComfyUI-Manager/issues/2329
https://github.com/Comfy-Org/ComfyUI-Manager/issues/2229
https://github.com/Comfy-Org/ComfyUI-Manager/issues/2117
https://github.com/Comfy-Org/ComfyUI-Manager/issues/1950
https://github.com/Comfy-Org/ComfyUI-Manager/issues/1629