### PR TITLE
fix(manager-v3/security): add litellm supply chain attack detection and improve pip matching

### DIFF
--- a/glob/security_check.py
+++ b/glob/security_check.py
@@ -53,6 +53,40 @@ And kill and remove /tmp/ultralytics_runner
 
 The version 8.3.41 to 8.3.42 of the Ultralytics package you installed is compromised. Please uninstall that version and reinstall the latest version.
 https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situation/
+    """,
+    "litellm==1.82.7": f"""
+Execute following commands:
+    {sys.executable} -m pip uninstall litellm
+
+The litellm PyPI package versions 1.82.7 and 1.82.8 were compromised via a supply chain attack.
+Malicious code harvests SSH keys, environment variables, API keys, cloud credentials, and exfiltrates them to an attacker-controlled server.
+Version 1.82.8 also installs a .pth file that executes malware on ANY Python startup, even without importing litellm.
+
+1. Uninstall litellm immediately.
+2. Assume all credentials accessible to the litellm environment are compromised.
+3. Rotate all API keys, cloud credentials, SSH keys, and database passwords.
+4. Check site-packages for unexpected .pth files (e.g. litellm_init.pth) and remove them.
+5. Run a full malware scan.
+
+Details: https://github.com/BerriAI/litellm/issues/24518
+Advisory: PYSEC-2026-2
+    """,
+    "litellm==1.82.8": f"""
+Execute following commands:
+    {sys.executable} -m pip uninstall litellm
+
+The litellm PyPI package versions 1.82.7 and 1.82.8 were compromised via a supply chain attack.
+Malicious code harvests SSH keys, environment variables, API keys, cloud credentials, and exfiltrates them to an attacker-controlled server.
+Version 1.82.8 also installs a .pth file that executes malware on ANY Python startup, even without importing litellm.
+
+1. Uninstall litellm immediately.
+2. Assume all credentials accessible to the litellm environment are compromised.
+3. Rotate all API keys, cloud credentials, SSH keys, and database passwords.
+4. Check site-packages for unexpected .pth files (e.g. litellm_init.pth) and remove them.
+5. Run a full malware scan.
+
+Details: https://github.com/BerriAI/litellm/issues/24518
+Advisory: PYSEC-2026-2
     """
              }
 
@@ -60,7 +94,10 @@ https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situati
 
     pip_blacklist = {
         "AppleBotzz": "ComfyUI_LLMVISION",
-        "ultralytics==8.3.41": "ultralytics==8.3.41"
+        "ultralytics==8.3.41": "ultralytics==8.3.41",
+        "ultralytics==8.3.42": "ultralytics==8.3.42",
+        "litellm==1.82.7": "litellm==1.82.7",
+        "litellm==1.82.8": "litellm==1.82.8",
     }
 
     file_blacklist = {
@@ -93,10 +130,15 @@ https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situati
             print(f"[SECURITY ALERT] custom node '{k}' is dangerous.")
             detected.add(v)
 
+    installed_pip_set = set(installed_pips.strip().split('\n'))
+
     for k, v in pip_blacklist.items():
-        if k in installed_pips:
-            detected.add(v)
-            break
+        if '==' in k:
+            if k in installed_pip_set:
+                detected.add(v)
+        else:
+            if any(line.split('==')[0] == k for line in installed_pip_set):
+                detected.add(v)
 
     for k, v in file_blacklist.items():
         for x in v:
@@ -105,10 +147,14 @@ https://blog.comfy.org/comfyui-statement-on-the-ultralytics-crypto-miner-situati
                 break
 
     if len(detected) > 0:
-        for line in installed_pips.split('\n'):
+        for line in installed_pip_set:
             for k, v in pip_blacklist.items():
-                if k in line:
-                    print(f"[SECURITY ALERT] '{line}' is dangerous.")
+                if '==' in k:
+                    if line == k:
+                        print(f"[SECURITY ALERT] '{line}' is dangerous.")
+                else:
+                    if line.split('==')[0] == k:
+                        print(f"[SECURITY ALERT] '{line}' is dangerous.")
 
         print("\n########################################################################")
         print("   Malware has been detected, forcibly terminating ComfyUI execution.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-manager"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
-version = "3.39.2"
+version = "3.39.3"
 license = { file = "LICENSE.txt" }
 dependencies = ["GitPython", "PyGithub", "matrix-nio", "transformers", "huggingface-hub>0.20", "typer", "rich", "typing-extensions", "toml", "uv", "chardet"]
 


### PR DESCRIPTION
## Summary
- Add detection for compromised `litellm` PyPI packages v1.82.7 and v1.82.8 ([PYSEC-2026-2](https://github.com/pypa/advisory-database/blob/main/vulns/litellm/PYSEC-2026-2.yaml)) with remediation guide including `.pth` file removal and credential rotation steps
- Fix `pip_blacklist` scanning bug: remove `break` that skipped remaining checks after first match, causing missed detections in multi-infection scenarios
- Replace substring matching with set-based exact matching to prevent false positives on similar version strings (e.g. `1.82.70` incorrectly matching `1.82.7`)
- Add missing `ultralytics==8.3.42` to `pip_blacklist` (was in `guide` but not in blacklist)

## Context
The litellm PyPI package was compromised via a supply chain attack on 2026-03-24. Malicious versions harvest SSH keys, environment variables, API keys, and cloud credentials. Version 1.82.8 additionally installs a `.pth` file that executes on ANY Python startup without importing litellm.

Reference: https://github.com/BerriAI/litellm/issues/24518