### PR TITLE
Add Halo-Lipsy: AMD unified memory lip sync node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41881,6 +41881,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-		}
+		},
+        {
+            "author": "bkpaine1",
+            "title": "Halo-Lipsy",
+            "id": "halo-lipsy",
+            "reference": "https://github.com/bkpaine1/Halo-Lipsy",
+            "files": [
+                "https://github.com/bkpaine1/Halo-Lipsy"
+            ],
+            "install_type": "git-clone",
+            "description": "AMD unified memory lip sync for ComfyUI. Native Wav2Lip inference with no subprocesses - finally works on Strix Halo, ROCm, and all AMD APUs. Features sync tuning, edge blending, and safe tensor casting for unified memory systems."
+        }
     ]
 }


### PR DESCRIPTION
## Summary

Adding **Halo-Lipsy** - a native Wav2Lip lip sync node that finally works on AMD APUs with unified memory.

### Why This Node Exists

Existing lip sync nodes fail on AMD unified memory systems because they:
- Use `subprocess.run()` which escapes the venv → library mismatches → crash
- Write temporary files that end up as 0-byte "ghost files"  
- Try to cast `vfloat16` tensors directly to NumPy → unified memory conflict
- Auto-detect CUDA and fail without NVIDIA drivers

**Halo-Lipsy fixes all of this:**
- Native Wav2Lip inference in the ComfyUI process (no subprocesses)
- Face detection forced to CPU (prevents memory fighting)
- Safe tensor casting: always `.float().cpu().numpy()`
- Works with ROCm's CUDA translation layer

### Features
- Sync tuning (frame offset, mel timing multiplier)
- Edge blending for clean face compositing
- Adjustable face detection and smoothing
- Force CPU mode for zero VRAM usage

### Tested On
- **Ryzen AI Max+ 395 (Strix Halo)** - 64GB unified memory
- **ROCm 7.11**
- ComfyUI with HunyuanVideo (15GB+) loaded simultaneously
- Also works on NVIDIA/CUDA systems

### Repository
https://github.com/bkpaine1/Halo-Lipsy

### Credits
- **bkpaine1** - Testing, AMD hardware, bug hunting
- **Claude Code** (Anthropic Opus 4.5) - Architecture & implementation
- **Wav2Lip** - Original model by Rudrabha Mukhopadhyay