### PR TITLE
Add ComfyUI-AutoModelDownloader to Custom Node List

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37926,6 +37926,17 @@
             "description": "Direct model downloads to your Runod pod with blazing-fast multi-connection support. No more downloading models to your local machine and re-uploading!"
         },
         {
+            "author": "FNGarvin",
+            "title": "ComfyUI Auto Model Downloader",
+            "id": "automodeldownloader",
+            "reference": "https://github.com/FNGarvin/ComfyUI-AutoModelDownloader",
+            "files": [
+                "https://github.com/FNGarvin/ComfyUI-AutoModelDownloader"
+            ],
+            "install_type": "git-clone",
+            "description": "Convenient, high-speed model downloads directly to your Comfy install with blazing-fast, multi-connection support. No more downloading models to your downloads folder and having to manually move them to the proper folder!"
+        },
+        {
             "author": "kjqwer",
             "title": "SmartSaveImage",
             "reference": "https://github.com/kjqwer/SmartSaveImage",


### PR DESCRIPTION
Requesting to add a pretty straightforward rebranding of [ComfyUI-RunpodDirect](https://github.com/MadiatorLabs/ComfyUI-RunpodDirect) with the Runpod bits removed in order to make the addon ideally suited for "offline" use.  I have verified the JSON syntax using the 'Use local DB' feature as requested in the project readme.

This version makes the addon more widely appealing by stripping out all things Runpod-specific.  I have added atomic/partial file download safeties to improve functionality on troubled connections. 

Features

* Direct Downloads: Download models directly to your ComfyUI instance.

* Background Downloads: Downloads happen in the background with progress tracking.

* Multi-Connection Support: Accelerated downloads using multiple connections.

* Cross-Platform: Works on Linux, Windows, and macOS.

* Secure: Validates filenames and paths to prevent security issues.

* Privacy Focused: No external tracking or analytics.
