### PR TITLE
Add Send-To-ComfyUI node

### DIFF
--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -61489,5 +61489,13 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
+    ],
+    "https://raw.githubusercontent.com/tardigrade1001/send-to-comfyui/main/load_latest_image.py": [
+        [
+        "LoadLatestImage"
+        ],
+        {
+        "title_aux": "Send To ComfyUI"
+        }
     ]
 }


### PR DESCRIPTION
Add Send-To-ComfyUI node to extension-node-map.json.

Repository:
https://github.com/tardigrade1001/send-to-comfyui

This node allows sending images or data directly to ComfyUI workflows.