### PR TITLE
Added comfyui-outline custom node to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -43304,6 +43304,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "dennisvink",
+            "title": "Outline Alpha Snap Node for ComfyUI",
+            "id": "outlinealphasnap",
+            "reference": "https://github.com/dennisvink/comfyui-outline",
+            "files": [
+                "https://raw.githubusercontent.com/dennisvink/comfyui-outline/refs/heads/main/nodes.py"
+            ],
+            "install_type": "copy",
+            "description": "This node adds an outside-only outline around the opaque region of an image while cleaning up semi‑transparent edge pixels and removing stray islands."
         }
     ]
 }


### PR DESCRIPTION
  - Adds a new custom node that snaps alpha edges, removes stray islands (keeps largest), and draws an outside-only outline.
  - Inputs: image, width (int), color (hex string).
  - Includes README and node registration under custom_nodes/comfyui-outline/