### PR TITLE
refactor(cli): move cm_cli to top-level package

### DIFF
--- a/cm_cli/__init__.py
+++ b/cm_cli/__init__.py
@@ -1,0 +1,3 @@
+def main():
+    from .__main__ import main as _main
+    _main()

--- a/cm_cli/__main__.py
+++ b/cm_cli/__main__.py
@@ -15,8 +15,6 @@ import git
 import importlib
 
 
-from ..common import manager_util
-
 # read env vars
 # COMFYUI_FOLDERS_BASE_PATH is not required in cm-cli.py
 # `comfy_path` should be resolved before importing manager_core
@@ -35,11 +33,12 @@ if not os.path.exists(os.path.join(comfy_path, 'folder_paths.py')):
 
 
 import utils.extra_config
-from ..common import cm_global
-from ..legacy import manager_core as core
-from ..common import context
-from ..legacy.manager_core import unified_manager
-from ..common import cnr_utils
+from comfyui_manager.common import manager_util
+from comfyui_manager.common import cm_global
+from comfyui_manager.legacy import manager_core as core
+from comfyui_manager.common import context
+from comfyui_manager.legacy.manager_core import unified_manager
+from comfyui_manager.common import cnr_utils
 
 comfyui_manager_path = os.path.abspath(os.path.dirname(__file__))
 
@@ -967,31 +966,6 @@ def simple_show(
     else:
         show_list(arg, True)
 
-
-@app.command('cli-only-mode', help="Set whether to use ComfyUI-Manager in CLI-only mode.")
-def cli_only_mode(
-        mode: str = typer.Argument(
-            ..., help="[enable|disable]"
-        ),
-        user_directory: str = typer.Option(
-            None,
-            help="user directory"
-        )
-):
-    cmd_ctx.set_user_directory(user_directory)
-    cli_mode_flag = os.path.join(cmd_ctx.manager_files_directory, '.enable-cli-only-mode')
-
-    if mode.lower() == 'enable':
-        with open(cli_mode_flag, 'w'):
-            pass
-        print("\nINFO: `cli-only-mode` is enabled\n")
-    elif mode.lower() == 'disable':
-        if os.path.exists(cli_mode_flag):
-            os.remove(cli_mode_flag)
-        print("\nINFO: `cli-only-mode` is disabled\n")
-    else:
-        print(f"\n[bold red]Invalid value for cli-only-mode: {mode}[/bold red]\n")
-        exit(1)
 
 
 @app.command(

--- a/comfyui_manager/glob/manager_core.py
+++ b/comfyui_manager/glob/manager_core.py
@@ -41,7 +41,7 @@ from ..common.enums import NetworkMode, SecurityLevel, DBMode
 from ..common import context
 
 
-version_code = [4, 0, 5]
+version_code = [4, 1]
 version_str = f"V{version_code[0]}.{version_code[1]}" + (f'.{version_code[2]}' if len(version_code) > 2 else '')
 
 

--- a/comfyui_manager/legacy/manager_core.py
+++ b/comfyui_manager/legacy/manager_core.py
@@ -42,7 +42,7 @@ from ..common.enums import NetworkMode, SecurityLevel, DBMode
 from ..common import context
 
 
-version_code = [4, 0, 5]
+version_code = [4, 1]
 version_str = f"V{version_code[0]}.{version_code[1]}" + (f'.{version_code[2]}' if len(version_code) > 2 else '')
 
 

--- a/comfyui_manager/prestartup_script.py
+++ b/comfyui_manager/prestartup_script.py
@@ -560,7 +560,7 @@ if os.path.exists(restore_snapshot_path):
         if 'COMFYUI_PATH' not in new_env:
             new_env['COMFYUI_PATH'] = os.path.dirname(folder_paths.__file__)
 
-        cmd_str = [sys.executable, '-m', 'comfyui_manager.cm_cli', 'restore-snapshot', restore_snapshot_path]
+        cmd_str = [sys.executable, '-m', 'cm_cli', 'restore-snapshot', restore_snapshot_path]
         exit_code = process_wrap(cmd_str, custom_nodes_base_path, handler=msg_capture, env=new_env)
 
         if exit_code != 0:

--- a/docs/en/cm-cli.md
+++ b/docs/en/cm-cli.md
@@ -7,7 +7,7 @@
 -= ComfyUI-Manager CLI (V2.24) =-
 
 
-python cm-cli.py [OPTIONS]
+cm-cli [OPTIONS]
 
 OPTIONS:
     [install|reinstall|uninstall|update|disable|enable|fix] node_name ... ?[--channel <channel name>] ?[--mode [remote|local|cache]]
@@ -15,32 +15,27 @@ OPTIONS:
     [simple-show|show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list] ?[--channel <channel name>] ?[--mode [remote|local|cache]]
     save-snapshot ?[--output <snapshot .json/.yaml>]
     restore-snapshot <snapshot .json/.yaml> ?[--pip-non-url] ?[--pip-non-local-url] ?[--pip-local-url]
-    cli-only-mode [enable|disable]
     restore-dependencies
     clear
 ```
 
 ## How To Use?
-* You can execute it via `python cm-cli.py`.
+* You can execute it via the `cm-cli` command.
 * For example, if you want to update all custom nodes:
-    * In the ComfyUI-Manager directory, you can execute the command `python cm-cli.py update all`.
-    * If running from the ComfyUI directory, you can specify the path to cm-cli.py like this: `python custom_nodes/ComfyUI-Manager/cm-cli.py update all`.
+    * `cm-cli update all`
 
 ## Prerequisite
 * It must be run in the same Python environment as the one running ComfyUI.
     * If using a venv, you must run it with the venv activated.
     * If using a portable version, and you are in the directory with the run_nvidia_gpu.bat file, you should execute the command as follows:
-        `.\python_embeded\python.exe ComfyUI\custom_nodes\ComfyUI-Manager\cm-cli.py update all`
-* The path for ComfyUI can be set with the COMFYUI_PATH environment variable. If omitted, a warning message will appear, and the path will be set relative to the installed location of ComfyUI-Manager:
-        ```
-        WARN: The `COMFYUI_PATH` environment variable is not set. Assuming `custom_nodes/ComfyUI-Manager/../../` as the ComfyUI path.
-        ```
+        `.\python_embeded\python.exe -m cm_cli update all`
+* The path for ComfyUI must be set with the `COMFYUI_PATH` environment variable.
 
 ## Features
 
 ### 1. --channel, --mode
 * For viewing information and managing custom nodes, you can set the information database through --channel and --mode.
-* For instance, executing the command `python cm-cli.py update all --channel recent --mode remote` will operate based on the latest information from remote rather than local data embedded in the current ComfyUI-Manager repo and will only target the list in the recent channel.
+* For instance, executing the command `cm-cli update all --channel recent --mode remote` will operate based on the latest information from remote rather than local data embedded in the current ComfyUI-Manager repo and will only target the list in the recent channel.
 * --channel, --mode are only available with the commands `simple-show, show, install, uninstall, update, disable, enable, fix`.
 
 ### 2. Viewing Management Information
@@ -49,7 +44,7 @@ OPTIONS:
 
 * `[show|simple-show]` - `show` provides detailed information, while `simple-show` displays information more simply.
 
-Executing a command like `python cm-cli.py show installed` will display detailed information about the installed custom nodes.
+Executing a command like `cm-cli show installed` will display detailed information about the installed custom nodes.
 
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
@@ -66,7 +61,7 @@ FETCH DATA from: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main
 [    DISABLED   ]  ComfyUI-Loopchain                                 (author: Fannovel16)
 ```
 
-Using a command like `python cm-cli.py simple-show installed` will simply display information about the installed custom nodes.
+Using a command like `cm-cli simple-show installed` will simply display information about the installed custom nodes.
 
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
@@ -95,7 +90,7 @@ ComfyUI-Loopchain
 
 `[install|reinstall|uninstall|update|disable|enable|fix] node_name ... ?[--channel <channel name>] ?[--mode [remote|local|cache]]`
 
-* You can apply management functions by listing the names of custom nodes, such as `python cm-cli.py install ComfyUI-Impact-Pack ComfyUI-Inspire-Pack ComfyUI_experiments`.
+* You can apply management functions by listing the names of custom nodes, such as `cm-cli install ComfyUI-Impact-Pack ComfyUI-Inspire-Pack ComfyUI_experiments`.
 * The names of the custom nodes are as shown by `show` and are the names of the git repositories.
 (Plans are to update the use of nicknames in the future.)
 
@@ -114,9 +109,9 @@ ComfyUI-Loopchain
 
 
 ### 4. Snapshot Management
-* `python cm-cli.py save-snapshot [--output <snapshot .json/.yaml>]`: Saves the current snapshot.
+* `cm-cli save-snapshot [--output <snapshot .json/.yaml>]`: Saves the current snapshot.
   * With `--output`, you can save a file in .yaml format to any specified path.
-* `python cm-cli.py restore-snapshot <snapshot .json/.yaml>`: Restores to the specified snapshot.
+* `cm-cli restore-snapshot <snapshot .json/.yaml>`: Restores to the specified snapshot.
   * If a file exists at the snapshot path, that snapshot is loaded.
   * If no file exists at the snapshot path, it is implicitly assumed to be in ComfyUI-Manager/snapshots.
   * `--pip-non-url`: Restore for pip packages registered on PyPI.
@@ -125,16 +120,7 @@ ComfyUI-Loopchain
   * `--user-directory`: Set the user directory.
   * `--restore-to`: The path where the restored custom nodes will be installed. (When this option is applied, only the custom nodes installed in the target path are recognized as installed.)
 
-### 5. CLI Only Mode
-
-You can set whether to use ComfyUI-Manager solely via CLI.
-
-`cli-only-mode [enable|disable]`
-
-* This mode can be used if you want to restrict the use of ComfyUI-Manager through the GUI for security or policy reasons.
-    * When CLI only mode is enabled, ComfyUI-Manager is loaded in a very restricted state, the internal web API is disabled, and the Manager button is not displayed in the main menu.
-
-### 6. Dependency Restoration
+### 5. Dependency Restoration
 
 `restore-dependencies`
 
@@ -142,6 +128,6 @@ You can set whether to use ComfyUI-Manager solely via CLI.
 * It is useful when starting a new cloud instance, like Colab, where dependencies need to be reinstalled and installation scripts re-executed.
 * It can also be utilized if ComfyUI is reinstalled and only the custom_nodes path has been backed up and restored.
 
-### 7. Clear
+### 6. Clear
 
 In the GUI, installations, updates, or snapshot restorations are scheduled to execute the next time ComfyUI is launched. The `clear` command clears this scheduled state, ensuring no pre-execution actions are applied.

--- a/docs/ko/cm-cli.md
+++ b/docs/ko/cm-cli.md
@@ -7,7 +7,7 @@
 -= ComfyUI-Manager CLI (V2.24) =-
 
 
-python cm-cli.py [OPTIONS]
+cm-cli [OPTIONS]
 
 OPTIONS:
     [install|reinstall|uninstall|update|disable|enable|fix] node_name ... ?[--channel <channel name>] ?[--mode [remote|local|cache]]
@@ -15,32 +15,27 @@ OPTIONS:
     [simple-show|show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list] ?[--channel <channel name>] ?[--mode [remote|local|cache]]
     save-snapshot ?[--output <snapshot .json/.yaml>]
     restore-snapshot <snapshot .json/.yaml> ?[--pip-non-url] ?[--pip-non-local-url] ?[--pip-local-url]
-    cli-only-mode [enable|disable]
     restore-dependencies
     clear
 ```
 
 ## How To Use?
-* `python cm-cli.py` 를 통해서 실행 시킬 수 있습니다.
+* `cm-cli` 명령으로 실행할 수 있습니다.
 * 예를 들어 custom node를 모두 업데이트 하고 싶다면
-    * ComfyUI-Manager 경로에서 `python cm-cli.py update all` 명령을 실행할 수 있습니다.
-    * ComfyUI 경로에서 실행한다면, `python custom_nodes/ComfyUI-Manager/cm-cli.py update all` 와 같이 cm-cli.py 의 경로를 지정할 수도 있습니다.
+    * `cm-cli update all` 명령을 실행할 수 있습니다.
 
 ## Prerequisite
 * ComfyUI 를 실행하는 python과 동일한 python 환경에서 실행해야 합니다.
     * venv를 사용할 경우 해당 venv를 activate 한 상태에서 실행해야 합니다.
 * portable 버전을 사용할 경우 run_nvidia_gpu.bat 파일이 있는 경로인 경우, 다음과 같은 방식으로 명령을 실행해야 합니다.
-        `.\python_embeded\python.exe ComfyUI\custom_nodes\ComfyUI-Manager\cm-cli.py update all`
-* ComfyUI 의 경로는 COMFYUI_PATH 환경 변수로 설정할 수 있습니다. 만약 생략할 경우 다음과 같은 경고 메시지가 나타나며, ComfyUI-Manager가 설치된 경로를 기준으로 상대 경로로 설정됩니다.
-        ```
-        WARN: The `COMFYUI_PATH` environment variable is not set. Assuming `custom_nodes/ComfyUI-Manager/../../` as the ComfyUI path.
-        ```
+        `.\python_embeded\python.exe -m cm_cli update all`
+* ComfyUI 의 경로는 `COMFYUI_PATH` 환경 변수로 설정해야 합니다.
 
 ## Features
 
 ### 1. --channel, --mode
 * 정보 보기 기능과 커스텀 노드 관리 기능의 경우는 --channel과 --mode를 통해 정보 DB를 설정할 수 있습니다.
-* 예를 들어 `python cm-cli.py update all --channel recent --mode remote`와 같은 명령을 실행할 경우, 현재 ComfyUI-Manager repo에 내장된 로컬의 정보가 아닌 remote의 최신 정보를 기준으로 동작하며, recent channel에 있는 목록을 대상으로만 동작합니다.
+* 예를 들어 `cm-cli update all --channel recent --mode remote`와 같은 명령을 실행할 경우, 현재 ComfyUI-Manager repo에 내장된 로컬의 정보가 아닌 remote의 최신 정보를 기준으로 동작하며, recent channel에 있는 목록을 대상으로만 동작합니다.
 * --channel, --mode 는 `simple-show, show, install, uninstall, update, disable, enable, fix` 명령에서만 사용 가능합니다.
 
 ### 2. 관리 정보 보기
@@ -51,7 +46,7 @@ OPTIONS:
 * `[show|simple-show]` - `show`는 상세하게 정보를 보여주며, `simple-show`는 간단하게 정보를 보여줍니다.
 
 
-`python cm-cli.py show installed` 와 같은 명령을 실행하면 설치된 커스텀 노드의 정보를 상세하게 보여줍니다.
+`cm-cli show installed` 와 같은 명령을 실행하면 설치된 커스텀 노드의 정보를 상세하게 보여줍니다.
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
 
@@ -67,7 +62,7 @@ FETCH DATA from: https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main
 [    DISABLED   ]  ComfyUI-Loopchain                                 (author: Fannovel16)
 ```
 
-`python cm-cli.py simple-show installed` 와 같은 명령을 이용해서 설치된 커스텀 노드의 정보를 간단하게 보여줍니다.
+`cm-cli simple-show installed` 와 같은 명령을 이용해서 설치된 커스텀 노드의 정보를 간단하게 보여줍니다.
 
 ```
 -= ComfyUI-Manager CLI (V2.24) =-
@@ -96,7 +91,7 @@ ComfyUI-Loopchain
 
 `[install|reinstall|uninstall|update|disable|enable|fix] node_name ... ?[--channel <channel name>] ?[--mode [remote|local|cache]]`
 
-* `python cm-cli.py install ComfyUI-Impact-Pack ComfyUI-Inspire-Pack ComfyUI_experiments` 와 같이 커스텀 노드의 이름을 나열해서 관리 기능을 적용할 수 있습니다.
+* `cm-cli install ComfyUI-Impact-Pack ComfyUI-Inspire-Pack ComfyUI_experiments` 와 같이 커스텀 노드의 이름을 나열해서 관리 기능을 적용할 수 있습니다.
 * 커스텀 노드의 이름은 `show`를 했을 때 보여주는 이름이며, git repository의 이름입니다. 
 (추후 nickname을 사용 가능하도록 업데이트할 예정입니다.)
 
@@ -115,9 +110,9 @@ ComfyUI-Loopchain
 
 
 ### 4. 스냅샷 관리 기능
-* `python cm-cli.py save-snapshot ?[--output <snapshot .json/.yaml>]`: 현재의 snapshot을 저장합니다.
+* `cm-cli save-snapshot ?[--output <snapshot .json/.yaml>]`: 현재의 snapshot을 저장합니다.
   * --output 으로 임의의 경로에 .yaml 파일과 format으로 저장할 수 있습니다.
-* `python cm-cli.py restore-snapshot <snapshot .json/.yaml>`: 지정된 snapshot으로 복구합니다.
+* `cm-cli restore-snapshot <snapshot .json/.yaml>`: 지정된 snapshot으로 복구합니다.
   * snapshot 경로에 파일이 존재하는 경우 해당 snapshot을 로드합니다.
   * snapshot 경로에 파일이 존재하지 않는 경우 묵시적으로, ComfyUI-Manager/snapshots 에 있다고 가정합니다.
   * `--pip-non-url`: PyPI 에 등록된 pip 패키지들에 대해서 복구를 수행
@@ -126,17 +121,7 @@ ComfyUI-Loopchain
   * `--user-directory`: 사용자 디렉토리 설정
   * `--restore-to`: 복구될 커스텀 노드가 설치될 경로. (이 옵션을 적용할 경우 오직 대상 경로에 설치된 custom nodes만 설치된 것으로 인식함.)
 
-### 5. CLI only mode
-
-ComfyUI-Manager를 CLI로만 사용할 것인지를 설정할 수 있습니다.
-
-`cli-only-mode [enable|disable]`
-
-* security 혹은 policy 의 이유로 GUI 를 통한 ComfyUI-Manager 사용을 제한하고 싶은 경우 이 모드를 사용할 수 있습니다.
-    * CLI only mode를 적용할 경우 ComfyUI-Manager 가 매우 제한된 상태로 로드되어, 내부적으로 제공하는 web API가 비활성화되며, 메인 메뉴에서도 Manager 버튼이 표시되지 않습니다.
-
-
-### 6. 의존성 설치
+### 5. 의존성 설치
 
 `restore-dependencies`
 
@@ -145,6 +130,6 @@ ComfyUI-Manager를 CLI로만 사용할 것인지를 설정할 수 있습니다.
 * ComfyUI를 재설치할 경우, custom_nodes 경로만 백업했다가 재설치할 경우 활용 가능합니다.
 
 
-### 7. clear
+### 6. clear
 
 GUI에서 install, update를 하거나 snapshot을 restore하는 경우 예약을 통해서 다음번 ComfyUI를 실행할 경우 실행되는 구조입니다. `clear` 는 이런 예약 상태를 clear해서, 아무런 사전 실행이 적용되지 않도록 합니다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-manager"
 license = { text = "GPL-3.0-only" }
-version = "4.0.5"
+version = "4.1b1"
 requires-python = ">= 3.9"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
 readme = "README.md"
@@ -46,10 +46,10 @@ Repository = "https://github.com/ltdrdata/ComfyUI-Manager"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["comfyui_manager*"]
+include = ["comfyui_manager*", "cm_cli*"]
 
 [project.scripts]
-cm-cli = "comfyui_manager.cm_cli.__main__:main"
+cm-cli = "cm_cli:main"
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Fixed an issue in `manager-v4` where `cm-cli` failed to run due to an import error.

- Move cm_cli from comfyui_manager/cm_cli/ to top-level cm_cli/ package
- Convert relative imports to absolute imports
- Remove non-functional cli-only-mode command (flag was never checked)
- Update docs: python cm-cli.py → cm-cli entrypoint
- Update prestartup snapshot restore to use -m cm_cli
- Version bump to 4.1b1