### PR TITLE
Add ComfyUI 2D Pose Editor node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45052,6 +45052,15 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ketle-man",
+            "title": "ComfyUI 2D Pose Editor",
+            "id": "comfyui-2dpose-editor",
+            "reference": "https://github.com/ketle-man/comfyui-2dpose-editor",
+            "files": ["https://github.com/ketle-man/comfyui-2dpose-editor"],
+            "install_type": "git-clone",
+            "description": "Interactive 2D rigging pose editor embedded inside a ComfyUI node. Drag joints to pose a figure, control eye direction, and export as IMAGE."
         }
     ]
 }


### PR DESCRIPTION
## New Custom Node: ComfyUI 2D Pose Editor

**Repository:** https://github.com/ketle-man/comfyui-2dpose-editor

### Description
An interactive 2D rigging pose editor embedded directly inside a ComfyUI node.

### Features
- Drag joint points to freely pose a humanoid figure
- Shoulder/hip joints support both rotation and length adjustment
- Eye dots can be dragged to control gaze direction
- 📸 Capture button exports the current pose as an IMAGE output
- 🔄 Reset button returns to the default pose

### Install type
`git-clone`