### PR TITLE
Fix: Add support for UNC network paths in channel normalization

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -357,6 +357,8 @@ def normalize_channel(channel):
         return channel
     elif channel.startswith('http://') and get_config()['http_channel_enabled'] == True:
         return channel
+    elif channel.startswith('\\\\') or os.path.isabs(channel):
+        return channel
 
     tmp_dict = get_channel_dict()
     channel_url = tmp_dict.get(channel)


### PR DESCRIPTION
### What this PR does
This PR patches `glob/manager_core.py` -> `normalize_channel()` to correctly identify and allow UNC network paths (e.g., `\\Server\Share\...`) and absolute local paths when loading custom nodes from a private registry/channel list.

### The Bug
Currently, `ComfyUI-Manager` rejects UNC network paths when attempting to load a custom channel. Because `normalize_channel()` primarily checks for `http`, `https`, or specific local directory structures, using a NAS or shared network drive throws an error and prevents the manager from loading custom node lists.

**Traceback context:**
`manager_core.InvalidChannel: \\Retinize_NAS\our_enterprise_custom_nodes`

### The Fix
Updated the string matching logic in `normalize_channel()` so that UNC paths (starting with `\\`) and absolute local paths bypass the `InvalidChannel` exception and are treated as valid local channels. Tested locally and confirmed that `custom-node-list.json` now successfully resolves and loads custom nodes over a network drive.