### PR TITLE
fix: Replaced link in pyproject.toml with correct one

### DIFF
--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -27781,10 +27781,12 @@
     "https://github.com/c0dezer019/FreezeFrame": [
         [
             "PSampler",
-            "PSamplerAdvanced"
+            "PSamplerAdvanced",
+	    "PSamplerCustom",
+	    "PSamplerCustomAdvanced"
         ],
         {
-            "title_aux": "Pausable Sampler"
+            "title_aux": "FreezeFrame"
         }
     ],
     "https://github.com/c0ffymachyne/ComfyUI_BeatByte": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = ["GitPython", "PyGithub", "matrix-nio", "transformers", "huggingf
 
 [project.urls]
 Repository = "https://github.com/ltdrdata/ComfyUI-Manager"
-#  Used by Comfy Registry https://comfyregistry.org
+#  Used by Comfy Registry https://registry.comfy.org
 
 [tool.comfy]
 PublisherId = "drltdata"


### PR DESCRIPTION
- Original link written in pyproject for comfyregistry leads to a malicious site
- Corrected FreezeFrame entry with correct mapping