### PR TITLE
fix: StrictVersion fails to parse semver pre-release versions (e.g. "0.6.2-b1")

### DIFF
--- a/glob/manager_util.py
+++ b/glob/manager_util.py
@@ -109,7 +109,14 @@ class StrictVersion:
         self.parse_version_string()
 
     def parse_version_string(self):
-        parts = self.version_string.split('.')
+        # Handle semver pre-release suffix: "1.2.3-beta.1" → core="1.2.3", pre="beta.1"
+        core = self.version_string
+        if '-' in core:
+            dash_pos = core.index('-')
+            self.pre_release = core[dash_pos + 1:]
+            core = core[:dash_pos]
+
+        parts = core.split('.')
         if not parts:
             raise ValueError("Version string must not be empty")
 
@@ -117,8 +124,8 @@ class StrictVersion:
         self.minor = int(parts[1]) if len(parts) > 1 else 0
         self.patch = int(parts[2]) if len(parts) > 2 else 0
 
-        # Handling pre-release versions if present
-        if len(parts) > 3:
+        # Also handle legacy 4-part dot notation: "1.2.3.beta1"
+        if self.pre_release is None and len(parts) > 3:
             self.pre_release = parts[3]
 
     def __str__(self):


### PR DESCRIPTION
## Problem

`StrictVersion.parse_version_string()` splits the version string by `.` and calls `int()` on each part. This crashes on standard [semver](https://semver.org/) pre-release versions that use a hyphen separator (e.g. `0.6.2-b1`), because `int("2-b1")` raises `ValueError`.

The exception is silently caught by `read_cnr_info()` in `cnr_utils.py`, causing the function to return `None`. This means `identify_node_pack_from_path()` also returns `None`, and the plugin **disappears from the installed list** — it cannot be updated, uninstalled, or managed through ComfyUI-Manager.

### Root Cause

The [Comfy Registry specification](https://docs.comfy.org/registry/specifications) requires versions to be **semantically versioned**, and [SemVer 2.0.0 §9](https://semver.org/#spec-item-9) defines pre-release versions with a **hyphen** separator:

> A pre-release version MAY be denoted by **appending a hyphen** and a series of dot separated identifiers immediately following the patch version.
> Examples: `1.0.0-alpha`, `1.0.0-alpha.1`, `1.0.0-0.3.7`

However, `StrictVersion` only handles the legacy 4-part dot notation (`X.Y.Z.prerelease`) and has no support for the hyphen format.

### Affected Plugins

Currently **7 plugins** in the CNR registry use hyphenated pre-release versions:

| Plugin | Version |
|--------|---------|
| comfyui-reactor | 0.6.2-b1 |
| comfyui-reactor-node | 0.5.2-b1 |
| comfyui-prompt-control | 3.0.0-beta.2 |
| TWanSigmaGraph | 0.2.0-alpha |
| comfyui_play_traversal | 2.0.0-inprogress |
| comfyui-dazzlenodes | 0.5.1-alpha |
| ComfyUI-AssetsPlus | 0.2.14-OBT |

### Fix

Extract the hyphen-separated pre-release suffix before splitting by `.`, while preserving backward compatibility with the legacy 4-part dot notation.

### Related Issues

- #1694 — "ReActor node isn't recognized in Manager as being installed" (same symptom, root cause now identified)

### Testing

Verified with all 7 affected versions + normal versions + legacy dot notation + edge cases:

```
0.6.2-b1        → OK (was: ValueError)
3.0.0-beta.2    → OK (was: ValueError)
0.2.0-alpha     → OK (was: ValueError)
1.0.0           → OK (unchanged)
0.6.2.b1        → OK (legacy format, still works)
```

Comparison semantics preserved:
- `0.6.2-b1 < 0.6.2` → True (pre-release < release, per semver)
- `0.6.2-alpha < 0.6.2-b1` → True (lexical comparison)