### PR TITLE
Add Booru Tagger custom node.

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -43627,6 +43627,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "nestflow",
+            "title": "Booru Taggers for ComfyUI",
+            "id": "boorutagger",
+            "reference": "https://github.com/nestflow/ComfyUI-Booru-Tagger",
+            "files": [
+                "https://github.com/nestflow/ComfyUI-Booru-Tagger"
+            ],
+            "install_type": "git-clone",
+            "description": "An improved and extended node of various Booru taggers (WD taggers, Pixai, Camie, etc.)"
         }
     ]
 }


### PR DESCRIPTION
A Booru tagger node built on [pysssss's original node](https://github.com/pythongosssss/ComfyUI-WD14-Tagger), with much performance improvements, API migration, and supports for newer models ([Pixai](https://huggingface.co/deepghs/pixai-tagger-v0.9-onnx) and [Camie v2](https://huggingface.co/Camais03/camie-tagger-v2) taggers currently).