### PR TITLE
Remove my repository entries from dev github stats

### DIFF
--- a/node_db/dev/github-stats.json
+++ b/node_db/dev/github-stats.json
@@ -4744,36 +4744,6 @@
         "last_update": "2026-03-27 16:26:14",
         "author_account_age_days": 2792
     },
-    "https://github.com/silveroxides/ComfyUI_CondsUtils": {
-        "stars": 5,
-        "last_update": "2025-10-21 08:37:47",
-        "author_account_age_days": 2151
-    },
-    "https://github.com/silveroxides/ComfyUI_LoHalo": {
-        "stars": 1,
-        "last_update": "2025-11-28 16:45:43",
-        "author_account_age_days": 2151
-    },
-    "https://github.com/silveroxides/ComfyUI_LogicMath": {
-        "stars": 0,
-        "last_update": "2025-11-03 04:18:17",
-        "author_account_age_days": 2151
-    },
-    "https://github.com/silveroxides/ComfyUI_PromptAttention": {
-        "stars": 2,
-        "last_update": "2025-11-14 19:22:01",
-        "author_account_age_days": 2151
-    },
-    "https://github.com/silveroxides/ComfyUI_ReduxEmbedToolkit": {
-        "stars": 5,
-        "last_update": "2025-10-21 08:37:47",
-        "author_account_age_days": 2151
-    },
-    "https://github.com/silveroxides/ComfyUI_SamplingUtils": {
-        "stars": 8,
-        "last_update": "2026-04-01 16:28:43",
-        "author_account_age_days": 2151
-    },
     "https://github.com/simonjaq/ComfyUI-sjnodes": {
         "stars": 0,
         "last_update": "2025-06-20 08:23:01",


### PR DESCRIPTION
Removed several GitHub repository entries from my nodes as they seem to interfer with users finding them in manager. These nodes have not been experimental in a long time.