### PR TITLE
Add ComfyUI-Info-Prompt-Toolkit to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45491,7 +45491,17 @@
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for AlphaVAE — native RGBA transparent image generation using FLUX"
         },
-
+        {
+          "author": "kinorax",
+          "title": "ComfyUI-Info-Prompt-Toolkit",
+          "id": "info-prompt-toolkit",
+          "reference": "https://github.com/kinorax/comfyui-info-prompt-toolkit",
+          "files": [
+            "https://github.com/kinorax/comfyui-info-prompt-toolkit"
+          ],
+          "install_type": "git-clone",
+          "description": "Civitai-compatible metadata saving, same-name .txt captions, XY Plot, Tiled Sampling, SAM3, Detailer, PixAI Tagger, wildcards, and Dynamic Prompts to simplify ComfyUI wiring, improve reusability, and carry trial results into the next production pass."
+        },
 
 
 


### PR DESCRIPTION
Adds `ComfyUI-Info-Prompt-Toolkit` to `custom-node-list.json`.

Repo:
- https://github.com/kinorax/comfyui-info-prompt-toolkit

ComfyUI custom node pack for prompt templating, workflow reuse, mask utilities, and related helper nodes.

Notes:
- Install type: `git-clone`
- `node_list.json` is included in the repo
- Some nodes require manual model placement under `ComfyUI/models`
- The published node set will expand soon