### PR TITLE
Add ComfyUI Pad to Multiple

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -43507,6 +43507,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "mr-september",
+            "title": "ComfyUI Pad to Multiple",
+            "id": "pad-to-multiple",
+            "reference": "https://github.com/mr-september/comfyui-pad-to-multiple",
+            "files": [
+                "https://github.com/mr-september/comfyui-pad-to-multiple"
+            ],
+            "install_type": "git-clone",
+            "description": "Pads images to multiples of N (right/bottom only) with solid color fill. Useful for VAE/model dimension requirements."
         }
     ]
 }


### PR DESCRIPTION
Adding a new custom node for padding images to multiples of a specified number.
   
Node adds padding to right/bottom edges only, useful for ensuring images meet model dimension requirements (divisible by 8, 16, 32, etc).
   
Repo: https://github.com/mr-september/comfyui-pad-to-multiple