### PR TITLE
Fix undefined access in custom nodes manager conflicts calculation

### DIFF
--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1314,13 +1314,22 @@ export class CustomNodesManager {
 			}
 			cList.forEach(key => {
 				const nodeItem = node_packs[key];
+				if(!nodeItem || !nodeItem.nodesMap) {
+					return;
+				}
 				const extItem = nodeItem.nodesMap[extName];
+				if(!extItem) {
+					return;
+				}
 				if(!extItem.conflicts) {
 					extItem.conflicts = []
 				}
 				const conflictsList = cList.filter(k => k !== key);
 				conflictsList.forEach(k => {
 					const nItem = node_packs[k];
+					if(!nItem) {
+						return;
+					}
 					extItem.conflicts.push({
 						key: k,
 						title: nItem.title, 


### PR DESCRIPTION
Add null checks for nodeItem, nodesMap, extItem, and nItem before accessing properties to prevent 'Cannot read properties of undefined' error when processing node conflicts.

Fixes error at custom-nodes-manager.js:1318