### PR TITLE
Add SNTZ_API to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47,6 +47,17 @@
             "description": "This extension provides various nodes to support Lora Block Weight and the Impact Pack. Provides many easily applicable regional features and applications for Variation Seed."
         },
         {
+            "author": "andrukisselev-netizen",
+            "title": "SNTZ API (Gemini + Photoshop Comfy nodes)",
+            "id": "sntz-api",
+            "reference": "https://github.com/andrukisselev-netizen/SNTZ_API",
+            "files": [
+                "https://github.com/andrukisselev-netizen/SNTZ_API"
+            ],
+            "install_type": "git-clone",
+            "description": "SNTZimage and SNTZphotoshop: Gemini image generation and Photoshop linked-folder workflow. UXP plugin in repo (sntz-plugin). See README and INSTALL.md."
+        },
+        {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI Connection Helper",
             "id": "connection-helper",


### PR DESCRIPTION
### Summary
Adds **SNTZ_API** to `custom-node-list.json` so users can install/update it via ComfyUI-Manager (`git-clone`).

### Repository
https://github.com/andrukisselev-netizen/SNTZ_API

### What it provides
- **SNTZimage** — Gemini image generation (text-to-image, text + images).
- **SNTZphotoshop** — Photoshop ↔ ComfyUI loop (selection export, generation, linked smart object workflow).
- **UXP Photoshop plugin** sources live in repo under `sntz-plugin/` (install separately; see `README.md` / `INSTALL.md`).

### Checklist
- [x] `python3 -m json.tool custom-node-list.json` passes locally.
- [x] Entry uses `install_type: "git-clone"` and points to the public GitHub URL above.