### PR TITLE
Add ComfyUI Gender Tag Filter node suite by senjinthedragon

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45052,6 +45052,13 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "senjinthedragon",
+            "title": "ComfyUI Gender Tag Filter",
+            "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
+            "category": "utils/tags",
+            "description": "Filters and rewrites gendered vocabulary in Danbooru tags and natural language prompts to fix female-biased output from models like TIPO."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45057,6 +45057,7 @@
             "author": "senjinthedragon",
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
+            "install_type": "git",
             "category": "utils/tags",
             "description": "Filters and rewrites gendered vocabulary in Danbooru tags and natural language prompts to fix female-biased output from models like TIPO."
         }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45057,6 +45057,9 @@
             "author": "senjinthedragon",
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
+            "files": [
+            	"https://github.com/senjinthedragon/comfyui-gender-tag-filter"
+            ],
             "install_type": "git",
             "category": "utils/tags",
             "description": "Filters and rewrites gendered vocabulary in Danbooru tags and natural language prompts to fix female-biased output from models like TIPO."

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45060,7 +45060,7 @@
             "files": [
             	"https://github.com/senjinthedragon/comfyui-gender-tag-filter"
             ],
-            "install_type": "git",
+            "install_type": "git-clone",
             "category": "utils/tags",
             "description": "Filters and rewrites gendered vocabulary in Danbooru tags and natural language prompts to fix female-biased output from models like TIPO."
         }


### PR DESCRIPTION
### Description
I am submitting a new custom node suite: **ComfyUI Gender Tag Filter**.

This project provides two nodes designed to filter and rewrite gendered vocabulary in AI image generation prompts. It specifically addresses the female-biased output of prompt expansion models (like TIPO) when generating male or mixed-gender scenes.

### Features
* **Gender Tag Filter:** Handles Danbooru/e621 style tags with compound anatomy root scanning.
* **Gender NL Filter:** Uses spaCy for high-accuracy negation detection and pronoun/reference swapping in natural language prompts.
* **Graceful Fallback:** Automatically falls back to regex-based logic if spaCy is not installed.
* **Lazy Loading:** spaCy models are only loaded on first use to save memory.

### Links
* **Repository:** https://github.com/senjinthedragon/comfyui-gender-tag-filter
* **Category:** `utils/tags`

I have tested these nodes locally within a clean ComfyUI environment and confirmed the `install.py` handles optional dependencies as intended.