### PR TITLE
FLUXNATION FLUX.1 Fused Neuromorphic SPIKE Attention & Step Cache Cuda Kernel

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "ULT7RA",
+            "title": "FLUXNATION FLUX.1 Fused Neuromorphic SPIKE Attention & Step Cache Cuda Kernel",
+            "id": "fluxnation",
+            "reference": "https://github.com/ULT7RA/FLUXNATION",
+            "files": [
+                "https://github.com/ULT7RA/FLUXNATION"
+            ],
+            "install_type": "git-clone",
+            "description": "FLUXNATION is a fused FP8 CUDA kernel for FLUX.1 that replaces the entire SingleStreamBlock forward pass with a single torch.ops call covering modulation dual GEMMs QKV projection RoPE attention gating and residual all in one shot. On top of that it ships with neuromorphic spike attention which scores every attention block by real dot product similarity and kills the ones that dont matter after image structure has formed keeping only the top 45 percent. Step caching then replays the cached output on alternating spike steps for zero attention compute every other step. The result is 30 percent faster generation than stock ComfyUI on an RTX 4090 with no quality loss. Works with every sampler ComfyUI supports at any step count. FP16 ports for 10 series 20 series and 30 series GPUs are included. A must have for anyone running FLUX.1."
+        },
+        {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI-Manager",
             "id": "manager",


### PR DESCRIPTION
Adding FLUXNATION to the custom node list. This is a fused FP8 CUDA kernel for FLUX.1 that replaces the entire SingleStreamBlock forward pass with a single torch.ops call. Modulation, dual GEMMs, QKV projection, RoPE, attention, gating and residual are all fused into one kernel call with zero Python overhead. On top of that it ships with neuromorphic spike attention which scores every attention block by real dot product similarity and drops the ones that dont matter once image structure has formed keeping only the top 45 percent. Step caching then replays the cached output on alternating spike steps so you get zero attention compute every other step. The result is 30 percent faster generation than stock ComfyUI with no quality loss. Works with all 38 ComfyUI samplers at any step count. A must have for anyone running a 40 series Ada Lovelace card including the 4070 4080 4090 and the Ti variants. FP16 ports are included for 10 series Pascal cards like the 1080 Ti, 20 series Turing cards like the 2080 Ti, and 30 series Ampere cards like the 3090 so older hardware is covered too. Repo is at https://github.com/ULT7RA/FLUXNATION