### PR TITLE
Add HALO Debug Pack - AMD ROCm bf16 diagnostic tools

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -42766,6 +42766,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "bkpaine1",
+            "title": "HALO Debug Pack",
+            "id": "halo-pack",
+            "reference": "https://github.com/bkpaine1/halo_pack",
+            "files": [
+                "https://github.com/bkpaine1/halo_pack"
+            ],
+            "install_type": "git-clone",
+            "description": "AMD ROCm bf16 diagnostic tools for ComfyUI. Fixes black image issues caused by numpy's lack of bfloat16 support. Includes FP32 VAE decode/encode and debug nodes for latent, conditioning, and model inspection. Useful for AMD Strix Halo, older NVIDIA cards, Apple Silicon, and unified memory systems."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds **HALO Debug Pack** to the custom node list - diagnostic tools for debugging black image issues caused by numpy's lack of bfloat16 support.

## Target Users

- AMD ROCm users (especially Strix Halo APUs)
- Older NVIDIA cards with bf16 issues
- Apple Silicon / unified memory systems
- Anyone experiencing black images from bf16 precision problems

## Nodes Included

| Node | Purpose |
|------|---------|
| HALO VAE Decode (FP32) | Forces VAE decode to fp32, fixing numpy bf16 conversion |
| HALO VAE Encode (FP32) | Forces VAE encode to fp32 for img2img |
| HALO Latent Debug | Checks sampler output for NaN/dead latents |
| HALO Conditioning Debug | Checks text encoder output for NaN |
| HALO Model Debug | Inspects model dtype (bf16/fp16/fp32) |

## Repository

https://github.com/bkpaine1/halo_pack

## Why This Matters

When PyTorch bf16 tensors get converted to numpy for image saving, numpy silently produces garbage because it doesn't support bfloat16. This causes the infamous "black image" problem. These nodes help users diagnose exactly where the issue occurs in their pipeline.

Thank you for maintaining ComfyUI-Manager!