### PR TITLE
Add ComfyUI-VRAM-watcher node with details

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41354,6 +41354,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+		},
+		{
+  			"author": "zwaigani",
+  			"title": "ComfyUI-VRAM-watcher",
+  			"id": "comfyui-vram-watcher",
+  			"reference": "https://github.com/zwaigani/ComfyUI-VRAM-watcher",
+  			"files": [
+    		"https://github.com/zwaigani/ComfyUI-VRAM-watcher"
+  			],
+  			"install_type": "git-clone",
+  			"description": "Displays GPU VRAM usage and system RAM usage as bar widgets in a ComfyUI node.",
+  			"tags": ["utils", "ui", "vram", "ram"]
+		}
     ]
 }


### PR DESCRIPTION
Repo: [https://github.com/zwaigani/ComfyUI-VRAM-watcher]
Summary: Displays GPU VRAM and system RAM usage as bar widgets in a ComfyUI node.