### PR TITLE
fix: use safe .get() for 'mode' query param in fetch_customnode_list

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -874,14 +874,16 @@ async def fetch_customnode_list(request):
     else:
         skip_update = False
 
-    if request.rel_url.query["mode"] == "local":
+    mode = request.rel_url.query.get("mode", "cache")
+
+    if mode == "local":
         channel = 'local'
     else:
         channel = core.get_config()['channel_url']
 
-    node_packs = await core.get_unified_total_nodes(channel, request.rel_url.query["mode"], 'cache')
-    json_obj_github = core.get_data_by_mode(request.rel_url.query["mode"], 'github-stats.json', 'default')
-    json_obj_extras = core.get_data_by_mode(request.rel_url.query["mode"], 'extras.json', 'default')
+    node_packs = await core.get_unified_total_nodes(channel, mode, 'cache')
+    json_obj_github = core.get_data_by_mode(mode, 'github-stats.json', 'default')
+    json_obj_extras = core.get_data_by_mode(mode, 'extras.json', 'default')
 
     core.populate_github_stats(node_packs, await json_obj_github)
     core.populate_favorites(node_packs, await json_obj_extras)


### PR DESCRIPTION
## Summary

- Fix `KeyError: 'mode'` crash in `/customnode/getlist` endpoint when the `mode` query parameter is not provided
- Extract the `mode` value once using `.get("mode", "cache")` with a default fallback, consistent with how `skip_update` is already handled on the same endpoint
- Eliminates repeated `request.rel_url.query["mode"]` lookups by storing in a local variable

Fixes #2740

## Test plan

- [ ] Send GET request to `/customnode/getlist` without `mode` param — should no longer crash
- [ ] Send GET request to `/customnode/getlist?mode=local` — should work as before
- [ ] Send GET request to `/customnode/getlist?mode=cache` — should work as before
- [ ] Verify custom node list loads correctly in Manager UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)