### PR TITLE
feat: add ComfyUI Save Image Without Metadata node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -44793,6 +44793,18 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "George Jiang",
+            "title": "ComfyUI Save Image Without Metadata",
+            "description": "Save images without embedding workflow or prompt metadata",
+            "reference": "https://github.com/GeorgeJiang/comfyui-save-image-no-meta",
+            "files": [
+                "https://github.com/GeorgeJiang/comfyui-save-image-no-meta"
+            ],
+            "install_type": "git-clone",
+            "category": "image",
+            "description": "Save images without embedding workflow or prompt metadata"
         }
     ]
 }


### PR DESCRIPTION
This node saves PNG images without embedding ComfyUI workflow metadata.

Repository: https://github.com/GeorgeJiang/comfyui-save-image-no-meta