### PR TITLE
Add Preview Video Monitor Pro

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41499,6 +41499,17 @@
             "install_type": "copy",
             "description": "A node which takes in x, y, width, height, total width, and total height, in order to accurately represent the area of an image which is covered by area-based conditioning."
         },
+		{
+            "author": "CrateTools",
+            "title": "Preview Video Monitor Pro",
+            "id": "preview-video-monitor-pro",
+            "reference": "https://github.com/CrateTools/comfyui-preview-video-monitor",
+            "files": [
+                "https://github.com/CrateTools/comfyui-preview-video-monitor"
+            ],
+            "install_type": "git-clone",
+            "description": "Second monitor preview for video generations with interactive playback controls, color tools, generation tracking, and workflow-embedded snapshots."
+        },
         {
             "author": "underclockeddev",
             "title": "BrevImage",


### PR DESCRIPTION
Adding Preview Video Monitor Pro - a custom node that turns second monitors into an interactive preview display and player with user controls. Wipe, compare, side by side, zoom, pan, and color tools let you review your work. The generation tracking system keeps all iterations organized and accessible. Snapshot from the monitor viewer with workflow embedded. Use up to 6 physical monitors.