### PR TITLE
Add 6 jeremieLouvaert custom node packs

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45049,6 +45049,66 @@
             "description": "Photographic prompt arsenal — curated templates and component builder with real camera gear, lighting, film stocks"
         },
         {
+            "author": "jeremieLouvaert",
+            "title": "ComfyUI-Darkroom",
+            "reference": "https://github.com/jeremieLouvaert/ComfyUI-Darkroom",
+            "files": [
+                "https://github.com/jeremieLouvaert/ComfyUI-Darkroom"
+            ],
+            "install_type": "git-clone",
+            "description": "Professional color grading and film emulation suite — 29 nodes: 161 film stocks with real Capture One curve data, Camera Raw tools, Resolve-level grading (LGG, Log Wheels, Hue vs Hue, Color Warper), lens optics with 102 real lens profiles. Zero API costs."
+        },
+        {
+            "author": "jeremieLouvaert",
+            "title": "ComfyUI-Gemini-Direct",
+            "reference": "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Direct",
+            "files": [
+                "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Direct"
+            ],
+            "install_type": "git-clone",
+            "description": "Direct Google Gemini image generation for ComfyUI — use your own API key, bypass credits. Supports Gemini 2.0 Flash, 2.5 Flash, 2.5 Pro. Includes Prompt Studio and photographer style transfer."
+        },
+        {
+            "author": "jeremieLouvaert",
+            "title": "ComfyUI-API-Optimizer",
+            "reference": "https://github.com/jeremieLouvaert/ComfyUI-API-Optimizer",
+            "files": [
+                "https://github.com/jeremieLouvaert/ComfyUI-API-Optimizer"
+            ],
+            "install_type": "git-clone",
+            "description": "API cost tracking, deterministic caching, and lazy execution bypass for ComfyUI cloud API workflows. Circuit-breaker spending control with persistent ledger."
+        },
+        {
+            "author": "jeremieLouvaert",
+            "title": "ComfyUI-Gemini-Conversation-Canvas",
+            "reference": "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Conversation-Canvas",
+            "files": [
+                "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Conversation-Canvas"
+            ],
+            "install_type": "git-clone",
+            "description": "Multi-turn conversational image editing powered by Google Gemini — persistent sessions, edit chaining, and visual gallery with full scene coherence across turns."
+        },
+        {
+            "author": "jeremieLouvaert",
+            "title": "comfyui-wireless-link-simple",
+            "reference": "https://github.com/jeremieLouvaert/comfyui-wireless-link-simple",
+            "files": [
+                "https://github.com/jeremieLouvaert/comfyui-wireless-link-simple"
+            ],
+            "install_type": "git-clone",
+            "description": "Simple wireless data transmission nodes for ComfyUI — send and receive any data type without visible wires using named channels. Inspired by Blackmagic Fusion."
+        },
+        {
+            "author": "jeremieLouvaert",
+            "title": "ComfyUI-Higgsfield-Direct",
+            "reference": "https://github.com/jeremieLouvaert/ComfyUI-Higgsfield-Direct",
+            "files": [
+                "https://github.com/jeremieLouvaert/ComfyUI-Higgsfield-Direct"
+            ],
+            "install_type": "git-clone",
+            "description": "Direct Higgsfield API integration for ComfyUI — multi-model image and video generation with Soul 2.0, Seedream 4, Kling 2.1, Seedance, and more. Use your own API key."
+        },
+        {
             "author": "vpominchuk",
             "title": "ComfyUI-Wildcard-Prompt",
             "reference": "https://github.com/vpominchuk/ComfyUI-Wildcard-Prompt",


### PR DESCRIPTION
## Summary

Adding 6 custom node packs to the node list. Two packs (comfyui-prompt-assembler and ComfyUI-Prompt-Vault) are already listed.

### New entries

| Pack | Nodes | Description |
|------|-------|-------------|
| **ComfyUI-Darkroom** | 29 | Professional color grading & film emulation (161 stocks, 102 lens profiles, 75+ presets) |
| **ComfyUI-Gemini-Direct** | 3 | Direct Google Gemini image generation with Prompt Studio |
| **ComfyUI-API-Optimizer** | 3 | API cost tracking, deterministic caching, lazy execution |
| **ComfyUI-Gemini-Conversation-Canvas** | 5 | Multi-turn conversational image editing via Gemini |
| **comfyui-wireless-link-simple** | 2 | Wireless data transmission with named channels |
| **ComfyUI-Higgsfield-Direct** | 4 | Direct Higgsfield API for image & video generation |

All repos are public, have proper `__init__.py` with `NODE_CLASS_MAPPINGS` and `NODE_DISPLAY_NAME_MAPPINGS`, include `requirements.txt` where needed, and are published on the Comfy Registry under `@akurate`.