### PR TITLE
Update va1: add ImageMaskComparer node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -31755,13 +31755,13 @@
         {
             "author": "vaishnav-vn",
             "title": "va1",
-            "name": "Pad Image by Aspect",
+            "name": "va1",
             "reference": "https://github.com/vaishnav-vn/va1",
             "files": [
                 "https://github.com/vaishnav-vn/va1"
             ],
             "install_type": "git-clone",
-            "description": "repo has Custon node designed to expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control — engineered for outpainting, compositional layout, and creative canvas expansion. "
+            "description": "ComfyUI custom nodes: (1) Pad Image by Aspect for Outpaint — expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control for outpainting and canvas expansion. (2) Image Mask Comparer — compare masked regions of two images with similarity scoring and automatic retry/re-queue on mismatch."
         },
         {
             "author": "wawahuy",

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -55591,6 +55591,7 @@
     ],
     "https://github.com/vaishnav-vn/va1": [
         [
+            "ImageMaskComparer",
             "RandomAspectRatioMask"
         ],
         {


### PR DESCRIPTION
- Add `ImageMaskComparer` to `extension-node-map.json` for the va1 custom node pack

- Update description in `custom-node-list.json` to reflect both nodes:
  1. **Pad Image by Aspect for Outpaint** — expand, pad, and mask images to fixed or randomized aspect ratios
  2. **Image Mask Comparer** (NEW) — compare masked regions of two images with similarity scoring and automatic retry/re-queue on mismatch