### PR TITLE
Add Sequencer AI Nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -21,7 +21,9 @@
             ],
             "install_type": "git-clone",
             "description": "This node pack offers various detector nodes and detailer nodes that allow you to configure a workflow that automatically enhances facial details. And provide iterative upscaler.\nNOTE: To use the UltralyticsDetectorProvider, you must install the 'ComfyUI Impact Subpack' separately.",
-            "preemptions":["SAMLoader"]
+            "preemptions": [
+                "SAMLoader"
+            ]
         },
         {
             "author": "Dr.Lt.Data",
@@ -109,7 +111,7 @@
                 "https://github.com/comfyanonymous/ComfyUI_TensorRT"
             ],
             "install_type": "git-clone",
-            "description": "This node enables the best performance on NVIDIA RTX™ Graphics Cards  (GPUs) for Stable Diffusion by leveraging NVIDIA TensorRT."
+            "description": "This node enables the best performance on NVIDIA RTX\u2122 Graphics Cards  (GPUs) for Stable Diffusion by leveraging NVIDIA TensorRT."
         },
         {
             "author": "Comfy-Org",
@@ -152,7 +154,7 @@
             "files": [
                 "https://github.com/Fannovel16/comfyui_controlnet_aux"
             ],
-            "preemptions":[
+            "preemptions": [
                 "AIO_Preprocessor",
                 "AnimalPosePreprocessor",
                 "AnimeFace_SemSegPreprocessor",
@@ -201,7 +203,8 @@
                 "UniFormer-SemSegPreprocessor",
                 "Unimatch_OptFlowPreprocessor",
                 "Zoe-DepthMapPreprocessor",
-                "Zoe_DepthAnythingPreprocessor"],
+                "Zoe_DepthAnythingPreprocessor"
+            ],
             "install_type": "git-clone",
             "description": "Plug-and-play ComfyUI node sets for making ControlNet hint images."
         },
@@ -631,7 +634,9 @@
             "files": [
                 "https://github.com/city96/SD-Latent-Upscaler"
             ],
-            "pip": ["huggingface-hub"],
+            "pip": [
+                "huggingface-hub"
+            ],
             "install_type": "git-clone",
             "description": "Upscaling stable diffusion latents using a small neural network."
         },
@@ -643,7 +648,9 @@
             "files": [
                 "https://github.com/city96/ComfyUI_DiT"
             ],
-            "pip": ["huggingface-hub"],
+            "pip": [
+                "huggingface-hub"
+            ],
             "install_type": "git-clone",
             "description": "Testbed for [a/DiT(Scalable Diffusion Models with Transformers)](https://github.com/facebookresearch/DiT). [w/None of this code is stable, expect breaking changes if for some reason you want to use this.]"
         },
@@ -677,7 +684,7 @@
             "files": [
                 "https://github.com/city96/ComfyUI-GGUF"
             ],
-            "preemptions":[
+            "preemptions": [
                 "CLIPLoaderGGUF",
                 "DualCLIPLoaderGGUF",
                 "TripleCLIPLoaderGGUF",
@@ -1221,7 +1228,9 @@
                 "IPAdapterWeightsFromStrategy",
                 "PrepImageForClipVision"
             ],
-            "pip": ["insightface"],
+            "pip": [
+                "insightface"
+            ],
             "install_type": "git-clone",
             "description": "ComfyUI reference implementation for IPAdapter models. The code is mostly taken from the original IPAdapter repository and laksjdjf's implementation, all credit goes to them. I just made the extension closer to ComfyUI philosophy."
         },
@@ -1417,7 +1426,10 @@
             "files": [
                 "https://github.com/andersxa/comfyui-PromptAttention"
             ],
-            "pip": ["scikit-learn", "matplotlib"],
+            "pip": [
+                "scikit-learn",
+                "matplotlib"
+            ],
             "install_type": "git-clone",
             "description": "Nodes: CLIP Directional Prompt Attention Encode. Direction prompt attention tries to solve the problem of contextual words (or parts of the prompt) having an effect on much later or irrelevant parts of the prompt."
         },
@@ -1425,7 +1437,9 @@
             "author": "ArtVentureX",
             "title": "AnimateDiff",
             "reference": "https://github.com/SipherAGI/comfyui-animatediff",
-            "pip": ["flash_attn"],
+            "pip": [
+                "flash_attn"
+            ],
             "files": [
                 "https://github.com/SipherAGI/comfyui-animatediff"
             ],
@@ -1895,7 +1909,7 @@
         },
         {
             "author": "Mike Sokol",
-            "title": "ComfyUI Sokes Nodes 🦬",
+            "title": "ComfyUI Sokes Nodes \ud83e\uddac",
             "reference": "https://github.com/m-sokes/ComfyUI-Sokes-Nodes",
             "files": [
                 "https://github.com/m-sokes/ComfyUI-Sokes-Nodes"
@@ -2168,14 +2182,14 @@
         },
         {
             "author": "laksjdjf",
-            "title": "cgem156-ComfyUI🍌",
+            "title": "cgem156-ComfyUI\ud83c\udf4c",
             "id": "cgem156",
             "reference": "https://github.com/laksjdjf/cgem156-ComfyUI",
             "files": [
                 "https://github.com/laksjdjf/cgem156-ComfyUI"
             ],
             "install_type": "git-clone",
-            "description": "The custom nodes of laksjdjf have been integrated into the node pack of cgem156🍌.\nNOTE:This includes the attention couple feature."
+            "description": "The custom nodes of laksjdjf have been integrated into the node pack of cgem156\ud83c\udf4c.\nNOTE:This includes the attention couple feature."
         },
         {
             "author": "laksjdjf",
@@ -2469,7 +2483,9 @@
                 "https://github.com/Ttl/ComfyUi_NNLatentUpscale"
             ],
             "install_type": "git-clone",
-            "preemptions": ["NNLatentUpscale"],
+            "preemptions": [
+                "NNLatentUpscale"
+            ],
             "description": "Nodes:NNLatentUpscale, A custom ComfyUI node designed for rapid latent upscaling using a compact neural network, eliminating the need for VAE-based decoding and encoding."
         },
         {
@@ -2521,7 +2537,9 @@
             "title": "comfy_PoP",
             "id": "pop",
             "reference": "https://github.com/picturesonpictures/comfy_PoP",
-            "files": ["https://github.com/picturesonpictures/comfy_PoP"],
+            "files": [
+                "https://github.com/picturesonpictures/comfy_PoP"
+            ],
             "install_type": "git-clone",
             "description": "A collection of custom nodes for ComfyUI. Includes a quick canny edge detection node with unconventional settings, simple LoRA stack nodes for workflow efficiency, and a customizable aspect ratio node."
         },
@@ -2681,7 +2699,7 @@
         },
         {
             "author": "BiffMunky",
-            "title": "Endless ️🌊✨ Nodes",
+            "title": "Endless \ufe0f\ud83c\udf0a\u2728 Nodes",
             "id": "endless",
             "reference": "https://github.com/tusharbhutt/Endless-Nodes",
             "files": [
@@ -2692,7 +2710,7 @@
         },
         {
             "author": "BiffMunky",
-            "title": "Endless 🌊✨ Buttons",
+            "title": "Endless \ud83c\udf0a\u2728 Buttons",
             "reference": "https://github.com/tusharbhutt/Endless-Buttons",
             "files": [
                 "https://github.com/tusharbhutt/Endless-Buttons"
@@ -3130,7 +3148,7 @@
             "files": [
                 "https://github.com/kijai/ComfyUI-Florence2"
             ],
-            "preemptions":[
+            "preemptions": [
                 "DownloadAndLoadFlorence2Lora",
                 "DownloadAndLoadFlorence2Model",
                 "Florence2ModelLoader",
@@ -3202,7 +3220,7 @@
             "files": [
                 "https://github.com/kijai/ComfyUI-segment-anything-2"
             ],
-            "preemptions":[
+            "preemptions": [
                 "DownloadAndLoadSAM2Model",
                 "Florence2toCoordinates",
                 "Sam2AutoSegmentation",
@@ -3620,7 +3638,7 @@
                 "https://github.com/zer0TF/cute-comfy"
             ],
             "install_type": "git-clone",
-            "description": "Adds a configurable folder watcher that auto-converts Comfy metadata into a Civitai-friendly format for automatic resource tagging when you upload images. Oh, and it makes your UI awesome, too. 💜"
+            "description": "Adds a configurable folder watcher that auto-converts Comfy metadata into a Civitai-friendly format for automatic resource tagging when you upload images. Oh, and it makes your UI awesome, too. \ud83d\udc9c"
         },
         {
             "author": "chflame163",
@@ -4196,7 +4214,7 @@
                 "https://github.com/Amorano/Jovimetrix"
             ],
             "install_type": "git-clone",
-            "description": "Webcam, MIDI, Spout, and GLSL support with animation via tick. Features wave-based parameter modulation, math operations, universal value conversion, shape masking, image channel ops, batch processing, dynamic bus routing, GIPHY and SPOUT integration. Load images/videos from URLs, save output anywhere, and apply transformations like flattening, cropping, and color adjustments. Includes tools for color blindness simulation, stereograms, and stereoscopic imaging—plus much more!"
+            "description": "Webcam, MIDI, Spout, and GLSL support with animation via tick. Features wave-based parameter modulation, math operations, universal value conversion, shape masking, image channel ops, batch processing, dynamic bus routing, GIPHY and SPOUT integration. Load images/videos from URLs, save output anywhere, and apply transformations like flattening, cropping, and color adjustments. Includes tools for color blindness simulation, stereograms, and stereoscopic imaging\u2014plus much more!"
         },
         {
             "author": "amorano",
@@ -4537,7 +4555,7 @@
                 "https://github.com/ZHO-ZHO-ZHO/comfyui-portrait-master-zh-cn"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI Portrait Master 简体中文版."
+            "description": "ComfyUI Portrait Master \u7b80\u4f53\u4e2d\u6587\u7248."
         },
         {
             "author": "ZHO-ZHO-ZHO",
@@ -4836,9 +4854,13 @@
             "author": "vanillacode314",
             "title": "Simple Wildcard",
             "reference": "https://github.com/vanillacode314/SimpleWildcardsComfyUI",
-            "files": ["https://github.com/vanillacode314/SimpleWildcardsComfyUI"],
+            "files": [
+                "https://github.com/vanillacode314/SimpleWildcardsComfyUI"
+            ],
             "install_type": "git-clone",
-            "pip": ["pipe"],
+            "pip": [
+                "pipe"
+            ],
             "description": "A simple wildcard node for ComfyUI. Can also be used a style prompt node."
         },
         {
@@ -4988,7 +5010,9 @@
             "files": [
                 "https://github.com/ningxiaoxiao/comfyui-NDI"
             ],
-            "pip": ["ndi-python"],
+            "pip": [
+                "ndi-python"
+            ],
             "install_type": "git-clone",
             "description": "Real-time input output node for ComfyUI by NDI. Leveraging the powerful linking capabilities of NDI, you can access NDI video stream frames and send images generated by the model to NDI video streams."
         },
@@ -5106,7 +5130,7 @@
             ],
             "nodename_pattern": "_jru$",
             "install_type": "git-clone",
-            "description": "Word embedding utility nodes for ComfyUI. Load a pre-trained embedding model, explore neighbors, do analogies, and project any token/phrase onto 1D/2D/3D semantic axes with human‑readable summaries."
+            "description": "Word embedding utility nodes for ComfyUI. Load a pre-trained embedding model, explore neighbors, do analogies, and project any token/phrase onto 1D/2D/3D semantic axes with human\u2011readable summaries."
         },
         {
             "author": "jtrue",
@@ -5444,7 +5468,7 @@
                 "https://github.com/AI2lab/comfyUI-siliconflow-api-2lab"
             ],
             "install_type": "git-clone",
-            "description": "Unofficial implementation of siliconflow API for ComfyUI\nHow to use:apply api key in ：https://cloud.siliconflow.cn/\nadd api key in config.json"
+            "description": "Unofficial implementation of siliconflow API for ComfyUI\nHow to use:apply api key in \uff1ahttps://cloud.siliconflow.cn/\nadd api key in config.json"
         },
         {
             "author": "NimaNzrii",
@@ -6027,7 +6051,9 @@
             "title": "ComfyUI-Paint-by-Example",
             "id": "paint-by-example",
             "reference": "https://github.com/Kangkang625/ComfyUI-paint-by-example",
-            "pip": ["diffusers"],
+            "pip": [
+                "diffusers"
+            ],
             "files": [
                 "https://github.com/Kangkang625/ComfyUI-paint-by-example"
             ],
@@ -6596,7 +6622,7 @@
             ],
             "nodename_pattern": "^\\[AnimateAnyone\\]",
             "install_type": "git-clone",
-            "description": "Improved AnimateAnyone implementation that allows you to use the opse image sequence and reference image to generate stylized video.\nThe current goal of this project is to achieve desired pose2video result with 1+FPS on GPUs that are equal to or better than RTX 3080!🚀\n[w/The torch environment may be compromised due to version issues as some torch-related packages are being reinstalled.]"
+            "description": "Improved AnimateAnyone implementation that allows you to use the opse image sequence and reference image to generate stylized video.\nThe current goal of this project is to achieve desired pose2video result with 1+FPS on GPUs that are equal to or better than RTX 3080!\ud83d\ude80\n[w/The torch environment may be compromised due to version issues as some torch-related packages are being reinstalled.]"
         },
         {
             "author": "tzwm",
@@ -6955,7 +6981,9 @@
             "files": [
                 "https://github.com/aws-samples/comfyui-llm-node-for-amazon-bedrock"
             ],
-            "pip": ["boto3"],
+            "pip": [
+                "boto3"
+            ],
             "install_type": "git-clone",
             "description": "Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs) from leading AI companies. This repo is the ComfyUI nodes for Bedrock service. You could invoke the foundation model in your ComfyUI pipeline."
         },
@@ -7350,7 +7378,7 @@
             "title": "comfyui_overly_complicated_sampling",
             "reference": "https://github.com/blepping/comfyui_overly_complicated_sampling",
             "files": [
-                  "https://github.com/blepping/comfyui_overly_complicated_sampling"
+                "https://github.com/blepping/comfyui_overly_complicated_sampling"
             ],
             "install_type": "git-clone",
             "description": "Experimental and mathematically unsound (but fun!) sampling for ComfyUI.\nFeel free create a question in Discussions for usage help: OCS Q&A Discussion[w/Status: In flux, may be useful but likely to change/break workflows frequently. Mainly for advanced users.]"
@@ -7360,7 +7388,7 @@
             "title": "ComfyUI-ApplyResAdapterUnet",
             "reference": "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet",
             "files": [
-                  "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet"
+                "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI node to apply the ResAdapter Unet patch for SD1.5 models"
@@ -7619,7 +7647,7 @@
         },
         {
             "author": "MaraScott",
-            "title": "🐰 MaraScott Nodes",
+            "title": "\ud83d\udc30 MaraScott Nodes",
             "id": "marascott-nodes",
             "reference": "https://github.com/MaraScott/ComfyUI_MaraScott_Nodes",
             "files": [
@@ -8440,7 +8468,7 @@
                 "https://github.com/1038lab/ComfyUI-FireRedTTS"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI integration for FireRedTTS‑2, a real-time multi-speaker TTS system enabling high-quality, emotionally expressive dialogue and monologue synthesis. Leveraging a streaming architecture and context-aware prosody modeling, it supports natural speaker turns and stable long-form generation, ideal for interactive chat and podcast applications."
+            "description": "A ComfyUI integration for FireRedTTS\u20112, a real-time multi-speaker TTS system enabling high-quality, emotionally expressive dialogue and monologue synthesis. Leveraging a streaming architecture and context-aware prosody modeling, it supports natural speaker turns and stable long-form generation, ideal for interactive chat and podcast applications."
         },
         {
             "author": "1038lab",
@@ -8490,7 +8518,7 @@
                 "https://github.com/1038lab/ComfyUI-QwenASR"
             ],
             "install_type": "git-clone",
-            "description": "A lightweight ComfyUI custom node pack for Qwen3-ASR, providing simple speech‑to‑text workflows with local model caching and optional timestamp output. Supports Qwen/Qwen3‑ASR‑1.7B and 0.6B, with HuggingFace/ModelScope download options and clean integration for ComfyUI pipelines."
+            "description": "A lightweight ComfyUI custom node pack for Qwen3-ASR, providing simple speech\u2011to\u2011text workflows with local model caching and optional timestamp output. Supports Qwen/Qwen3\u2011ASR\u20111.7B and 0.6B, with HuggingFace/ModelScope download options and clean integration for ComfyUI pipelines."
         },
         {
             "author": "1038lab",
@@ -9190,7 +9218,7 @@
                 "https://github.com/cozymantis/human-parser-comfyui-node"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI node to automatically extract masks for body regions and clothing/fashion items. Made with 💚 by the CozyMantis squad."
+            "description": "A ComfyUI node to automatically extract masks for body regions and clothing/fashion items. Made with \ud83d\udc9a by the CozyMantis squad."
         },
         {
             "author": "CozyMantis",
@@ -9201,7 +9229,7 @@
                 "https://github.com/cozymantis/pose-generator-comfyui-node"
             ],
             "install_type": "git-clone",
-            "description": "Generate OpenPose face/body reference poses in ComfyUI with ease. Made with 💚 by the CozyMantis squad."
+            "description": "Generate OpenPose face/body reference poses in ComfyUI with ease. Made with \ud83d\udc9a by the CozyMantis squad."
         },
         {
             "author": "CozyMantis",
@@ -9212,7 +9240,7 @@
                 "https://github.com/cozymantis/cozy-utils-comfyui-nodes"
             ],
             "install_type": "git-clone",
-            "description": "Various cozy nodes, made with 💚 by the CozyMantis squad."
+            "description": "Various cozy nodes, made with \ud83d\udc9a by the CozyMantis squad."
         },
         {
             "author": "vivax3794",
@@ -9434,7 +9462,7 @@
                 "https://github.com/AIGCTeam/ComfyUI_kkTranslator_nodes"
             ],
             "install_type": "git-clone",
-            "description": "These nodes are mainly used to translate prompt words from other languages into English. PromptTranslateToText implements prompt word translation based on Helsinki NLP translation model.It doesn't require internet connection。"
+            "description": "These nodes are mainly used to translate prompt words from other languages into English. PromptTranslateToText implements prompt word translation based on Helsinki NLP translation model.It doesn't require internet connection\u3002"
         },
         {
             "author": "vsevolod-oparin",
@@ -9552,7 +9580,7 @@
             "id": "impactframes-videoprompts",
             "reference": "https://github.com/if-ai/ComfyUI-IF_VideoPrompts",
             "files": [
-              "https://github.com/if-ai/ComfyUI-IF_VideoPrompts"
+                "https://github.com/if-ai/ComfyUI-IF_VideoPrompts"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI extension for video-based prompting and processing with support for various models and video processing capabilities"
@@ -9563,7 +9591,7 @@
             "id": "impactframes-llm",
             "reference": "https://github.com/if-ai/ComfyUI-IF_LLM",
             "files": [
-              "https://github.com/if-ai/ComfyUI-IF_LLM"
+                "https://github.com/if-ai/ComfyUI-IF_LLM"
             ],
             "install_type": "git-clone",
             "description": "Run Local and API LLMs, Features Conditioning manipulation via Omost, supports Ollama, LlamaCPP LMstudio, Koboldcpp, TextGen, Transformers or via APIs Anthropic, Groq, OpenAI, Google Gemini, Mistral, xAI and create your own charcters assistants (SystemPrompts) with custom presets and muchmore"
@@ -9574,7 +9602,7 @@
             "id": "impactframes-loadimages",
             "reference": "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages",
             "files": [
-              "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages"
+                "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages"
             ],
             "install_type": "git-clone",
             "description": "It Load Images with subfolders form arbitrary folders previous on node outputs lists- convinient selection via file browser"
@@ -9890,7 +9918,9 @@
             "title": "ComfyUI-RGT",
             "id": "rgt",
             "reference": "https://github.com/viperyl/ComfyUI-RGT",
-            "pip": ["loguru"],
+            "pip": [
+                "loguru"
+            ],
             "files": [
                 "https://github.com/viperyl/ComfyUI-RGT"
             ],
@@ -10483,7 +10513,7 @@
                 "https://github.com/jtydhr88/ComfyUI-StableStudio"
             ],
             "install_type": "git-clone",
-            "description": "A practical plug‑in that adds a StableStudio style user interface to ComfyUI. This project aims to give you a clean, responsive UI for managing StableStudio features inside ComfyUI, without complicating your workflow. It focuses on reliability, speed, and a calm, uncluttered design that helps you work faster."
+            "description": "A practical plug\u2011in that adds a StableStudio style user interface to ComfyUI. This project aims to give you a clean, responsive UI for managing StableStudio features inside ComfyUI, without complicating your workflow. It focuses on reliability, speed, and a calm, uncluttered design that helps you work faster."
         },
         {
             "author": "jtydhr88",
@@ -11022,7 +11052,7 @@
                 "https://github.com/Koishi-Star/Euler-Smea-Dyn-Sampler"
             ],
             "install_type": "git-clone",
-            "description": "СomfyUI version of [a/Euler Smea Dyn Sampler](https://github.com/Koishi-Star/Euler-Smea-Dyn-Sampler). It adds samplers directly to KSampler nodes."
+            "description": "\u0421omfyUI version of [a/Euler Smea Dyn Sampler](https://github.com/Koishi-Star/Euler-Smea-Dyn-Sampler). It adds samplers directly to KSampler nodes."
         },
         {
             "author": "Koishi-Star",
@@ -11187,7 +11217,7 @@
                 "https://github.com/smthemex/ComfyUI_Llama3_8B"
             ],
             "install_type": "git-clone",
-            "description": "Llama3_8B for comfyUI， using pipeline workflow."
+            "description": "Llama3_8B for comfyUI\uff0c using pipeline workflow."
         },
         {
             "author": "smthemex",
@@ -11296,7 +11326,7 @@
                 "https://github.com/smthemex/ComfyUI_Sapiens"
             ],
             "install_type": "git-clone",
-            "description": "You can call Using Sapiens to get seg，normal，pose，depth，mask."
+            "description": "You can call Using Sapiens to get seg\uff0cnormal\uff0cpose\uff0cdepth\uff0cmask."
         },
         {
             "author": "smthemex",
@@ -11336,7 +11366,7 @@
                 "https://github.com/smthemex/ComfyUI_InstantIR_Wrapper"
             ],
             "install_type": "git-clone",
-            "description": "You can InstantIR to Fix blurry photos in ComfyUI ，[a/InstantIR](https://github.com/instantX-research/InstantIR):Blind Image Restoration with Instant Generative Reference"
+            "description": "You can InstantIR to Fix blurry photos in ComfyUI \uff0c[a/InstantIR](https://github.com/instantX-research/InstantIR):Blind Image Restoration with Instant Generative Reference"
         },
         {
             "author": "smthemex",
@@ -11376,7 +11406,7 @@
                 "https://github.com/smthemex/ComfyUI_SVFR"
             ],
             "install_type": "git-clone",
-            "description": "SVFR is a unified framework for face video restoration that supports tasks such as BFR, Colorization, Inpainting，you can use it in ComfyUI"
+            "description": "SVFR is a unified framework for face video restoration that supports tasks such as BFR, Colorization, Inpainting\uff0cyou can use it in ComfyUI"
         },
         {
             "author": "smthemex",
@@ -11446,7 +11476,7 @@
                 "https://github.com/smthemex/ComfyUI_PhotoDoodle"
             ],
             "install_type": "git-clone",
-            "description": "PhotoDoodle: Learning Artistic Image Editing from Few-Shot Pairwise Data，you can use it in comfyUI"
+            "description": "PhotoDoodle: Learning Artistic Image Editing from Few-Shot Pairwise Data\uff0cyou can use it in comfyUI"
         },
         {
             "author": "smthemex",
@@ -11476,7 +11506,7 @@
                 "https://github.com/smthemex/ComfyUI_DICE_Talk"
             ],
             "install_type": "git-clone",
-            "description": "Use DICE-Talk in ComfyUI，which is a method about Correlation-Aware Emotional Talking Portrait Generation."
+            "description": "Use DICE-Talk in ComfyUI\uff0cwhich is a method about Correlation-Aware Emotional Talking Portrait Generation."
         },
         {
             "author": "smthemex",
@@ -11566,7 +11596,7 @@
                 "https://github.com/smthemex/ComfyUI_LucidFlux"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI_LucidFlux:Caption-Free Universal Image Restoration with a Large-Scale Diffusion Transformer，you can use it in ComfyUI"
+            "description": "ComfyUI_LucidFlux:Caption-Free Universal Image Restoration with a Large-Scale Diffusion Transformer\uff0cyou can use it in ComfyUI"
         },
         {
             "author": "smthemex",
@@ -11606,7 +11636,7 @@
                 "https://github.com/smthemex/ComfyUI_Step_Audio_EditX_SM"
             ],
             "install_type": "git-clone",
-            "description": "Step_Audio_EditX：the first open-source LLM-based audio model excelling at expressive and iterative audio editing—encompassing emotion, speaking style, and paralinguistics—alongside robust zero-shot text-to-speech (TTS) capabilities，try it in comfyUI"
+            "description": "Step_Audio_EditX\uff1athe first open-source LLM-based audio model excelling at expressive and iterative audio editing\u2014encompassing emotion, speaking style, and paralinguistics\u2014alongside robust zero-shot text-to-speech (TTS) capabilities\uff0ctry it in comfyUI"
         },
         {
             "author": "smthemex",
@@ -12116,7 +12146,9 @@
             "files": [
                 "https://github.com/MinusZoneAI/ComfyUI-Flux1Quantize-MZ"
             ],
-            "pip": ["git+https://github.com/IST-DASLab/marlin"],
+            "pip": [
+                "git+https://github.com/IST-DASLab/marlin"
+            ],
             "install_type": "git-clone",
             "description": "Quantization tools are from [a/https://github.com/casper-hansen/AutoAWQ](https://github.com/casper-hansen/AutoAWQ) and [a/https://github.com/IST-DASLab/marlin](https://github.com/IST-DASLab/marlin)\nOnly applicable to graphics cards with sm_80 and above (30 series and above)\nNeed to install marlin dependencies first"
         },
@@ -12171,7 +12203,7 @@
                 "https://github.com/lquesada/ComfyUI-Prompt-Combinator"
             ],
             "install_type": "git-clone",
-            "description": "'🔢 Prompt Combinator' is a node that generates all possible combinations of prompts from several lists of strings.\n'🔢 Prompt Combinator Merger' is a node that enables merging the output of two different '🔢 Prompt Combinator' nodes."
+            "description": "'\ud83d\udd22 Prompt Combinator' is a node that generates all possible combinations of prompts from several lists of strings.\n'\ud83d\udd22 Prompt Combinator Merger' is a node that enables merging the output of two different '\ud83d\udd22 Prompt Combinator' nodes."
         },
         {
             "author": "lquesada",
@@ -12182,7 +12214,7 @@
                 "https://github.com/lquesada/ComfyUI-Inpaint-CropAndStitch"
             ],
             "install_type": "git-clone",
-            "description": "'✂️ Inpaint Crop' is a node that crops an image before sampling. The context area can be specified via the mask, expand pixels and expand factor or via a separate (optional) mask.\n'✂️ Inpaint Stitch' is a node that stitches the inpainted image back into the original image without altering unmasked areas."
+            "description": "'\u2702\ufe0f Inpaint Crop' is a node that crops an image before sampling. The context area can be specified via the mask, expand pixels and expand factor or via a separate (optional) mask.\n'\u2702\ufe0f Inpaint Stitch' is a node that stitches the inpainted image back into the original image without altering unmasked areas."
         },
         {
             "author": "lquesada",
@@ -12346,7 +12378,7 @@
         },
         {
             "author": "nat-chan",
-            "title": "ComfyUI-Transceiver📡",
+            "title": "ComfyUI-Transceiver\ud83d\udce1",
             "id": "transceiver",
             "reference": "https://github.com/nat-chan/comfyui-transceiver",
             "files": [
@@ -12598,7 +12630,7 @@
         },
         {
             "author": "philz1337x",
-            "title": "✨ Clarity AI - Creative Image Upscaler and Enhancer for ComfyUI",
+            "title": "\u2728 Clarity AI - Creative Image Upscaler and Enhancer for ComfyUI",
             "reference": "https://github.com/philz1337x/ComfyUI-ClarityAI",
             "files": [
                 "https://github.com/philz1337x/ComfyUI-ClarityAI"
@@ -12794,7 +12826,7 @@
         },
         {
             "author": "YFG",
-            "title": "😸 YFG Comical Nodes",
+            "title": "\ud83d\ude38 YFG Comical Nodes",
             "id": "comical",
             "reference": "https://github.com/gonzalu/ComfyUI_YFG_Comical",
             "files": [
@@ -12845,7 +12877,7 @@
                 "https://github.com/christian-byrne/img2txt-comfyui-nodes"
             ],
             "install_type": "git-clone",
-            "description": "Get general description or specify questions to ask about images (medium, art style, background, etc.). Supports Chinese 🇨🇳 questions via MiniCPM model."
+            "description": "Get general description or specify questions to ask about images (medium, art style, background, etc.). Supports Chinese \ud83c\udde8\ud83c\uddf3 questions via MiniCPM model."
         },
         {
             "author": "christian-byrne",
@@ -13588,7 +13620,7 @@
                 "https://github.com/PnthrLeo/comfyUI-PL-data-tools"
             ],
             "install_type": "git-clone",
-            "description": "Image data check, filtering and augmentation tools for ComfyUI 🔬\nNOTE: Renamed from 'comfyUI-image-search'"
+            "description": "Image data check, filtering and augmentation tools for ComfyUI \ud83d\udd2c\nNOTE: Renamed from 'comfyUI-image-search'"
         },
         {
             "author": "l20richo",
@@ -13652,7 +13684,7 @@
                 "https://github.com/vanche1212/ComfyUI-InspireMusic"
             ],
             "install_type": "git-clone",
-            "description": "InspireMusic ComfyUI Plugin – ComfyUI Integration Plugin for AI Music Generation\nA ComfyUI node plugin based on Alibaba’s InspireMusic model, supporting text-to-music generation and music continuation features."
+            "description": "InspireMusic ComfyUI Plugin \u2013 ComfyUI Integration Plugin for AI Music Generation\nA ComfyUI node plugin based on Alibaba\u2019s InspireMusic model, supporting text-to-music generation and music continuation features."
         },
         {
             "author": "hben35096",
@@ -13790,9 +13822,9 @@
             "reference": "https://github.com/risunobushi/ComfyUI_DisplacementMapTools",
             "files": [
                 "https://github.com/risunobushi/ComfyUI_DisplacementMapTools"
-             ],
-             "install_type": "git-clone",
-             "description": "NODES: Extract Displacement Map Node, Displace Logo"
+            ],
+            "install_type": "git-clone",
+            "description": "NODES: Extract Displacement Map Node, Displace Logo"
         },
         {
             "author": "risunobushi",
@@ -14716,7 +14748,7 @@
                 "https://github.com/adigayung/ComfyUI-Translator"
             ],
             "install_type": "git-clone",
-            "description": "Auto translate all languages ​​to english"
+            "description": "Auto translate all languages \u200b\u200bto english"
         },
         {
             "author": "ZZXYWQ",
@@ -14731,7 +14763,7 @@
         },
         {
             "author": "SiliconFlow",
-            "title": "☁️BizyAir Nodes",
+            "title": "\u2601\ufe0fBizyAir Nodes",
             "id": "bizyair",
             "reference": "https://github.com/siliconflow/BizyAir",
             "files": [
@@ -15269,7 +15301,7 @@
                 "https://github.com/fssorc/ComfyUI_RopeWrapper"
             ],
             "install_type": "git-clone",
-            "description": "Wrap Rope into ComfyUI, do a little change to use in ComfyUI. All credit goes to Hillobar and his ROPE [ㅁ/https://github.com/Hillobar/Rope](https://github.com/Hillobar/Rope)"
+            "description": "Wrap Rope into ComfyUI, do a little change to use in ComfyUI. All credit goes to Hillobar and his ROPE [\u3141/https://github.com/Hillobar/Rope](https://github.com/Hillobar/Rope)"
         },
         {
             "author": "BetaDoggo",
@@ -15775,7 +15807,7 @@
         },
         {
             "author": "akatz-ai",
-            "title": "🌊 Depthflow Nodes",
+            "title": "\ud83c\udf0a Depthflow Nodes",
             "id": "depthflow-akatz-ai",
             "reference": "https://github.com/akatz-ai/ComfyUI-Depthflow-Nodes",
             "files": [
@@ -16051,7 +16083,7 @@
                 "https://github.com/Dobidop/ComfyStereo"
             ],
             "install_type": "git-clone",
-            "description": "Two simple nodes for stereoscopic image generation. Nodes: Stereo Image Node - a basic port from the Automatic1111 stereo script in thygate/stable-diffusion-webui-depthmap-script, LazyStereo - a naïve stereo image generator"
+            "description": "Two simple nodes for stereoscopic image generation. Nodes: Stereo Image Node - a basic port from the Automatic1111 stereo script in thygate/stable-diffusion-webui-depthmap-script, LazyStereo - a na\u00efve stereo image generator"
         },
         {
             "author": "SeniorPioner",
@@ -16784,8 +16816,7 @@
             "title": "ControlAltAI Nodes",
             "id": "controlaltai",
             "reference": "https://github.com/gseth/ControlAltAI-Nodes",
-            "files":
-            [
+            "files": [
                 "https://github.com/gseth/ControlAltAI-Nodes"
             ],
             "install_type": "git-clone",
@@ -17783,15 +17814,15 @@
             "description": "This repository encapsulates the BAGEL model as ComfyUI nodes for use, including image editing and image inversion features, but it does not include text-to-image functionality."
         },
         {
-           "author": "GrenKain",
-           "title": "PixelArt Processing Nodes",
-           "id": "gk_pixelart",
-           "reference": "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI",
-           "files": [
-               "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI"
-           ],
-           "install_type": "git-clone",
-           "description": "This repository provides custom nodes for ComfyUI that enable pixel art style image processing, including downscaling, upscaling, color quantization, and resolution adjustments."
+            "author": "GrenKain",
+            "title": "PixelArt Processing Nodes",
+            "id": "gk_pixelart",
+            "reference": "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI",
+            "files": [
+                "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "This repository provides custom nodes for ComfyUI that enable pixel art style image processing, including downscaling, upscaling, color quantization, and resolution adjustments."
         },
         {
             "author": "Trgtuan10",
@@ -17967,7 +17998,7 @@
                 "https://github.com/Cyber-BlackCat/ComfyUI-Image-Vector"
             ],
             "install_type": "git-clone",
-            "description": "modify the original node instruction of image vector, add ‘imagemagick’ which is the key base Python library of ‘wand’ library."
+            "description": "modify the original node instruction of image vector, add \u2018imagemagick\u2019 which is the key base Python library of \u2018wand\u2019 library."
         },
         {
             "author": "cr7Por",
@@ -18007,7 +18038,9 @@
             "files": [
                 "https://github.com/MetaGLM/ComfyUI-ZhipuAI-Platform"
             ],
-            "pip": ["zhipuai-platform-video"],
+            "pip": [
+                "zhipuai-platform-video"
+            ],
             "install_type": "git-clone",
             "description": "This platform extension provides ZhipuAI nodes, enabling you to configure a workflow for online video generation."
         },
@@ -18467,15 +18500,15 @@
             "description": "Custom nodes for MiniCPM language models in ComfyUI. Provides advanced text generation and image understanding functions."
         },
         {
-             "author": "CY-CHENYUE",
-             "title": "ComfyUI-Molmo",
-             "id": "comfyui-molmo",
-             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Molmo",
-             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Molmo"
-             ],
-             "install_type": "git-clone",
-             "description": "Use of the molmo model.Generate detailed image descriptions and analysis using Molmo models in ComfyUI."
+            "author": "CY-CHENYUE",
+            "title": "ComfyUI-Molmo",
+            "id": "comfyui-molmo",
+            "reference": "https://github.com/CY-CHENYUE/ComfyUI-Molmo",
+            "files": [
+                "https://github.com/CY-CHENYUE/ComfyUI-Molmo"
+            ],
+            "install_type": "git-clone",
+            "description": "Use of the molmo model.Generate detailed image descriptions and analysis using Molmo models in ComfyUI."
         },
         {
             "author": "CY-CHENYUE",
@@ -18483,9 +18516,13 @@
             "id": "ComfyUI-InpaintEasy",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy"
+                "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy"
             ],
-            "tags": ["inpaint", "crop", "image"],
+            "tags": [
+                "inpaint",
+                "crop",
+                "image"
+            ],
             "install_type": "git-clone",
             "description": "InpaintEasy is a set of optimized local repainting (Inpaint) nodes that provide a simpler and more powerful local repainting workflow. It makes local repainting work easier and more efficient with intelligent cropping and merging functions."
         },
@@ -18495,7 +18532,7 @@
             "id": "ComfyUI-OmniGenX",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX"
+                "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX"
             ],
             "install_type": "git-clone",
             "description": "OmniGen Unified Image Generation Model Integration."
@@ -18506,9 +18543,13 @@
             "id": "ComfyUI-Redux-Prompt",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt"
+                "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt"
             ],
-            "tags": ["Flux", "redux", "prompt"],
+            "tags": [
+                "Flux",
+                "redux",
+                "prompt"
+            ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node that provides fine-grained control over style transfer using Redux style models."
         },
@@ -18518,7 +18559,7 @@
             "id": "ComfyUI-MiniCPM-o",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o"
+                "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for MiniCPM"
@@ -18529,7 +18570,7 @@
             "id": "ComfyUI-Janus-Pro",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro"
+                "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Janus-Pro, a unified multimodal understanding and generation framework."
@@ -18540,7 +18581,7 @@
             "id": "ComfyUI-Free-GPU",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU"
+                "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU"
             ],
             "description": "ComfyUI-Free-GPU provides a node for releasing RAM and VRAM in ComfyUI.",
             "install_type": "git-clone"
@@ -18551,7 +18592,7 @@
             "id": "ComfyUI-Gemini-API",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API"
+                "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API"
             ],
             "description": "A custom node for ComfyUI to integrate Google Gemini API.",
             "install_type": "git-clone"
@@ -18562,7 +18603,7 @@
             "id": "ComfyUI-GPT-API",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-GPT-API",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-GPT-API"
+                "https://github.com/CY-CHENYUE/ComfyUI-GPT-API"
             ],
             "description": "A custom node for ComfyUI to integrate GPT API.",
             "install_type": "git-clone"
@@ -18573,7 +18614,7 @@
             "id": "ComfyUI-FramePack-HY",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY"
+                "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY"
             ],
             "description": "A custom node for ComfyUI to FramePack.",
             "install_type": "git-clone"
@@ -18584,7 +18625,7 @@
             "id": "ComfyUI-ImageCompositionCy",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy"
+                "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy"
             ],
             "description": "A powerful ComfyUI multi-image composition node that supports real-time adjustment of image position, size, and rotation angle on an interactive Canvas, with freehand drawing capabilities and real-time preview of composition effects.",
             "install_type": "git-clone"
@@ -18965,7 +19006,7 @@
                 "https://github.com/yvann-ba/ComfyUI_Yvann-Nodes"
             ],
             "install_type": "git-clone",
-            "description": "Audio Reactive nodes for AI animations 🔊 Analyze audio, extract drums, bass, vocals. Compatible with IPAdapter, ControlNets, AnimateDiff... Generate reactive masks and weights. Create audio-driven visuals. Produce weight graphs and audio masks. Ideal for music videos and reactive animations. Features audio scheduling and waveform analysis"
+            "description": "Audio Reactive nodes for AI animations \ud83d\udd0a Analyze audio, extract drums, bass, vocals. Compatible with IPAdapter, ControlNets, AnimateDiff... Generate reactive masks and weights. Create audio-driven visuals. Produce weight graphs and audio masks. Ideal for music videos and reactive animations. Features audio scheduling and waveform analysis"
         },
         {
             "author": "Playbook",
@@ -19565,7 +19606,7 @@
                 "https://github.com/clhui/ComfyUi-clh-Tool"
             ],
             "install_type": "git-clone",
-            "description": "Some mathematical calculation nodes，freedom And omnipotent, string calculation nodes, can customize the number of parameters and calculation formulas（expression）. The calculation content can also be displayed in places such as the label title of Comfy Node，String to Image Title Label"
+            "description": "Some mathematical calculation nodes\uff0cfreedom And omnipotent, string calculation nodes, can customize the number of parameters and calculation formulas\uff08expression\uff09. The calculation content can also be displayed in places such as the label title of Comfy Node\uff0cString to Image Title Label"
         },
         {
             "author": "ruucm",
@@ -19586,9 +19627,11 @@
             "files": [
                 "https://github.com/TZOOTZ/ComfyUI-TZOOTZ_VHS"
             ],
-            "pip": ["numpy<2"],
+            "pip": [
+                "numpy<2"
+            ],
             "install_type": "git-clone",
-            "description": "The TZOOTZ VHS Effect Node is designed for multimedia creators who want to blend digital precision with analog imperfection ↔️. Inspired by retro VHS aesthetics, this node lets you apply grain, color bleeding, saturation adjustments, and more, giving any image a touch of analog warmth and noise."
+            "description": "The TZOOTZ VHS Effect Node is designed for multimedia creators who want to blend digital precision with analog imperfection \u2194\ufe0f. Inspired by retro VHS aesthetics, this node lets you apply grain, color bleeding, saturation adjustments, and more, giving any image a touch of analog warmth and noise."
         },
         {
             "author": "jianzhichun",
@@ -19761,7 +19804,7 @@
                 "https://github.com/lgldlk/ComfyUI-PC-ding-dong"
             ],
             "install_type": "git-clone",
-            "description": "Just like when your pizza is ready and the oven goes 'Ding! 🍕', this plugin lets your ComfyUI notify you when your AI creations are done baking!\nA ComfyUI custom node that sends you a friendly 'ding-dong' notification when your workflows are fully cooked and ready to serve. No more staring at the screen waiting - let the AI kitchen tell you when dinner's ready! 👨‍🍳"
+            "description": "Just like when your pizza is ready and the oven goes 'Ding! \ud83c\udf55', this plugin lets your ComfyUI notify you when your AI creations are done baking!\nA ComfyUI custom node that sends you a friendly 'ding-dong' notification when your workflows are fully cooked and ready to serve. No more staring at the screen waiting - let the AI kitchen tell you when dinner's ready! \ud83d\udc68\u200d\ud83c\udf73"
         },
         {
             "author": "Wakfull33",
@@ -19805,211 +19848,211 @@
             "description": "Fork of [a/sd_webui_stealth_pnginfo](https://github.com/ashen-sensored/sd_webui_stealth_pnginfo) with ComfyUI support."
         },
         {
-           "author": "dafeng012",
-           "title": "comfyui-imgmake",
-           "reference": "https://github.com/dafeng012/comfyui-imgmake",
-           "files": [
-               "https://github.com/dafeng012/comfyui-imgmake"
-           ],
-           "install_type": "git-clone",
-           "description": "This extension integrates ebsynth_utility into comfyui, and I've written some of my own nodes for secondary use."
-       },
-       {
-           "author": "zubenelakrab",
-           "title": "ComfyUI-ASV-Nodes Node",
-           "id": "ComfyUI-ASV-Nodes",
-           "reference": "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes",
-           "files": [
-               "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes"
-           ],
-           "install_type": "git-clone",
-           "description": "ComfyUI-ASV-Nodes make prompting easier."
-       },
-       {
-           "author": "zubenelakrab",
-           "title": "ComfyUI Neural Nodes",
-           "reference": "https://github.com/xobiomesh/ComfyUI_xObiomesh",
-           "files": [
-               "https://github.com/xobiomesh/ComfyUI_xObiomesh"
-           ],
-           "install_type": "git-clone",
-           "description": "An advanced ComfyUI extension that enables multi-agent LLM conversations using Ollama models."
-       },
-       {
-           "author": "KohakuBlueleaf",
-           "title": "TIPO-extension",
-           "reference": "https://github.com/KohakuBlueleaf/z-tipo-extension",
-           "files": [
-               "https://github.com/KohakuBlueleaf/z-tipo-extension"
-           ],
-           "install_type": "git-clone",
-           "description": "A general extension to utilize TIPO or DanTagGen to do 'text-presampling' based on KGen library: [a/https://github.com/KohakuBlueleaf/KGen](https://github.com/KohakuBlueleaf/KGen)"
-       },
-       {
-           "author": "KohakuBlueleaf",
-           "title": "HDM-ext",
-           "id": "HDM",
-           "reference": "https://github.com/KohakuBlueleaf/HDM-ext",
-           "files": [
-               "https://github.com/KohakuBlueleaf/HDM-ext"
-           ],
-           "install_type": "git-clone",
-           "description": "HDM model loader for ComfyUI"
-       },
-       {
-           "author": "hanoixan",
-           "title": "ComfyUI DataBeast",
-           "reference": "https://github.com/hanoixan/ComfyUI-DataBeast",
-           "files": [
-               "https://github.com/hanoixan/ComfyUI-DataBeast"
-           ],
-           "install_type": "git-clone",
-           "description": "This extension provides convenience nodes for batch processing."
-       },
-       {
-           "author": "HelloVision",
-           "title": "ComfyUI_HelloMeme",
-           "reference": "https://github.com/HelloVision/ComfyUI_HelloMeme",
-           "files": [
-               "https://github.com/HelloVision/ComfyUI_HelloMeme"
-           ],
-           "install_type": "git-clone",
-           "description": "This repository is the official implementation of the [a/HelloMeme](https://arxiv.org/pdf/2410.22901) ComfyUI interface, featuring both image and video generation functionalities. Example workflow files can be found in the ComfyUI_HelloMeme/workflows directory. Test images and videos are saved in the ComfyUI_HelloMeme/examples directory. Below are screenshots of the interfaces for image and video generation.\nNOTE: 'HelloMeme: Integrating Spatial Knitting Attentions to Embed High-Level and Fidelity-Rich Conditions in Diffusion Models'"
-       },
-       {
-           "author": "recraftai",
-           "title": "ComfyUI-RecraftAI",
-           "id": "comfyui-recraftai",
-           "reference": "https://github.com/recraft-ai/ComfyUI-RecraftAI",
-           "files": [
-               "https://github.com/recraft-ai/ComfyUI-RecraftAI"
-           ],
-           "install_type": "git-clone",
-           "description": "Recraft AI API Custom Nodes"
-       },
-       {
-           "author": "basix",
-           "title": "Basix Image Filters",
-           "id": "basix_image_filters",
-           "reference": "https://github.com/maludwig/basix_image_filters",
-           "files": [
-               "https://github.com/maludwig/basix_image_filters"
-           ],
-           "install_type": "git-clone",
-           "description": "A handful of image filters for ComfyUI (darken, lighten, levels, saturate, hue)"
-       },
-       {
-           "author": "Frost Ming",
-           "title": "Comfy-Pack",
-           "reference": "https://github.com/bentoml/comfy-pack",
-           "files": [
-              "https://github.com/bentoml/comfy-pack"
-           ],
-           "description": "A comprehensive toolkit for standardizing, packaging and deploying ComfyUI workflows as reproducible environments and production-ready REST services",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "Poseidon-fan",
-           "title": "ComfyUI-RabbitMQ-Publisher",
-           "reference": "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher",
-           "files": [
-              "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher"
-           ],
-           "description": "ComfyUI custom_node that publish output image to rabbit_mq",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "1zhangyy1",
-           "title": "ComfyUI VIDU",
-           "reference": "https://github.com/1zhangyy1/comfyui-vidu-nodes",
-           "files": [
-              "https://github.com/1zhangyy1/comfyui-vidu-nodes"
-           ],
-           "description": "This is a ComfyUI node package that integrates with VIDU API, supporting features such as text-to-video, image-to-video, character-to-video generation, and video super-resolution.",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "LevelPixel",
-           "title": "ComfyUI Level Pixel",
-           "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel",
-           "files": [
-               "https://github.com/LevelPixel/ComfyUI-LevelPixel"
-           ],
-           "install_type": "git-clone",
-           "description": "Main nodes of the Level Pixel company (aka levelpixel, LP). Includes convenient nodes for working with images from folders; counting files in a folder; cleaning memory; tag filters. Model Unloader, LLM Unloader, Free memory, Tag Filters, Tag Category Filters, Tag Choice Parser, File counter, Image Loader From Path (with counters), Image Remove Background based on RemBG, Autotagger."
-       },
-       {
-           "author": "LevelPixel",
-           "title": "ComfyUI Level Pixel Advanced",
-           "id": "comfyui-levelpixel-advanced",
-           "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced",
-           "files": [
-               "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced"
-           ],
-           "install_type": "git-clone",
-           "description": "Advanced nodes of the Level Pixel company (levelpixel, LP). Includes convenient advanced nodes for working with LLM и VLM models (LLaVa) with GGUF format. Qwen2.5-VL and Qwen2.5 supported. Also included is a node for the RAM model. Nodes have the ability to automatically unload models from VRAM."
-       },
-       {
-           "author": "morino-kumasan",
-           "title": "comfyui-toml-prompt",
-           "reference": "https://github.com/morino-kumasan/comfyui-toml-prompt",
-           "files": [
-              "https://github.com/morino-kumasan/comfyui-toml-prompt"
-           ],
-           "install_type": "git-clone",
-           "description": "Encode Prompt in TOML for ComfyUI."
-       },
-       {
-           "author": "wentao-uw",
-           "title": "ComfyUI template matching",
-           "reference": "https://github.com/wentao-uw/ComfyUI-template-matching",
-           "files": [
-              "https://github.com/wentao-uw/ComfyUI-template-matching"
-           ],
-           "description": "This project is a ComfyUI version of [a/https://github.com/cozheyuanzhangde/Invariant-TemplateMatching](https://github.com/cozheyuanzhangde/Invariant-TemplateMatching).",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "w00dycomfyuirun",
-           "title": "ComfyUI_Appstore",
-           "id": "ComfyUI_Appstore",
-           "reference": "https://github.com/ronaldzgithub/ComfyUI_Appstore",
-           "files": [
-               "https://github.com/ronaldzgithub/ComfyUI_Appstore"
-           ],
-           "install_type": "git-clone",
-           "description": "ComfyUI_Appstore, a tool that converts ComfyUI workflows into web apps on huaxiaobao.net with one click, and supports payments, like ComfyUI_Bxb (Bxb) does. Providing a way for the comfyui authors to get profit from."
-       },
-       {
-           "author": "kycg",
-           "title": "Kw_Json_Lora_CivitAIDownloader",
-           "reference": "https://github.com/kycg/comfyui-Lora-auto-downloader",
-           "files": [
-              "https://github.com/kycg/comfyui-Lora-auto-downloader"
-           ],
-           "description": "This tool allows you to download models from CivitAI based on a JSON configuration that defines LORA and checkpoint models. It uses token-based authentication to download files from specified URLs and saves them to specified directories. based on CivitAIDownloader",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "VangengLab",
-           "title": "ComfyUI-LivePortrait_v2",
-           "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v2",
-           "files": [
-               "https://github.com/VangengLab/ComfyUI-LivePortrait_v2"
-           ],
-           "install_type": "git-clone",
-           "description": "We developed a custom_node for Liveportrait_v2 that enables flexible use on Comfyui to drive animal image-based emoji generation from videos."
-       },
-       {
-           "author": "VangengLab",
-           "title": "ComfyUI-LivePortrait_v3",
-           "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v3",
-           "files": [
-               "https://github.com/VangengLab/ComfyUI-LivePortrait_v3"
-           ],
-           "install_type": "git-clone",
-           "description": "We developed a custom_node for Liveportrait_v3 that enables flexible use on Comfyui to drive image-based emoji generation from photos."
-       },
+            "author": "dafeng012",
+            "title": "comfyui-imgmake",
+            "reference": "https://github.com/dafeng012/comfyui-imgmake",
+            "files": [
+                "https://github.com/dafeng012/comfyui-imgmake"
+            ],
+            "install_type": "git-clone",
+            "description": "This extension integrates ebsynth_utility into comfyui, and I've written some of my own nodes for secondary use."
+        },
+        {
+            "author": "zubenelakrab",
+            "title": "ComfyUI-ASV-Nodes Node",
+            "id": "ComfyUI-ASV-Nodes",
+            "reference": "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes",
+            "files": [
+                "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-ASV-Nodes make prompting easier."
+        },
+        {
+            "author": "zubenelakrab",
+            "title": "ComfyUI Neural Nodes",
+            "reference": "https://github.com/xobiomesh/ComfyUI_xObiomesh",
+            "files": [
+                "https://github.com/xobiomesh/ComfyUI_xObiomesh"
+            ],
+            "install_type": "git-clone",
+            "description": "An advanced ComfyUI extension that enables multi-agent LLM conversations using Ollama models."
+        },
+        {
+            "author": "KohakuBlueleaf",
+            "title": "TIPO-extension",
+            "reference": "https://github.com/KohakuBlueleaf/z-tipo-extension",
+            "files": [
+                "https://github.com/KohakuBlueleaf/z-tipo-extension"
+            ],
+            "install_type": "git-clone",
+            "description": "A general extension to utilize TIPO or DanTagGen to do 'text-presampling' based on KGen library: [a/https://github.com/KohakuBlueleaf/KGen](https://github.com/KohakuBlueleaf/KGen)"
+        },
+        {
+            "author": "KohakuBlueleaf",
+            "title": "HDM-ext",
+            "id": "HDM",
+            "reference": "https://github.com/KohakuBlueleaf/HDM-ext",
+            "files": [
+                "https://github.com/KohakuBlueleaf/HDM-ext"
+            ],
+            "install_type": "git-clone",
+            "description": "HDM model loader for ComfyUI"
+        },
+        {
+            "author": "hanoixan",
+            "title": "ComfyUI DataBeast",
+            "reference": "https://github.com/hanoixan/ComfyUI-DataBeast",
+            "files": [
+                "https://github.com/hanoixan/ComfyUI-DataBeast"
+            ],
+            "install_type": "git-clone",
+            "description": "This extension provides convenience nodes for batch processing."
+        },
+        {
+            "author": "HelloVision",
+            "title": "ComfyUI_HelloMeme",
+            "reference": "https://github.com/HelloVision/ComfyUI_HelloMeme",
+            "files": [
+                "https://github.com/HelloVision/ComfyUI_HelloMeme"
+            ],
+            "install_type": "git-clone",
+            "description": "This repository is the official implementation of the [a/HelloMeme](https://arxiv.org/pdf/2410.22901) ComfyUI interface, featuring both image and video generation functionalities. Example workflow files can be found in the ComfyUI_HelloMeme/workflows directory. Test images and videos are saved in the ComfyUI_HelloMeme/examples directory. Below are screenshots of the interfaces for image and video generation.\nNOTE: 'HelloMeme: Integrating Spatial Knitting Attentions to Embed High-Level and Fidelity-Rich Conditions in Diffusion Models'"
+        },
+        {
+            "author": "recraftai",
+            "title": "ComfyUI-RecraftAI",
+            "id": "comfyui-recraftai",
+            "reference": "https://github.com/recraft-ai/ComfyUI-RecraftAI",
+            "files": [
+                "https://github.com/recraft-ai/ComfyUI-RecraftAI"
+            ],
+            "install_type": "git-clone",
+            "description": "Recraft AI API Custom Nodes"
+        },
+        {
+            "author": "basix",
+            "title": "Basix Image Filters",
+            "id": "basix_image_filters",
+            "reference": "https://github.com/maludwig/basix_image_filters",
+            "files": [
+                "https://github.com/maludwig/basix_image_filters"
+            ],
+            "install_type": "git-clone",
+            "description": "A handful of image filters for ComfyUI (darken, lighten, levels, saturate, hue)"
+        },
+        {
+            "author": "Frost Ming",
+            "title": "Comfy-Pack",
+            "reference": "https://github.com/bentoml/comfy-pack",
+            "files": [
+                "https://github.com/bentoml/comfy-pack"
+            ],
+            "description": "A comprehensive toolkit for standardizing, packaging and deploying ComfyUI workflows as reproducible environments and production-ready REST services",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "Poseidon-fan",
+            "title": "ComfyUI-RabbitMQ-Publisher",
+            "reference": "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher",
+            "files": [
+                "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher"
+            ],
+            "description": "ComfyUI custom_node that publish output image to rabbit_mq",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "1zhangyy1",
+            "title": "ComfyUI VIDU",
+            "reference": "https://github.com/1zhangyy1/comfyui-vidu-nodes",
+            "files": [
+                "https://github.com/1zhangyy1/comfyui-vidu-nodes"
+            ],
+            "description": "This is a ComfyUI node package that integrates with VIDU API, supporting features such as text-to-video, image-to-video, character-to-video generation, and video super-resolution.",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "LevelPixel",
+            "title": "ComfyUI Level Pixel",
+            "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel",
+            "files": [
+                "https://github.com/LevelPixel/ComfyUI-LevelPixel"
+            ],
+            "install_type": "git-clone",
+            "description": "Main nodes of the Level Pixel company (aka levelpixel, LP). Includes convenient nodes for working with images from folders; counting files in a folder; cleaning memory; tag filters. Model Unloader, LLM Unloader, Free memory, Tag Filters, Tag Category Filters, Tag Choice Parser, File counter, Image Loader From Path (with counters), Image Remove Background based on RemBG, Autotagger."
+        },
+        {
+            "author": "LevelPixel",
+            "title": "ComfyUI Level Pixel Advanced",
+            "id": "comfyui-levelpixel-advanced",
+            "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced",
+            "files": [
+                "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced nodes of the Level Pixel company (levelpixel, LP). Includes convenient advanced nodes for working with LLM \u0438 VLM models (LLaVa) with GGUF format. Qwen2.5-VL and Qwen2.5 supported. Also included is a node for the RAM model. Nodes have the ability to automatically unload models from VRAM."
+        },
+        {
+            "author": "morino-kumasan",
+            "title": "comfyui-toml-prompt",
+            "reference": "https://github.com/morino-kumasan/comfyui-toml-prompt",
+            "files": [
+                "https://github.com/morino-kumasan/comfyui-toml-prompt"
+            ],
+            "install_type": "git-clone",
+            "description": "Encode Prompt in TOML for ComfyUI."
+        },
+        {
+            "author": "wentao-uw",
+            "title": "ComfyUI template matching",
+            "reference": "https://github.com/wentao-uw/ComfyUI-template-matching",
+            "files": [
+                "https://github.com/wentao-uw/ComfyUI-template-matching"
+            ],
+            "description": "This project is a ComfyUI version of [a/https://github.com/cozheyuanzhangde/Invariant-TemplateMatching](https://github.com/cozheyuanzhangde/Invariant-TemplateMatching).",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "w00dycomfyuirun",
+            "title": "ComfyUI_Appstore",
+            "id": "ComfyUI_Appstore",
+            "reference": "https://github.com/ronaldzgithub/ComfyUI_Appstore",
+            "files": [
+                "https://github.com/ronaldzgithub/ComfyUI_Appstore"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI_Appstore, a tool that converts ComfyUI workflows into web apps on huaxiaobao.net with one click, and supports payments, like ComfyUI_Bxb (Bxb) does. Providing a way for the comfyui authors to get profit from."
+        },
+        {
+            "author": "kycg",
+            "title": "Kw_Json_Lora_CivitAIDownloader",
+            "reference": "https://github.com/kycg/comfyui-Lora-auto-downloader",
+            "files": [
+                "https://github.com/kycg/comfyui-Lora-auto-downloader"
+            ],
+            "description": "This tool allows you to download models from CivitAI based on a JSON configuration that defines LORA and checkpoint models. It uses token-based authentication to download files from specified URLs and saves them to specified directories. based on CivitAIDownloader",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "VangengLab",
+            "title": "ComfyUI-LivePortrait_v2",
+            "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v2",
+            "files": [
+                "https://github.com/VangengLab/ComfyUI-LivePortrait_v2"
+            ],
+            "install_type": "git-clone",
+            "description": "We developed a custom_node for Liveportrait_v2 that enables flexible use on Comfyui to drive animal image-based emoji generation from videos."
+        },
+        {
+            "author": "VangengLab",
+            "title": "ComfyUI-LivePortrait_v3",
+            "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v3",
+            "files": [
+                "https://github.com/VangengLab/ComfyUI-LivePortrait_v3"
+            ],
+            "install_type": "git-clone",
+            "description": "We developed a custom_node for Liveportrait_v3 that enables flexible use on Comfyui to drive image-based emoji generation from photos."
+        },
         {
             "author": "Comflowy",
             "title": "Comflowy's Custom Nodes",
@@ -20348,7 +20391,7 @@
                 "https://github.com/c0ffymachyne/ComfyUI_BeatByte"
             ],
             "install_type": "git-clone",
-            "description": "Bytebeat is like composing music with the tools of a programmer’s toolkit. Instead of piano keys, you have operators like >>, |, and &. It’s like giving your CPU a guitar and letting it shred! 🤘"
+            "description": "Bytebeat is like composing music with the tools of a programmer\u2019s toolkit. Instead of piano keys, you have operators like >>, |, and &. It\u2019s like giving your CPU a guitar and letting it shred! \ud83e\udd18"
         },
         {
             "author": "liuqianhonga",
@@ -20590,7 +20633,7 @@
                 "https://github.com/AIPOQUE/ComfyUI-APQNodes"
             ],
             "install_type": "git-clone",
-            "description": "Without fine-tuning, FLUX.1 Dev model cannot understand exact color codes. However, it is known that FLUX.1 Dev can repeatedly produce certain colors with certain prompt(color name). Fortunately, on CIVITAI, [a/“novuschroma” shared 155 pre-tested color names](https://civitai.com/models/879997/color-wildcards-for-flux-and-sdxl) that FLUX.1 Dev can handle. Thanks to his resource, color palette consists exclusively of 155 colors can be configured. ‘ColorPalette’ node from ComfyUI APQNodes converts input hex color code to the most similar color name(from pre-tested 155 color names) of which FLUX.1 Dev is aware."
+            "description": "Without fine-tuning, FLUX.1 Dev model cannot understand exact color codes. However, it is known that FLUX.1 Dev can repeatedly produce certain colors with certain prompt(color name). Fortunately, on CIVITAI, [a/\u201cnovuschroma\u201d shared 155 pre-tested color names](https://civitai.com/models/879997/color-wildcards-for-flux-and-sdxl) that FLUX.1 Dev can handle. Thanks to his resource, color palette consists exclusively of 155 colors can be configured. \u2018ColorPalette\u2019 node from ComfyUI APQNodes converts input hex color code to the most similar color name(from pre-tested 155 color names) of which FLUX.1 Dev is aware."
         },
         {
             "author": "arcum42",
@@ -21160,7 +21203,7 @@
                 "https://github.com/Yuan-ManX/ComfyUI-Bagel"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI-Bagel is now available in ComfyUI, BAGEL is an open‑source multimodal foundation model with 7B active parameters (14B total) trained on large‑scale interleaved multimodal data. [w/Don't install together with neverbiasu/ComfyUI-BAGEL simultaneously.]"
+            "description": "ComfyUI-Bagel is now available in ComfyUI, BAGEL is an open\u2011source multimodal foundation model with 7B active parameters (14B total) trained on large\u2011scale interleaved multimodal data. [w/Don't install together with neverbiasu/ComfyUI-BAGEL simultaneously.]"
         },
         {
             "author": "Yuan-ManX",
@@ -21200,7 +21243,7 @@
                 "https://github.com/Yuan-ManX/ComfyUI-Direct3D-S2"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI-Direct3D‑S2 is now available in ComfyUI, Direct3D‑S2 - Gigascale 3D Generation Made Easy with Spatial Sparse Attention. Direct3D‑S2 is a scalable 3D generation framework based on sparse volumes that achieves superior output quality with dramatically reduced training costs."
+            "description": "ComfyUI-Direct3D\u2011S2 is now available in ComfyUI, Direct3D\u2011S2 - Gigascale 3D Generation Made Easy with Spatial Sparse Attention. Direct3D\u2011S2 is a scalable 3D generation framework based on sparse volumes that achieves superior output quality with dramatically reduced training costs."
         },
         {
             "author": "Yuan-ManX",
@@ -21512,7 +21555,7 @@
             "title": "ComfyUI-MVAdapter",
             "reference": "https://github.com/huanngzh/ComfyUI-MVAdapter",
             "files": [
-               "https://github.com/huanngzh/ComfyUI-MVAdapter"
+                "https://github.com/huanngzh/ComfyUI-MVAdapter"
             ],
             "description": "This extension integrates [a/MV-Adapter](https://github.com/huanngzh/MV-Adapter) into ComfyUI, allowing users to generate multi-view consistent images from text prompts or single images directly within the ComfyUI interface.",
             "install_type": "git-clone"
@@ -21522,7 +21565,7 @@
             "title": "ComfyUI-Seed-Nodes",
             "reference": "https://github.com/Aerse/ComfyUI-Seed-Nodes",
             "files": [
-               "https://github.com/Aerse/ComfyUI-Seed-Nodes"
+                "https://github.com/Aerse/ComfyUI-Seed-Nodes"
             ],
             "description": "ComfyUI-Seed-Nodes is a custom node library that extends the functionality of ComfyUI, offering advanced image loading and pixelation tools.",
             "install_type": "git-clone"
@@ -21532,7 +21575,7 @@
             "title": "ComfyUI-InstantX-IPAdapter-SD3",
             "reference": "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3",
             "files": [
-               "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3"
+                "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3"
             ],
             "description": "ComfyUI implementation of the [a/InstantX IP-Adapter for SD3.5 Large](https://huggingface.co/InstantX/SD3.5-Large-IP-Adapter).",
             "install_type": "git-clone"
@@ -21542,7 +21585,7 @@
             "title": "ComfyUI-RegionalAdaptiveSampling",
             "reference": "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling",
             "files": [
-               "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling"
+                "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling"
             ],
             "description": "ComfyUI implementation of Regional Adaptive Sampling, (original implementation at https://github.com/microsoft/RAS).",
             "install_type": "git-clone"
@@ -21553,7 +21596,7 @@
             "reference": "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl",
             "reference2": "https://github.com/sourceful-official/ComfyUI_LoadLoraModelOnlyWithUrl",
             "files": [
-               "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl"
+                "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl"
             ],
             "description": "ComfyUI-LoadLoraModelOnlyWithUrl",
             "install_type": "git-clone"
@@ -21563,7 +21606,7 @@
             "title": "Kimara.ai's Advanced Watermarking Tools",
             "reference": "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks",
             "files": [
-               "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks"
+                "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks"
             ],
             "description": "The KimaraAIWatermarker custom node allows you to apply watermark text and logo overlays to images. Optionally, the watermark can be moved by the move_watermark_step amount of pixels after each generated image. To apply a moving watermark to a list of images, use the KimaraAIBatchImages node to concatenate the list into a single tensor, then use that as an input for the watermark node, as shown in the example image below.",
             "install_type": "git-clone"
@@ -21647,7 +21690,7 @@
                 "https://github.com/abdozmantar/ComfyUI-DeepExtractV2"
             ],
             "install_type": "git-clone",
-            "description": "DeepExtractV2 – lightning-fast, high-quality audio separator. Instantly isolate vocals, drums, bass, and more from any track. Ideal for creators, DJs, and audio pros."
+            "description": "DeepExtractV2 \u2013 lightning-fast, high-quality audio separator. Instantly isolate vocals, drums, bass, and more from any track. Ideal for creators, DJs, and audio pros."
         },
         {
             "author": "ctefer",
@@ -21920,7 +21963,7 @@
                 "https://github.com/pollockjj/ComfyUI-MultiGPU"
             ],
             "install_type": "git-clone",
-            "description": "This extension adds CUDA device selection to supported loader nodes in ComfyUI. By monkey-patching ComfyUI’s memory management, each model component (like UNet, Clip, or VAE) can be loaded on a specific GPU. Examples included are multi-GPU workflows for SDXL, FLUX, LTXVideo, and Hunyuan Video for both standard and GGUF loader nodes."
+            "description": "This extension adds CUDA device selection to supported loader nodes in ComfyUI. By monkey-patching ComfyUI\u2019s memory management, each model component (like UNet, Clip, or VAE) can be loaded on a specific GPU. Examples included are multi-GPU workflows for SDXL, FLUX, LTXVideo, and Hunyuan Video for both standard and GGUF loader nodes."
         },
         {
             "author": "PressWagon",
@@ -21982,7 +22025,7 @@
                 "https://github.com/Light-x02/ComfyUI-Lightx02-Nodes"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes for ComfyUI by Light-x02. Optimize and simplify workflows, adding utilities, samplers, schedulers and various tools (Flux, images, etc.) to enrich and extend ComfyUI’s capabilities."
+            "description": "Custom nodes for ComfyUI by Light-x02. Optimize and simplify workflows, adding utilities, samplers, schedulers and various tools (Flux, images, etc.) to enrich and extend ComfyUI\u2019s capabilities."
         },
         {
             "author": "Light-x02",
@@ -22013,7 +22056,7 @@
                 "https://github.com/Light-x02/ComfyUI-checkpoint-Discovery-Hub"
             ],
             "install_type": "git-clone",
-            "description": "Checkpoint Discovery Hub — An advanced browser for your ComfyUI models. Easily explore, filter, and load your checkpoints, manage presets, favorites, and Civitai metadata — all from a sleek and intuitive interface."
+            "description": "Checkpoint Discovery Hub \u2014 An advanced browser for your ComfyUI models. Easily explore, filter, and load your checkpoints, manage presets, favorites, and Civitai metadata \u2014 all from a sleek and intuitive interface."
         },
         {
             "author": "marcoc2",
@@ -22047,7 +22090,7 @@
         },
         {
             "author": "AEmotionStudio",
-            "title": "ComfyUI Christmas Theme 🎄✨",
+            "title": "ComfyUI Christmas Theme \ud83c\udf84\u2728",
             "reference": "https://github.com/AEmotionStudio/ComfyUI-ChristmasTheme",
             "files": [
                 "https://github.com/AEmotionStudio/ComfyUI-ChristmasTheme"
@@ -22057,7 +22100,7 @@
         },
         {
             "author": "AEmotionStudio",
-            "title": "ComfyUI-EnhancedLinksandNodes 🎨✨",
+            "title": "ComfyUI-EnhancedLinksandNodes \ud83c\udfa8\u2728",
             "reference": "https://github.com/AEmotionStudio/ComfyUI-EnhancedLinksandNodes",
             "reference2": "https://github.com/AEmotionStudio/ComfyUI-Enhanced",
             "files": [
@@ -22347,7 +22390,7 @@
                 "https://github.com/ronsantash/Comfyui-flexi-lora-loader"
             ],
             "install_type": "git-clone",
-            "description": "FlexiLoRALoader - A ComfyUI custom node for dynamic LoRA weight management. Apply multiple LoRAs with flexible weight patterns and randomization features for creative AI image generation.\nFeatures: • Multiple LoRA handling (up to 3) • Weight pattern presets • Random/Sequential mode • Debug logging support"
+            "description": "FlexiLoRALoader - A ComfyUI custom node for dynamic LoRA weight management. Apply multiple LoRAs with flexible weight patterns and randomization features for creative AI image generation.\nFeatures: \u2022 Multiple LoRA handling (up to 3) \u2022 Weight pattern presets \u2022 Random/Sequential mode \u2022 Debug logging support"
         },
         {
             "author": "cherninlab",
@@ -22377,7 +22420,10 @@
             "files": [
                 "https://github.com/ciga2011/ComfyUI-MarkItDown"
             ],
-            "pip": ["markitdown", "openai"],
+            "pip": [
+                "markitdown",
+                "openai"
+            ],
             "install_type": "git-clone",
             "description": "This node pack helps to convert various files to Markdown. It supports pdf, pptx, xlsx, docx, html and image files."
         },
@@ -22432,7 +22478,9 @@
             "files": [
                 "https://github.com/jurdnisglobby/ComfyUI-Jurdns-Groq-Node"
             ],
-            "pip": ["groq"],
+            "pip": [
+                "groq"
+            ],
             "install_type": "git-clone",
             "description": "This node utilizes the Groq.com API to enhance prompts. (Place API key and main system prompt in the groq_config.json)"
         },
@@ -22816,7 +22864,7 @@
                 "https://github.com/billwuhao/ComfyUI_MegaTTS3"
             ],
             "install_type": "git-clone",
-            "description": "Lightweight and Efficient, 🎧Ultra High-Quality Voice Cloning, Chinese and English."
+            "description": "Lightweight and Efficient, \ud83c\udfa7Ultra High-Quality Voice Cloning, Chinese and English."
         },
         {
             "author": "mw",
@@ -22876,7 +22924,7 @@
                 "https://github.com/billwuhao/ComfyUI_SOME"
             ],
             "install_type": "git-clone",
-            "description": "Sing to Midi 🎶"
+            "description": "Sing to Midi \ud83c\udfb6"
         },
         {
             "author": "umiyuki",
@@ -22946,7 +22994,7 @@
                 "https://github.com/facok/ComfyUI-TeaCacheHunyuanVideo"
             ],
             "install_type": "git-clone",
-            "description": "This is a TeaCache acceleration node for HunYuan Video, supporting the native node workflow for seamless upgrades. Simply choose the acceleration multiplier you want—currently, three levels are available."
+            "description": "This is a TeaCache acceleration node for HunYuan Video, supporting the native node workflow for seamless upgrades. Simply choose the acceleration multiplier you want\u2014currently, three levels are available."
         },
         {
             "author": "facok",
@@ -23030,7 +23078,7 @@
             "files": [
                 "https://github.com/calcuis/gguf"
             ],
-            "preemptions":[
+            "preemptions": [
                 "LoaderGGUF",
                 "ClipLoaderGGUF",
                 "DualClipLoaderGGUF",
@@ -23230,7 +23278,7 @@
                 "https://github.com/Wenaka2004/ComfyUI-TagClassifier"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom node，use Deepseek v3 to classify the input tags"
+            "description": "ComfyUI custom node\uff0cuse Deepseek v3 to classify the input tags"
         },
         {
             "author": "westNeighbor",
@@ -23547,7 +23595,7 @@
             "description": "A custom node for ComfyUI that generates creative and detailed prompts using OpenAI's GPT models."
         },
         {
-            "author" : "ngosset",
+            "author": "ngosset",
             "title": "ImageSimilarity",
             "id": "imageSimilarity",
             "reference": "https://github.com/ngosset/ComfyUI-ImageSimilarity",
@@ -23568,7 +23616,7 @@
             "description": "The plug-in is designed to automatically save the association between the LoRA model and Trigger words to a Local JSON file so that when the LoRA model is loaded, the associated trigger words can be automatically loaded via the node 'LoRA Trigger Local' without manual input."
         },
         {
-            "author" : "strand1",
+            "author": "strand1",
             "title": "ComfyUI-Autogen",
             "reference": "https://github.com/strand1/ComfyUI-Autogen",
             "files": [
@@ -23697,7 +23745,7 @@
                 "https://github.com/Dehypnotic/comfyui-dehypnotic-save-nodes"
             ],
             "install_type": "git-clone",
-            "description": "Save toolkit for audio, image, and video: MP3 audio export with VBR/CBR options, multi-format image saving with workflow/thumbnail metadata, and video + frame encoding (MP4/MKV/WEBM/MOV) — all sharing whitelist-safe paths and rich placeholder templating."
+            "description": "Save toolkit for audio, image, and video: MP3 audio export with VBR/CBR options, multi-format image saving with workflow/thumbnail metadata, and video + frame encoding (MP4/MKV/WEBM/MOV) \u2014 all sharing whitelist-safe paths and rich placeholder templating."
         },
         {
             "author": "feixuetuba",
@@ -23801,7 +23849,7 @@
                 "https://github.com/mango-rgb/ComfyUI-Mango-Random-node"
             ],
             "install_type": "git-clone",
-            "description": "🥭 Mango Random Nodes - A collection of random file nodes for ComfyUI"
+            "description": "\ud83e\udd6d Mango Random Nodes - A collection of random file nodes for ComfyUI"
         },
         {
             "author": "WUYUDING2583",
@@ -23829,9 +23877,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-DatasetHelper",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-DatasetHelper"
-             ],
-             "install_type": "git-clone",
-             "description": "This custom node set for ComfyUI provides a DatasetBatchNode for automated, sequential processing of datasets, particularly useful for iterative training or batched image/video generation workflows."
+            ],
+            "install_type": "git-clone",
+            "description": "This custom node set for ComfyUI provides a DatasetBatchNode for automated, sequential processing of datasets, particularly useful for iterative training or batched image/video generation workflows."
         },
         {
             "author": "fblissjr",
@@ -23839,9 +23887,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-WanSeamlessFlow",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-WanSeamlessFlow"
-             ],
-             "install_type": "git-clone",
-             "description": "experimental wanvideo comfyui node with a singular goal - visually seamless transitions between context windows"
+            ],
+            "install_type": "git-clone",
+            "description": "experimental wanvideo comfyui node with a singular goal - visually seamless transitions between context windows"
         },
         {
             "author": "fblissjr",
@@ -23849,9 +23897,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-WanActivationEditor",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-WanActivationEditor"
-             ],
-             "install_type": "git-clone",
-             "description": "editing activations in wanvideo"
+            ],
+            "install_type": "git-clone",
+            "description": "editing activations in wanvideo"
         },
         {
             "author": "fblissjr",
@@ -23859,9 +23907,9 @@
             "reference": "https://github.com/fblissjr/shrug-prompter",
             "files": [
                 "https://github.com/fblissjr/shrug-prompter"
-             ],
-             "install_type": "git-clone",
-             "description": "A comprehensive Vision-Language Model (VLM) integration system for ComfyUI with more intelligent prompt optimization, object detection, template support, and performance optimizations. Optimized for Wan2.1, Flux Kontext, and general purpose. Goes well with my other project, an MLX/llama.cpp server with hot swappable models and ollama api compatibility, (heylookitsanllm)[a/https://github.com/fblissjr/heylookitsanllm](https://github.com/fblissjr/heylookitsanllm)"
+            ],
+            "install_type": "git-clone",
+            "description": "A comprehensive Vision-Language Model (VLM) integration system for ComfyUI with more intelligent prompt optimization, object detection, template support, and performance optimizations. Optimized for Wan2.1, Flux Kontext, and general purpose. Goes well with my other project, an MLX/llama.cpp server with hot swappable models and ollama api compatibility, (heylookitsanllm)[a/https://github.com/fblissjr/heylookitsanllm](https://github.com/fblissjr/heylookitsanllm)"
         },
         {
             "author": "fblissjr",
@@ -23869,9 +23917,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-QwenImageWanBridge",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-QwenImageWanBridge"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for bridging Qwen-Image and WAN video models in ComfyUI."
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for bridging Qwen-Image and WAN video models in ComfyUI."
         },
         {
             "author": "vincentfs",
@@ -24035,7 +24083,7 @@
                 "https://github.com/ProGamerGov/ComfyUI_preview360panorama"
             ],
             "install_type": "git-clone",
-            "description": "A custom ComfyUI node for interactive 360° panorama image previews. Panoramic 360 images are also sometimes known as VR photography (virtual reality), HDRI environments (ex: skyboxes), image spheres, spherical images, 360 pano, and 360 degree photos."
+            "description": "A custom ComfyUI node for interactive 360\u00b0 panorama image previews. Panoramic 360 images are also sometimes known as VR photography (virtual reality), HDRI environments (ex: skyboxes), image spheres, spherical images, 360 pano, and 360 degree photos."
         },
         {
             "author": "burnsbert",
@@ -24044,9 +24092,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-LMStudio",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-LMStudio"
-             ],
-             "install_type": "git-clone",
-             "description": "This ComfyUI extension provides custom nodes for integrating with LM Studio, allowing for loading, managing, and making requests of LLM models through the LMStudio local server and command-line interface."
+            ],
+            "install_type": "git-clone",
+            "description": "This ComfyUI extension provides custom nodes for integrating with LM Studio, allowing for loading, managing, and making requests of LLM models through the LMStudio local server and command-line interface."
         },
         {
             "author": "burnsbert",
@@ -24055,9 +24103,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-Workflow",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-Workflow"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for general workflow quality of life including resolutions sorted by aspect ratio, upscaling helps, and unique file names"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for general workflow quality of life including resolutions sorted by aspect ratio, upscaling helps, and unique file names"
         },
         {
             "author": "burnsbert",
@@ -24066,9 +24114,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-PromptHelper",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-PromptHelper"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for enhancing and manipulating prompts in ComfyUI. Includes nodes for random color palette generation following different color theory methodologies, prompt text replacement and randomization, list sampling, loading files into strings, and season/weather/time-of-day generation."
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for enhancing and manipulating prompts in ComfyUI. Includes nodes for random color palette generation following different color theory methodologies, prompt text replacement and randomization, list sampling, loading files into strings, and season/weather/time-of-day generation."
         },
         {
             "author": "SykkoAtHome",
@@ -24076,9 +24124,9 @@
             "reference": "https://github.com/SykkoAtHome/ComfyUI_FaceProcessor",
             "files": [
                 "https://github.com/SykkoAtHome/ComfyUI_FaceProcessor"
-             ],
-             "install_type": "git-clone",
-             "description": "A custom node collection for ComfyUI that provides advanced face detection, alignment, and transformation capabilities using MediaPipe Face Mesh."
+            ],
+            "install_type": "git-clone",
+            "description": "A custom node collection for ComfyUI that provides advanced face detection, alignment, and transformation capabilities using MediaPipe Face Mesh."
         },
         {
             "author": "Mattabyte",
@@ -24086,9 +24134,9 @@
             "reference": "https://github.com/Mattabyte/ComfyUI-SecureApiCall",
             "files": [
                 "https://github.com/Mattabyte/ComfyUI-SecureApiCall"
-             ],
-             "install_type": "git-clone",
-             "description": "This package provides custom nodes to ComfyUI to POST data to a secure API."
+            ],
+            "install_type": "git-clone",
+            "description": "This package provides custom nodes to ComfyUI to POST data to a secure API."
         },
         {
             "author": "oxysoft",
@@ -24097,9 +24145,9 @@
             "reference2": "https://github.com/oxysoft/ComfyUI-gowiththeflow",
             "files": [
                 "https://github.com/oxysoft/ComfyUI-gowiththeflow"
-             ],
-             "install_type": "git-clone",
-             "description": "Implementation of GoWithTheFlow, original code at [a/https://github.com/Eyeline-Research/Go-with-the-Flow/](https://github.com/Eyeline-Research/Go-with-the-Flow/) and [a/https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py](https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py)"
+            ],
+            "install_type": "git-clone",
+            "description": "Implementation of GoWithTheFlow, original code at [a/https://github.com/Eyeline-Research/Go-with-the-Flow/](https://github.com/Eyeline-Research/Go-with-the-Flow/) and [a/https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py](https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py)"
         },
         {
             "author": "willmiao",
@@ -24107,9 +24155,9 @@
             "reference": "https://github.com/willmiao/ComfyUI-Lora-Manager",
             "files": [
                 "https://github.com/willmiao/ComfyUI-Lora-Manager"
-             ],
-             "install_type": "git-clone",
-             "description": "Revolutionize your workflow with the ultimate LoRA companion for ComfyUI!"
+            ],
+            "install_type": "git-clone",
+            "description": "Revolutionize your workflow with the ultimate LoRA companion for ComfyUI!"
         },
         {
             "author": "tigeryy2",
@@ -24117,9 +24165,9 @@
             "reference": "https://github.com/tigeryy2/comfyui-structured-outputs",
             "files": [
                 "https://github.com/tigeryy2/comfyui-structured-outputs"
-             ],
-             "install_type": "git-clone",
-             "description": "ComfyUI nodes for LLM Structured Outputs with integration for prompting"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for LLM Structured Outputs with integration for prompting"
         },
         {
             "author": "Conor-Collins",
@@ -24127,9 +24175,9 @@
             "reference": "https://github.com/Conor-Collins/ComfyUI-CoCoTools_IO",
             "files": [
                 "https://github.com/Conor-Collins/ComfyUI-CoCoTools_IO"
-             ],
-             "install_type": "git-clone",
-             "description": "Advanced image input and output: EXR, 32 bit support and more"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced image input and output: EXR, 32 bit support and more"
         },
         {
             "author": "852wa",
@@ -24137,9 +24185,9 @@
             "reference": "https://github.com/852wa/ComfyUI-ColorshiftColor",
             "files": [
                 "https://github.com/852wa/ComfyUI-ColorshiftColor"
-             ],
-             "install_type": "git-clone",
-             "description": "This is a custom node for ComfyUI.\nIt reduces colors based on a specified number and allows for adjustments to hue, saturation, and brightness.\nFeatures:Each parameter can be set to random, You can toggle masking (not changing colors) using color numbers, Mask inversion can also be toggled on or off."
+            ],
+            "install_type": "git-clone",
+            "description": "This is a custom node for ComfyUI.\nIt reduces colors based on a specified number and allows for adjustments to hue, saturation, and brightness.\nFeatures:Each parameter can be set to random, You can toggle masking (not changing colors) using color numbers, Mask inversion can also be toggled on or off."
         },
         {
             "author": "852wa",
@@ -24147,9 +24195,9 @@
             "reference": "https://github.com/852wa/ComfyUI-AAP",
             "files": [
                 "https://github.com/852wa/ComfyUI-AAP"
-             ],
-             "install_type": "git-clone",
-             "description": "This is a custom node for ComfyUI.\nFeatures:Removes white areas in the input image by making them transparent based on brightness, Outputs in black and transparent, Outputs in gray and transparent.\nThis is a simple node with the above functionalities implemented. It also supports sequential processing."
+            ],
+            "install_type": "git-clone",
+            "description": "This is a custom node for ComfyUI.\nFeatures:Removes white areas in the input image by making them transparent based on brightness, Outputs in black and transparent, Outputs in gray and transparent.\nThis is a simple node with the above functionalities implemented. It also supports sequential processing."
         },
         {
             "author": "ReBeating",
@@ -24157,9 +24205,9 @@
             "reference": "https://github.com/ReBeating/ComfyUI-Artist-Selector",
             "files": [
                 "https://github.com/ReBeating/ComfyUI-Artist-Selector"
-             ],
-             "install_type": "git-clone",
-             "description": "A useful comfyui node named LoadArtistTag for selecting artist tags, including 1000+ single-artist tags and 300 mixed-artists tags."
+            ],
+            "install_type": "git-clone",
+            "description": "A useful comfyui node named LoadArtistTag for selecting artist tags, including 1000+ single-artist tags and 300 mixed-artists tags."
         },
         {
             "author": "gmorks",
@@ -24167,9 +24215,9 @@
             "reference": "https://github.com/gmorks/ComfyUI-SendToDiscord",
             "files": [
                 "https://github.com/gmorks/ComfyUI-SendToDiscord"
-             ],
-             "install_type": "git-clone",
-             "description": "ComfyUI-SendToDiscord is a custom node for ComfyUI that simplifies sending preview images to Discord via webhooks. It supports both single-image uploads and batch mode, making it an efficient tool for sharing your generated images directly with your Discord server."
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-SendToDiscord is a custom node for ComfyUI that simplifies sending preview images to Discord via webhooks. It supports both single-image uploads and batch mode, making it an efficient tool for sharing your generated images directly with your Discord server."
         },
         {
             "author": "gmorks",
@@ -24177,9 +24225,9 @@
             "reference": "https://github.com/gmorks/ComfyUI-Animagine-Prompt",
             "files": [
                 "https://github.com/gmorks/ComfyUI-Animagine-Prompt"
-             ],
-             "install_type": "git-clone",
-             "description": "Comfy UI node to prompt build for https://huggingface.co/cagliostrolab/animagine-xl-4.0 model"
+            ],
+            "install_type": "git-clone",
+            "description": "Comfy UI node to prompt build for https://huggingface.co/cagliostrolab/animagine-xl-4.0 model"
         },
         {
             "author": "gmorks",
@@ -24198,9 +24246,9 @@
             "reference2": "https://github.com/derekluo/ComfyUI-Prompt-Expander",
             "files": [
                 "https://github.com/jinanlongen/ComfyUI-Prompt-Expander"
-             ],
-             "install_type": "git-clone",
-             "description": "A custom node for ComfyUI that expands text prompts using the SuperPrompt-v1 T5 model. This node helps generate more detailed and descriptive prompts from simple input text, which can be particularly useful for image generation workflows."
+            ],
+            "install_type": "git-clone",
+            "description": "A custom node for ComfyUI that expands text prompts using the SuperPrompt-v1 T5 model. This node helps generate more detailed and descriptive prompts from simple input text, which can be particularly useful for image generation workflows."
         },
         {
             "author": "Style-Mosaic",
@@ -24208,9 +24256,9 @@
             "reference": "https://github.com/Style-Mosaic/dino-x-comfyui-node",
             "files": [
                 "https://github.com/Style-Mosaic/dino-x-comfyui-node"
-             ],
-             "install_type": "git-clone",
-             "description": "A ComfyUI node that integrates DINO-X API for object detection and segmentation. This node allows you to detect and segment objects in images using text prompts."
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI node that integrates DINO-X API for object detection and segmentation. This node allows you to detect and segment objects in images using text prompts."
         },
         {
             "author": "checkbins",
@@ -24263,7 +24311,13 @@
             ],
             "description": "Node for compositing multiple images with interactive preview and layer management",
             "install_type": "git-clone",
-            "tags": ["image", "composite", "layer", "blend", "transform"]
+            "tags": [
+                "image",
+                "composite",
+                "layer",
+                "blend",
+                "transform"
+            ]
         },
         {
             "author": "zentrocdot",
@@ -24423,7 +24477,7 @@
                 "https://github.com/DragonDiffusionbyBoyo/BoyoSupercoolWrapper"
             ],
             "install_type": "git-clone",
-            "description": "This is a ComfyUI wrapper for Andrew DalPino's SuperCool upscaler, enabling its use directly within ComfyUI's node workflow. No extra dependencies required—just drop in the models and go."
+            "description": "This is a ComfyUI wrapper for Andrew DalPino's SuperCool upscaler, enabling its use directly within ComfyUI's node workflow. No extra dependencies required\u2014just drop in the models and go."
         },
         {
             "author": "StarAsh042",
@@ -24534,9 +24588,9 @@
             "reference": "https://github.com/ShinChven/sc-comfy-nodes",
             "files": [
                 "https://github.com/ShinChven/sc-comfy-nodes"
-             ],
-             "install_type": "git-clone",
-             "description": "This project contains custom nodes for ComfyUI, developed by ShinChven. The nodes in this package extend the functionality of ComfyUI by providing additional features and utilities."
+            ],
+            "install_type": "git-clone",
+            "description": "This project contains custom nodes for ComfyUI, developed by ShinChven. The nodes in this package extend the functionality of ComfyUI by providing additional features and utilities."
         },
         {
             "author": "vkff5833",
@@ -24544,9 +24598,9 @@
             "reference": "https://github.com/vkff5833/ComfyUI-MobileClient",
             "files": [
                 "https://github.com/vkff5833/ComfyUI-MobileClient"
-             ],
-             "install_type": "git-clone",
-             "description": "Add a mobile-friendly web interface to ComfyUI."
+            ],
+            "install_type": "git-clone",
+            "description": "Add a mobile-friendly web interface to ComfyUI."
         },
         {
             "author": "mediocreatmybest",
@@ -24554,9 +24608,9 @@
             "reference": "https://github.com/mediocreatmybest/ComfyUI-Transformers-Pipeline",
             "files": [
                 "https://github.com/mediocreatmybest/ComfyUI-Transformers-Pipeline"
-             ],
-             "install_type": "git-clone",
-             "description": "Additional ComfyUI nodes to utilise the Transformers pipeline in a simple and modular way."
+            ],
+            "install_type": "git-clone",
+            "description": "Additional ComfyUI nodes to utilise the Transformers pipeline in a simple and modular way."
         },
         {
             "author": "IrisRainbowNeko",
@@ -24564,9 +24618,9 @@
             "reference": "https://github.com/Deep-Neko/ComfyUI_ascii_art",
             "files": [
                 "https://github.com/Deep-Neko/ComfyUI_ascii_art"
-             ],
-             "install_type": "git-clone",
-             "description": "ascii art preprocessors in ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ascii art preprocessors in ComfyUI"
         },
         {
             "author": "mie",
@@ -25029,7 +25083,7 @@
         },
         {
             "author": "benda1989",
-            "title": "GKK·CosyVoice",
+            "title": "GKK\u00b7CosyVoice",
             "reference": "https://github.com/benda1989/CosyVoice2_ComfyUI",
             "files": [
                 "https://github.com/benda1989/CosyVoice2_ComfyUI"
@@ -25039,7 +25093,7 @@
         },
         {
             "author": "benda1989",
-            "title": "GKK·Sonic",
+            "title": "GKK\u00b7Sonic",
             "reference": "https://github.com/benda1989/Sonic_ComfyUI",
             "files": [
                 "https://github.com/benda1989/Sonic_ComfyUI"
@@ -25092,7 +25146,7 @@
             "title": "ComfyUI-MultiCutAndDrag",
             "reference": "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag"
+                "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag"
             ],
             "install_type": "git-clone",
             "description": "Cut and and drag that allows you to cut and drag multiple images on a path"
@@ -25102,7 +25156,7 @@
             "title": "ComfyUI-ZeptaframePromptMerger",
             "reference": "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger"
+                "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger"
             ],
             "install_type": "git-clone",
             "description": "Custom node that merges general and subject-specific prompts"
@@ -25112,7 +25166,7 @@
             "title": "ComfyUI-ResizeZeptaPayload",
             "reference": "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload"
+                "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload"
             ],
             "install_type": "git-clone",
             "description": "Resize a batch of trajectories or images"
@@ -25122,7 +25176,7 @@
             "title": "Stable Virtual Camera",
             "reference": "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper"
+                "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper"
             ],
             "install_type": "git-clone",
             "description": "Generative View Synthesis with Diffusion Models"
@@ -25592,7 +25646,7 @@
                 "https://github.com/nunchaku-tech/ComfyUI-nunchaku"
             ],
             "install_type": "git-clone",
-            "description": "Nunchaku ComfyUI Node. Nunchaku is the inference that supports SVDQuant. SVDQuant is a new post-training training quantization paradigm for diffusion models, which quantize both the weights and activations of FLUX.1 to 4 bits, achieving 3.5× memory and 8.7× latency reduction on a 16GB laptop 4090 GPU. See more details: https://github.com/mit-han-lab/nunchaku"
+            "description": "Nunchaku ComfyUI Node. Nunchaku is the inference that supports SVDQuant. SVDQuant is a new post-training training quantization paradigm for diffusion models, which quantize both the weights and activations of FLUX.1 to 4 bits, achieving 3.5\u00d7 memory and 8.7\u00d7 latency reduction on a 16GB laptop 4090 GPU. See more details: https://github.com/mit-han-lab/nunchaku"
         },
         {
             "author": "Nikosis",
@@ -25730,7 +25784,7 @@
             "title": "ComfyUI_depthMapOperation",
             "reference": "https://github.com/chri002/ComfyUI_depthMapOperation",
             "files": [
-               "https://github.com/chri002/ComfyUI_depthMapOperation"
+                "https://github.com/chri002/ComfyUI_depthMapOperation"
             ],
             "description": "A simple set of nodes to generate a point cloud from an image and its depth map, perform transformations and some basic operations.",
             "install_type": "git-clone"
@@ -25740,7 +25794,7 @@
             "title": "comfyui-piq",
             "reference": "https://github.com/Laurent2916/comfyui-piq",
             "files": [
-               "https://github.com/Laurent2916/comfyui-piq"
+                "https://github.com/Laurent2916/comfyui-piq"
             ],
             "description": "PIQ ComfyUI custom nodes",
             "install_type": "git-clone"
@@ -25750,7 +25804,7 @@
             "title": "ComfyUI-CSM-Nodes",
             "reference": "https://github.com/thezveroboy/ComfyUI-CSM-Nodes",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI-CSM-Nodes"
+                "https://github.com/thezveroboy/ComfyUI-CSM-Nodes"
             ],
             "description": "Custom nodes for ComfyUI implementing the csm model for text-to-speech generation.",
             "install_type": "git-clone"
@@ -25760,7 +25814,7 @@
             "title": "ComfyUI-WAN-ClipSkip",
             "reference": "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip"
+                "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip"
             ],
             "description": "Custom nodes for ComfyUI implementing the csm model for text-to-speech generation.",
             "install_type": "git-clone"
@@ -25770,7 +25824,7 @@
             "title": "ComfyUI_ACE-Step-zveroboy",
             "reference": "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy"
+                "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy"
             ],
             "description": "I took the original source code from the repository [a/ComfyUI_ACE-Step](https://github.com/billwuhao/ComfyUI_ACE-Step) and modified it to make the model loading explicit instead of hidden.",
             "install_type": "git-clone"
@@ -25850,7 +25904,7 @@
             "title": "comfyui_ssl_gemini_EXP",
             "reference": "https://github.com/tatookan/comfyui_ssl_gemini_EXP",
             "files": [
-               "https://github.com/tatookan/comfyui_ssl_gemini_EXP"
+                "https://github.com/tatookan/comfyui_ssl_gemini_EXP"
             ],
             "description": "Calling gemini2.0 at comfyui . The project will continue to organize good APIs!",
             "install_type": "git-clone"
@@ -25860,7 +25914,7 @@
             "title": "comfyui_arcane_style_trans",
             "reference": "https://github.com/atluslin/comfyui_arcane_style_trans",
             "files": [
-               "https://github.com/atluslin/comfyui_arcane_style_trans"
+                "https://github.com/atluslin/comfyui_arcane_style_trans"
             ],
             "description": "ComfyUI's Arcane stylization plugin",
             "install_type": "git-clone"
@@ -25870,7 +25924,7 @@
             "title": "ComfyUI-AlphaFlatten",
             "reference": "https://github.com/pixelworldai/ComfyUI-AlphaFlatten",
             "files": [
-               "https://github.com/pixelworldai/ComfyUI-AlphaFlatten"
+                "https://github.com/pixelworldai/ComfyUI-AlphaFlatten"
             ],
             "install_type": "git-clone",
             "description": "This node takes a batch of images with alpha channels (RGBA format) and combines them into a single image, respecting the transparency of each layer. It's particularly useful for compositing multiple masked elements (like faces) into a single image."
@@ -25880,7 +25934,7 @@
             "title": "ComfyUI-WorkflowGraphics",
             "reference": "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics",
             "files": [
-               "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics"
+                "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics"
             ],
             "install_type": "git-clone",
             "description": "Embed images directly in your workflow JSONs"
@@ -26337,7 +26391,7 @@
                 "https://github.com/bemoregt/ComfyUI_PhaseFrameInterpolation"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI custom node for 2× video frame interpolation using a Fourier-transform-based phase difference algorithm."
+            "description": "A ComfyUI custom node for 2\u00d7 video frame interpolation using a Fourier-transform-based phase difference algorithm."
         },
         {
             "author": "bemoregt",
@@ -26502,13 +26556,13 @@
         },
         {
             "author": "cleanlii",
-            "title": "DalleImageNodes - OpenAI DALL·E Nodes for ComfyUI",
+            "title": "DalleImageNodes - OpenAI DALL\u00b7E Nodes for ComfyUI",
             "reference": "https://github.com/cleanlii/comfyui-dalle-integration",
             "files": [
                 "https://github.com/cleanlii/comfyui-dalle-integration"
             ],
             "install_type": "git-clone",
-            "description": "DalleImageNodes is a custom extension for ComfyUI that integrates OpenAI's DALL·E 3 API for: Image generation, Inpainting (image editing), Image variation.\nThis project supports the latest OpenAI Python SDK (v1.x) and automatically handles image resizing and format requirements (RGBA, fixed sizes) based on the examples from the offical Dall-E website."
+            "description": "DalleImageNodes is a custom extension for ComfyUI that integrates OpenAI's DALL\u00b7E 3 API for: Image generation, Inpainting (image editing), Image variation.\nThis project supports the latest OpenAI Python SDK (v1.x) and automatically handles image resizing and format requirements (RGBA, fixed sizes) based on the examples from the offical Dall-E website."
         },
         {
             "author": "Sekiun",
@@ -26525,7 +26579,7 @@
             "title": "ComfyUI-HF-Model-Downloader",
             "reference": "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader",
             "files": [
-              "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader"
+                "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader"
             ],
             "install_type": "git-clone",
             "description": "Easily download and install 2D to 3D and Flux models from Hugging Face."
@@ -26626,7 +26680,7 @@
             "id": "load-image-from-http-url",
             "reference": "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL",
             "files": [
-              "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL"
+                "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL"
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI node that fetches an image from an HTTP URL and returns it as an image tensor. Useful for API-based workflows."
@@ -27040,7 +27094,7 @@
                 "https://github.com/avenstack/ComfyUI-AV-MegaTTS3"
             ],
             "install_type": "git-clone",
-            "description": "🎧Ultra High-Quality Voice Cloning, Chinese and English."
+            "description": "\ud83c\udfa7Ultra High-Quality Voice Cloning, Chinese and English."
         },
         {
             "author": "avenstack",
@@ -27370,7 +27424,7 @@
                 "https://github.com/augment-lib/upscale-pro"
             ],
             "install_type": "git-clone",
-            "description": "✨ Augment Upscale — Logo and image upscaler for ComfyUI. Upscale logos, icons, and brand assets to high resolution with sharp, clean results. A professional alternative to Magnific AI built directly into your ComfyUI workflow. Supports 2x upscaling via the Augment Studio API with automatic job polling and tensor output. Ideal for logo design, brand asset pipelines, print-ready artwork, and any workflow that needs crisp detail-preserving enlargement. Includes built-in flow control trigger and wait nodes for chaining multi-step pipelines. Get your API key at [a/augmentstudio.app/pricing](https://augmentstudio.app/pricing)"
+            "description": "\u2728 Augment Upscale \u2014 Logo and image upscaler for ComfyUI. Upscale logos, icons, and brand assets to high resolution with sharp, clean results. A professional alternative to Magnific AI built directly into your ComfyUI workflow. Supports 2x upscaling via the Augment Studio API with automatic job polling and tensor output. Ideal for logo design, brand asset pipelines, print-ready artwork, and any workflow that needs crisp detail-preserving enlargement. Includes built-in flow control trigger and wait nodes for chaining multi-step pipelines. Get your API key at [a/augmentstudio.app/pricing](https://augmentstudio.app/pricing)"
         },
         {
             "author": "rkfg",
@@ -27712,7 +27766,15 @@
             ],
             "install_type": "git-clone",
             "description": "Node2.0-based professional alignment & real-time node color picker - innovative first support: A must-have plugin for managing node layout and color schemes in ComfyUI. Features a real-time color picker, alignment, 7 preset colors, grayscale/custom modes, and one-click reverse alignment.",
-            "tags": ["node2.0", "alignment", "color-picker", "node-utility", "ui", "organizer", "frontend"]
+            "tags": [
+                "node2.0",
+                "alignment",
+                "color-picker",
+                "node-utility",
+                "ui",
+                "organizer",
+                "frontend"
+            ]
         },
         {
             "author": "matorzhin",
@@ -27777,7 +27839,7 @@
         },
         {
             "author": "McKlinton2",
-            "title": "ComfyUI McKlinton Pack — Mask Node",
+            "title": "ComfyUI McKlinton Pack \u2014 Mask Node",
             "reference": "https://github.com/McKlinton2/comfyui-mcklinton-pack",
             "files": [
                 "https://github.com/McKlinton2/comfyui-mcklinton-pack"
@@ -27834,7 +27896,11 @@
                 "https://github.com/Irsalistic/comfyui-dam-object-extractor"
             ],
             "description": "A ComfyUI node that uses NVIDIA's DAM model to identify objects in masked regions",
-            "tags": ["object recognition", "vision", "image analysis"],
+            "tags": [
+                "object recognition",
+                "vision",
+                "image analysis"
+            ],
             "install_type": "git-clone"
         },
         {
@@ -28122,7 +28188,7 @@
                 "https://github.com/alastor-666-1933/caching_to_not_waste"
             ],
             "install_type": "git-clone",
-            "description": "This node allows you to cache/caching/store and reuse resized images, ControlNet images, masks, and texts. It avoids repeating heavy operations by loading previously saved files — saving time, memory, and processing power in future executions."
+            "description": "This node allows you to cache/caching/store and reuse resized images, ControlNet images, masks, and texts. It avoids repeating heavy operations by loading previously saved files \u2014 saving time, memory, and processing power in future executions."
         },
         {
             "author": "hayd-zju",
@@ -28506,7 +28572,7 @@
                 "https://github.com/X-School-Academy/X-FluxAgent"
             ],
             "install_type": "git-clone",
-            "description": "X-FluxAgent turns ComfyUI into a smart, AI-powered agent capable of building software, automating tasks, and even managing your daily workflows — all with natural language prompts, no coding experience needed."
+            "description": "X-FluxAgent turns ComfyUI into a smart, AI-powered agent capable of building software, automating tasks, and even managing your daily workflows \u2014 all with natural language prompts, no coding experience needed."
         },
         {
             "author": "cluny85",
@@ -28628,7 +28694,7 @@
                 "https://github.com/lepiai/ComfyUI-Minitools"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI Mini Toolkit – Helps reduce node redundancy. Let’s see if there’s time to keep it updated regularly."
+            "description": "ComfyUI Mini Toolkit \u2013 Helps reduce node redundancy. Let\u2019s see if there\u2019s time to keep it updated regularly."
         },
         {
             "author": "wildminder",
@@ -28688,7 +28754,7 @@
                 "https://github.com/wildminder/ComfyUI-KaniTTS"
             ],
             "install_type": "git-clone",
-            "description": "Kani TTS. Generate natural, high‑quality speech from text"
+            "description": "Kani TTS. Generate natural, high\u2011quality speech from text"
         },
         {
             "author": "wildminder",
@@ -28812,7 +28878,7 @@
                 "https://github.com/babe-and-spencer-enterprises/base-comfyui-node"
             ],
             "install_type": "git-clone",
-            "description": "A custom ComfyUI node that lets you upload generated images directly to your [a/BASE](https://getbase.app/) account — no manual downloads or re-uploads needed."
+            "description": "A custom ComfyUI node that lets you upload generated images directly to your [a/BASE](https://getbase.app/) account \u2014 no manual downloads or re-uploads needed."
         },
         {
             "author": "R5-Revo",
@@ -29225,7 +29291,7 @@
                 "https://github.com/orion4d/Calculator_Pro"
             ],
             "install_type": "git-clone",
-            "description": "utilitaires pour ComfyUI, conçue pour effectuer des calculs et des conversions"
+            "description": "utilitaires pour ComfyUI, con\u00e7ue pour effectuer des calculs et des conversions"
         },
         {
             "author": "orion4d",
@@ -29342,10 +29408,10 @@
         {
             "author": "LingSss9",
             "title": "comfyui-merge",
-             "id": "comfyui-merge",
-             "reference": "https://github.com/LingSss9/comfyui-merge",
-             "files": [
-                 "https://github.com/LingSss9/comfyui-merge"
+            "id": "comfyui-merge",
+            "reference": "https://github.com/LingSss9/comfyui-merge",
+            "files": [
+                "https://github.com/LingSss9/comfyui-merge"
             ],
             "install_type": "git-clone",
             "description": "Merge up to 4 LoRA models with balanced, order-independent logic. Inspired by WebUI SuperMerger."
@@ -29353,9 +29419,9 @@
         {
             "author": "p1atdev",
             "title": "comfyui-timm-backbone",
-             "reference": "https://github.com/p1atdev/comfyui-timm-backbone",
-             "files": [
-                 "https://github.com/p1atdev/comfyui-timm-backbone"
+            "reference": "https://github.com/p1atdev/comfyui-timm-backbone",
+            "files": [
+                "https://github.com/p1atdev/comfyui-timm-backbone"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI Timm Backbone Nodes is a custom node set that enables you to load and use pre-trained models from the [a/timm](https://github.com/huggingface/pytorch-image-models) library within ComfyUI workflows."
@@ -29363,9 +29429,9 @@
         {
             "author": "p1atdev",
             "title": "TKG-DM (Training-free Chroma Key Content Generation Diffusion Model) for ComfyUI",
-             "reference": "https://github.com/p1atdev/comfyui-tkg-chroma-key",
-             "files": [
-                 "https://github.com/p1atdev/comfyui-tkg-chroma-key"
+            "reference": "https://github.com/p1atdev/comfyui-tkg-chroma-key",
+            "files": [
+                "https://github.com/p1atdev/comfyui-tkg-chroma-key"
             ],
             "install_type": "git-clone",
             "description": "This repository provides an unofficial ComfyUI custom node implementation of the paper TKG-DM: Training-free Chroma Key Content Generation Diffusion Model."
@@ -29373,9 +29439,9 @@
         {
             "author": "Zch6111",
             "title": "AI_Text_Comfyui",
-             "reference": "https://github.com/Zch6111/AI_Text_Comfyui",
-             "files": [
-                 "https://github.com/Zch6111/AI_Text_Comfyui"
+            "reference": "https://github.com/Zch6111/AI_Text_Comfyui",
+            "files": [
+                "https://github.com/Zch6111/AI_Text_Comfyui"
             ],
             "install_type": "git-clone",
             "description": "AI_Text_Comfyui is a custom node for ComfyUI that connects to the OpenAI Chat API and automatically generates creative text prompts for AI workflows. This simplified version removes external dependencies like dotenv, requiring the OpenAI key to be set using a system environment variable."
@@ -29383,9 +29449,9 @@
         {
             "author": "mrcuddle",
             "title": "Underage Filter",
-             "reference": "https://github.com/T-Ph525/ComfyUI-Underage-Filter",
-             "files": [
-                 "https://github.com/T-Ph525/ComfyUI-Underage-Filter"
+            "reference": "https://github.com/T-Ph525/ComfyUI-Underage-Filter",
+            "files": [
+                "https://github.com/T-Ph525/ComfyUI-Underage-Filter"
             ],
             "install_type": "git-clone",
             "description": "An implementation to detect underage subjects in images for ComfyUI."
@@ -29393,9 +29459,9 @@
         {
             "author": "ToTheBeginning",
             "title": "DreamO Comfyui",
-             "reference": "https://github.com/ToTheBeginning/ComfyUI-DreamO",
-             "files": [
-                 "https://github.com/ToTheBeginning/ComfyUI-DreamO"
+            "reference": "https://github.com/ToTheBeginning/ComfyUI-DreamO",
+            "files": [
+                "https://github.com/ToTheBeginning/ComfyUI-DreamO"
             ],
             "install_type": "git-clone",
             "description": "[a/DreamO](https://github.com/bytedance/DreamO) ComfyUI native implementation."
@@ -29403,9 +29469,9 @@
         {
             "author": "XWAVEart",
             "title": "ComfyUI XWAVE Nodes",
-             "reference": "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes",
-             "files": [
-                 "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes"
+            "reference": "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes",
+            "files": [
+                "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes"
             ],
             "install_type": "git-clone",
             "description": "A collection of artistic glitch and image manipulation nodes for ComfyUI, featuring advanced noise effects, color manipulations, distortions, and more."
@@ -29552,7 +29618,7 @@
                 "https://github.com/MDMAchine/ComfyUI_MD_Nodes"
             ],
             "install_type": "git-clone",
-            "description": "A wild collection of custom nodes for ComfyUI including noise schedulers, samplers, audio preview, latent visualizers, and more — built for maximal creative chaos."
+            "description": "A wild collection of custom nodes for ComfyUI including noise schedulers, samplers, audio preview, latent visualizers, and more \u2014 built for maximal creative chaos."
         },
         {
             "author": "shiertier",
@@ -29772,7 +29838,7 @@
                 "https://github.com/o-l-l-i/ComfyUI-Olm-Resolution-Picker"
             ],
             "install_type": "git-clone",
-            "description": "A smart, customizable resolution selector node with live aspect ratio preview, image overlays, and checkerboard support — cleanly parsed from a human-readable text file."
+            "description": "A smart, customizable resolution selector node with live aspect ratio preview, image overlays, and checkerboard support \u2014 cleanly parsed from a human-readable text file."
         },
         {
             "author": "o-l-l-i",
@@ -29792,7 +29858,7 @@
                 "https://github.com/o-l-l-i/ComfyUI-Olm-CurveEditor"
             ],
             "install_type": "git-clone",
-            "description": "A single-purpose, multi-channel curve editor for ComfyUI, providing precise color control over R, G, B, and Luma channels directly within the node graph. It’s a focused, lightweight, and standalone solution built specifically for one task: applying color curves cleanly and efficiently."
+            "description": "A single-purpose, multi-channel curve editor for ComfyUI, providing precise color control over R, G, B, and Luma channels directly within the node graph. It\u2019s a focused, lightweight, and standalone solution built specifically for one task: applying color curves cleanly and efficiently."
         },
         {
             "author": "o-l-l-i",
@@ -29802,7 +29868,7 @@
                 "https://github.com/o-l-l-i/ComfyUI-Olm-Sketch"
             ],
             "install_type": "git-clone",
-            "description": "An interactive sketching and drawing node for ComfyUI with stylus/pen support – built for fast, intuitive scribbling directly inside your workflows, geared towards ControlNet-style workflows which utilize scribbles and line art."
+            "description": "An interactive sketching and drawing node for ComfyUI with stylus/pen support \u2013 built for fast, intuitive scribbling directly inside your workflows, geared towards ControlNet-style workflows which utilize scribbles and line art."
         },
         {
             "author": "o-l-l-i",
@@ -29852,7 +29918,7 @@
                 "https://github.com/o-l-l-i/ComfyUI-Olm-Histogram"
             ],
             "install_type": "git-clone",
-            "description": "A compact, real-time histogram analysis node for ComfyUI — with easy-to-use interactive UI, smooth rendering, and accurate pixel sampling. Built for compositing-style workflows and color diagnostics."
+            "description": "A compact, real-time histogram analysis node for ComfyUI \u2014 with easy-to-use interactive UI, smooth rendering, and accurate pixel sampling. Built for compositing-style workflows and color diagnostics."
         },
         {
             "author": "o-l-l-i",
@@ -30090,7 +30156,7 @@
             "title": "Notification Bridge",
             "reference": "https://github.com/INuBq8/ComfyUI-NotificationBridge",
             "files": [
-                        "https://github.com/INuBq8/ComfyUI-NotificationBridge"
+                "https://github.com/INuBq8/ComfyUI-NotificationBridge"
             ],
             "install_type": "git-clone",
             "description": "Bridge nodes for ComfyUI that send messages through WhatsApp (Twilio) and Discord when a workflow completes."
@@ -30366,7 +30432,7 @@
             "files": [
                 "https://github.com/l3ony2k/comfyui-leon-nodes"
             ],
-            "nodename_pattern": "^🤖 Leon",
+            "nodename_pattern": "^\ud83e\udd16 Leon",
             "install_type": "git-clone",
             "description": "A comprehensive collection of utility and API integration nodes for ComfyUI. Includes image manipulation (4-grid split), string utilities, and multiple API integrations: ImgBB upload, HyprLab upload, Google Image API, Luma AI, FLUX Image API, FLUX Kontext API, and Midjourney proxy integration. Features include image/video hosting, AI image generation, and image description capabilities.",
             "pip": [
@@ -30482,7 +30548,7 @@
                 "https://github.com/lord-lethris/ComfyUI-lethris-dia2"
             ],
             "install_type": "Git-Clone",
-            "description": "This package provides two ComfyUI nodes: 🗣️ Dia2 TTS Generator for text-to-speech using Dia2-2B, and 💬 Dia2 Captions Generator to convert TTS timestamps into SRT/SSA/VTT subtitles. Includes example workflow and voice samples. GPU users require CUDA 12.8+."
+            "description": "This package provides two ComfyUI nodes: \ud83d\udde3\ufe0f Dia2 TTS Generator for text-to-speech using Dia2-2B, and \ud83d\udcac Dia2 Captions Generator to convert TTS timestamps into SRT/SSA/VTT subtitles. Includes example workflow and voice samples. GPU users require CUDA 12.8+."
         },
         {
             "author": "ialhabbal",
@@ -30505,15 +30571,24 @@
             "description": "GGUF Quantization support for native ComfyUI models with FantasyTalking."
         },
         {
-            "author": "😈 CasterPollux",
+            "author": "\ud83d\ude08 CasterPollux",
             "title": "MiniMax Video Object Remover Suite",
             "reference": "https://github.com/casterpollux/MiniMax-bmo",
             "files": [
                 "https://github.com/casterpollux/MiniMax-bmo"
             ],
-            "nodename_pattern":  "MiniMax.*BMO|BMO.*MiniMax",
-            "pip":  ["segment-anything"],
-            "tags": ["video", "inpainting", "object-removal", "suite", "professional", "BMO"],
+            "nodename_pattern": "MiniMax.*BMO|BMO.*MiniMax",
+            "pip": [
+                "segment-anything"
+            ],
+            "tags": [
+                "video",
+                "inpainting",
+                "object-removal",
+                "suite",
+                "professional",
+                "BMO"
+            ],
             "install_type": "git-clone",
             "description": "Professional video object removal suite using MiniMax optimization. Includes BMO-enhanced nodes with VAE normalization, temporal preservation, and 6-step inference. Complete video inpainting solution for ComfyUI."
         },
@@ -30746,7 +30821,7 @@
                 "https://github.com/Maxed-Out-99/ComfyUI-SmartModelLoaders-MXD"
             ],
             "install_type": "git-clone",
-            "description": "Smart, unified model loaders for ComfyUI that support both standard .safetensors and quantized .gguf formats — no switching nodes required. Includes flexible UNET and CLIP loaders that work across models like SDXL, SD3, Flux, and more."
+            "description": "Smart, unified model loaders for ComfyUI that support both standard .safetensors and quantized .gguf formats \u2014 no switching nodes required. Includes flexible UNET and CLIP loaders that work across models like SDXL, SD3, Flux, and more."
         },
         {
             "author": "joeriben",
@@ -30797,7 +30872,7 @@
                 "https://github.com/31702160136/ComfyUI-GrsAI"
             ],
             "install_type": "git-clone",
-            "description": "GrsAI API node supports models: Flux-Pro-1.1 (¥ 0.03), Flux-Ultra-1.1 (¥ 0.04), Flux Kontext Pro (¥ 0.035), Flux Kontext Max (¥ 0.07), GPT Image (¥ 0.02). Support text generated images, image generated images, and multi image fusion."
+            "description": "GrsAI API node supports models: Flux-Pro-1.1 (\u00a5 0.03), Flux-Ultra-1.1 (\u00a5 0.04), Flux Kontext Pro (\u00a5 0.035), Flux Kontext Max (\u00a5 0.07), GPT Image (\u00a5 0.02). Support text generated images, image generated images, and multi image fusion."
         },
         {
             "author": "AKharytonchyk",
@@ -31227,7 +31302,7 @@
         },
         {
             "author": "Ltamann",
-            "title": "TBG’s ComfyUI Development Takeaways",
+            "title": "TBG\u2019s ComfyUI Development Takeaways",
             "reference": "https://github.com/Ltamann/ComfyUI-TBG-Takeaways",
             "files": [
                 "https://github.com/Ltamann/ComfyUI-TBG-Takeaways"
@@ -31243,7 +31318,7 @@
                 "https://github.com/Ltamann/ComfyUI-FastVLM-7B"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI-FastVLM-7B Apple A custom node for Apple’s FastVLM-7B vision-language model. This node lets you pass an image + instruction and returns a generated text response."
+            "description": "ComfyUI-FastVLM-7B Apple A custom node for Apple\u2019s FastVLM-7B vision-language model. This node lets you pass an image + instruction and returns a generated text response."
         },
         {
             "author": "Ltamann",
@@ -31276,15 +31351,15 @@
             "description": "DiffusionLight (Turbo) implemented in ComfyUI"
         },
         {
-          "author": "sunx.ai",
-          "title": "SunxAI Custom Nodes for ComfyUI",
-          "id": "comfyui_sun_nodes",
-          "reference": "https://github.com/upseem/comfyui_sun_nodes",
-          "files": [
-            "https://github.com/upseem/comfyui_sun_nodes"
-          ],
-          "install_type": "git-clone",
-          "description": "A set of custom nodes developed by SunxAI for ComfyUI, including image loop processing and more. "
+            "author": "sunx.ai",
+            "title": "SunxAI Custom Nodes for ComfyUI",
+            "id": "comfyui_sun_nodes",
+            "reference": "https://github.com/upseem/comfyui_sun_nodes",
+            "files": [
+                "https://github.com/upseem/comfyui_sun_nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "A set of custom nodes developed by SunxAI for ComfyUI, including image loop processing and more. "
         },
         {
             "author": "sunx.ai",
@@ -31419,15 +31494,15 @@
             "description": "Advanced seed diversity enhancement for ComfyUI with intelligent noise injection and directional biasing."
         },
         {
-          "author": "vrgamegirl19",
-          "title": "VRGameDevGirl Video Enhancement Nodes",
-          "id": "vrgamedev_video_nodes",
-          "reference": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
-          "files": [
-              "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl"
-          ],
-          "install_type": "git-clone",
-          "description": "Film grain and color match nodes designed for high-quality frame-by-frame video enhancement in ComfyUI."
+            "author": "vrgamegirl19",
+            "title": "VRGameDevGirl Video Enhancement Nodes",
+            "id": "vrgamedev_video_nodes",
+            "reference": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
+            "files": [
+                "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl"
+            ],
+            "install_type": "git-clone",
+            "description": "Film grain and color match nodes designed for high-quality frame-by-frame video enhancement in ComfyUI."
         },
         {
             "author": "namtb96",
@@ -31678,7 +31753,7 @@
                 "https://github.com/reallusion/ComfyUI-Reallusion"
             ],
             "install_type": "git-clone",
-            "description": "This nodepack contains custom nodes for ComfyUI designed specifically for handling Reallusion-related assets such as Character Creator and iClone image and video files. These nodes are intended to be used as backend components that communicate and operate through the AI Render Plugin interface of iClone or Character Creator, enabling a seamless integration between ComfyUI's powerful image/video generation capabilities and Reallusion’s animation tools. By bridging ComfyUI with iClone/Character Creator’s AI Render Plugin, these nodes facilitate workflows where AI-assisted content generation can be controlled, customized, and rendered directly from within Reallusion software environments."
+            "description": "This nodepack contains custom nodes for ComfyUI designed specifically for handling Reallusion-related assets such as Character Creator and iClone image and video files. These nodes are intended to be used as backend components that communicate and operate through the AI Render Plugin interface of iClone or Character Creator, enabling a seamless integration between ComfyUI's powerful image/video generation capabilities and Reallusion\u2019s animation tools. By bridging ComfyUI with iClone/Character Creator\u2019s AI Render Plugin, these nodes facilitate workflows where AI-assisted content generation can be controlled, customized, and rendered directly from within Reallusion software environments."
         },
         {
             "author": "glitchinthemetrix16",
@@ -31696,8 +31771,8 @@
             "id": "comfyui-exloadout",
             "reference": "https://github.com/IsItDanOrAi/ComfyUI-exLoadout",
             "files": [
-                    "https://github.com/IsItDanOrAi/ComfyUI-exLoadout"
-                ],
+                "https://github.com/IsItDanOrAi/ComfyUI-exLoadout"
+            ],
             "install_type": "git-clone",
             "description": "Excel spreadsheet-driven ComfyUI nodes that let you load models, values, and workflows based on saved rows in Excel. Great for organizing and switching between CLIPs, VAEs, LoRAs, and more."
         },
@@ -31741,7 +31816,7 @@
                 "https://github.com/zeeoale/PromptCreatorNode"
             ],
             "install_type": "git-clone",
-            "description": "A powerful custom node for ComfyUI that generates rich, dynamic prompts based on modular JSON worlds — with color realm control (RGB / CMYK), LoRA triggers, and optional AI-based prompt enhancement."
+            "description": "A powerful custom node for ComfyUI that generates rich, dynamic prompts based on modular JSON worlds \u2014 with color realm control (RGB / CMYK), LoRA triggers, and optional AI-based prompt enhancement."
         },
         {
             "author": "Android zhang",
@@ -31791,7 +31866,7 @@
                 "https://github.com/Lex-DRL/ComfyUI-BestResolution"
             ],
             "install_type": "git-clone",
-            "description": "QoL nodes for semi-automatic calculation of the best (most optimal) sampling resolution \n• compatible with ANY model (from now or the future), \n• accounting for upscale... \n• ...and pixel-step."
+            "description": "QoL nodes for semi-automatic calculation of the best (most optimal) sampling resolution \n\u2022 compatible with ANY model (from now or the future), \n\u2022 accounting for upscale... \n\u2022 ...and pixel-step."
         },
         {
             "author": "lex-drl",
@@ -31801,7 +31876,7 @@
                 "https://github.com/Lex-DRL/ComfyUI-StringConstructor"
             ],
             "install_type": "git-clone",
-            "description": "Composing prompt variants from the same text pieces with ease:\n• Build your \"library\" (dictionary) of named text chunks (sub-strings) to use it across the entire workflow.\n• Compile these snippets into different prompts in-place - with just one string formatting node.\n• Freely update the dictionary down the line - get different prompts.\n• Reference text chunks within each other to build dependent hierarchies of less/more detailed descriptions.\n• A real life-saver for regional prompting (aka area composition)."
+            "description": "Composing prompt variants from the same text pieces with ease:\n\u2022 Build your \"library\" (dictionary) of named text chunks (sub-strings) to use it across the entire workflow.\n\u2022 Compile these snippets into different prompts in-place - with just one string formatting node.\n\u2022 Freely update the dictionary down the line - get different prompts.\n\u2022 Reference text chunks within each other to build dependent hierarchies of less/more detailed descriptions.\n\u2022 A real life-saver for regional prompting (aka area composition)."
         },
         {
             "author": "baikong",
@@ -31893,8 +31968,15 @@
             "install_type": "git-clone",
             "description": "A comprehensive VRAM management tool for ComfyUI. Includes automatic cleanup and GPU monitoring.",
             "nodename_pattern": "StFist",
-            "pip": ["GPUtil>=1.4.0"],
-            "tags": ["vram", "gpu", "optimizer", "monitoring"]
+            "pip": [
+                "GPUtil>=1.4.0"
+            ],
+            "tags": [
+                "vram",
+                "gpu",
+                "optimizer",
+                "monitoring"
+            ]
         },
         {
             "author": "blird",
@@ -32028,7 +32110,7 @@
                 "https://github.com/brucew4yn3rp/ComfyUI_FrontEndCleanup"
             ],
             "install_type": "git-clone",
-             "description": "This node customizes the ComfyUI frontend by relocating the action bar into the top bar and hiding selected UI elements to reduce visual clutter."
+            "description": "This node customizes the ComfyUI frontend by relocating the action bar into the top bar and hiding selected UI elements to reduce visual clutter."
         },
         {
             "author": "cedarconnor",
@@ -32038,7 +32120,7 @@
                 "https://github.com/cedarconnor/comfyui-LatLong"
             ],
             "install_type": "git-clone",
-            "description": "Advanced equirectangular (360°) image processing nodes for ComfyUI, enabling precise rotation, horizon adjustment, and specialized cropping operations for panoramic images."
+            "description": "Advanced equirectangular (360\u00b0) image processing nodes for ComfyUI, enabling precise rotation, horizon adjustment, and specialized cropping operations for panoramic images."
         },
         {
             "author": "cedarconnor",
@@ -32068,7 +32150,7 @@
                 "https://github.com/cedarconnor/ComfyUI-DreamCube"
             ],
             "install_type": "git-clone",
-            "description": "360° panoramic depth estimation with multi-plane synchronization for ComfyUI, featuring equirectangular-cubemap transformations, cross-face consistency, and boundary blending for seamless depth maps."
+            "description": "360\u00b0 panoramic depth estimation with multi-plane synchronization for ComfyUI, featuring equirectangular-cubemap transformations, cross-face consistency, and boundary blending for seamless depth maps."
         },
         {
             "author": "cedarconnor",
@@ -32089,7 +32171,7 @@
                 "https://github.com/vaishnav-vn/va1"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom nodes: (1) Pad Image by Aspect for Outpaint — expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control for outpainting and canvas expansion. (2) Image Mask Comparer — compare masked regions of two images with similarity scoring and automatic retry/re-queue on mismatch."
+            "description": "ComfyUI custom nodes: (1) Pad Image by Aspect for Outpaint \u2014 expand, pad, and mask images to fixed or randomized aspect ratios with precise spatial and scale control for outpainting and canvas expansion. (2) Image Mask Comparer \u2014 compare masked regions of two images with similarity scoring and automatic retry/re-queue on mismatch."
         },
         {
             "author": "wawahuy",
@@ -32171,7 +32253,7 @@
                 "https://github.com/comnote-max/builmenlabo"
             ],
             "install_type": "git-clone",
-            "description": "Comprehensive collection of ComfyUI custom nodes: 🦙 Advanced LLM text generation with Llama-CPP (CPU/GPU acceleration), 🌐 Smart multi-language prompt translation (Google/DeepL/Yandex/Baidu), 🌍 20-language interface toggle, 📸 AI-powered Gemini pose analysis, 🎛️ Smart ControlNet management. Perfect unified package for AI artists and creators. Blog: https://note.com/hirodream44",
+            "description": "Comprehensive collection of ComfyUI custom nodes: \ud83e\udd99 Advanced LLM text generation with Llama-CPP (CPU/GPU acceleration), \ud83c\udf10 Smart multi-language prompt translation (Google/DeepL/Yandex/Baidu), \ud83c\udf0d 20-language interface toggle, \ud83d\udcf8 AI-powered Gemini pose analysis, \ud83c\udf9b\ufe0f Smart ControlNet management. Perfect unified package for AI artists and creators. Blog: https://note.com/hirodream44",
             "nodename_pattern": "builmenlabo",
             "tags": [
                 "LLM",
@@ -32286,8 +32368,14 @@
                 "https://github.com/comfyuistudio/ComfyUI-Studio-nodes"
             ],
             "install_type": "git-clone",
-            "description": "🧩 Aspect Ratio Image Size Calculator, 🖼️ Aspect Ratio Resizer, and 📄 Markdown Link Generator for ComfyUI.",
-            "tags": ["image", "resize", "aspect-ratio", "markdown", "utils"]
+            "description": "\ud83e\udde9 Aspect Ratio Image Size Calculator, \ud83d\uddbc\ufe0f Aspect Ratio Resizer, and \ud83d\udcc4 Markdown Link Generator for ComfyUI.",
+            "tags": [
+                "image",
+                "resize",
+                "aspect-ratio",
+                "markdown",
+                "utils"
+            ]
         },
         {
             "author": "jenn",
@@ -32378,7 +32466,7 @@
                 "https://github.com/kmlbdh/ComfyUI-kmlbdh-VideoCombine"
             ],
             "install_type": "git-clone",
-            "description": "A custom ComfyUI node designed for stable, high-resolution video export — even on limited hardware."
+            "description": "A custom ComfyUI node designed for stable, high-resolution video export \u2014 even on limited hardware."
         },
         {
             "author": "joosthel",
@@ -32529,7 +32617,7 @@
                 "https://github.com/charlyad142/ComfyUI_Charly_FitToAspectNode"
             ],
             "install_type": "git-clone",
-            "description": "Un nodo personalizado para ComfyUI que ajusta imágenes a diferentes relaciones de aspecto manteniendo las proporciones originales."
+            "description": "Un nodo personalizado para ComfyUI que ajusta im\u00e1genes a diferentes relaciones de aspecto manteniendo las proporciones originales."
         },
         {
             "author": "jupo-ai",
@@ -32722,7 +32810,7 @@
                 "https://github.com/max-dingsda/OllamaTools"
             ],
             "install_type": "git-clone",
-            "description": "This project makes local LLMs easy to use for prompt enhancement and image captioning –No API keys. No external tools. No headache."
+            "description": "This project makes local LLMs easy to use for prompt enhancement and image captioning \u2013No API keys. No external tools. No headache."
         },
         {
             "author": "max-dingsda",
@@ -33162,13 +33250,13 @@
         },
         {
             "author": "mamorett",
-            "title": "MiniCPM‑V‑4 (GGUF) for ComfyUI",
+            "title": "MiniCPM\u2011V\u20114 (GGUF) for ComfyUI",
             "reference": "https://github.com/mamorett/ComfyUI_minicpmv4",
             "files": [
                 "https://github.com/mamorett/ComfyUI_minicpmv4"
             ],
             "install_type": "git-clone",
-            "description": "Modular ComfyUI nodes to run the vision-language model MiniCPM‑V‑4 in GGUF format, powered by llama‑cpp‑python."
+            "description": "Modular ComfyUI nodes to run the vision-language model MiniCPM\u2011V\u20114 in GGUF format, powered by llama\u2011cpp\u2011python."
         },
         {
             "author": "mamorett",
@@ -33220,7 +33308,11 @@
                 "https://github.com/marco-zanella/ComfyUI-BooleanExpression"
             ],
             "install_type": "git-clone",
-            "tags": ["boolean", "logic", "comparison"],
+            "tags": [
+                "boolean",
+                "logic",
+                "comparison"
+            ],
             "description": "A collection of logic and comparison nodes for ComfyUI. This package adds building blocks for boolean logic, arithmetic comparisons, and string comparisons, making it easier to design conditional workflows directly in ComfyUI."
         },
         {
@@ -33231,7 +33323,7 @@
                 "https://github.com/WeChatCV/Stand-In_Preprocessor_ComfyUI"
             ],
             "install_type": "git-clone",
-            "description": "This repository provides a temporary ComfyUI node implementation of the Stand-In preprocessor, aiming to correct the misunderstanding of Stand-In’s preprocessing logic in [a/ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper).\n[w/We strongly recommend using the workflows provided in this repo to ensure proper compatibility and the best identity-preserving performance.]"
+            "description": "This repository provides a temporary ComfyUI node implementation of the Stand-In preprocessor, aiming to correct the misunderstanding of Stand-In\u2019s preprocessing logic in [a/ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper).\n[w/We strongly recommend using the workflows provided in this repo to ensure proper compatibility and the best identity-preserving performance.]"
         },
         {
             "author": "SilverAndJade",
@@ -33292,7 +33384,7 @@
                 "https://github.com/L33chKing/ComfyUI_LatentResidueCleaner"
             ],
             "install_type": "git-clone",
-            "description": "Latent Residue Cleaner — a ComfyUI node that removes diffusion noise residue from AI-generated images using GPU-accelerated guided, bilateral, flat snap, and hue snap filters"
+            "description": "Latent Residue Cleaner \u2014 a ComfyUI node that removes diffusion noise residue from AI-generated images using GPU-accelerated guided, bilateral, flat snap, and hue snap filters"
         },
         {
             "author": "routhakash",
@@ -33346,7 +33438,7 @@
             "install_type": "git-clone",
             "description": "Smart dynamic layer swapping between GPU and CPU for optimal inference performance with comprehensive mixed precision handling and copy-compute overlap optimization. Enables running much larger models on limited VRAM setups."
         },
-		{
+        {
             "author": "Dehypnotic",
             "title": "NumberedText",
             "reference": "https://github.com/Dehypnotic/comfyui-numbered-text",
@@ -33485,7 +33577,12 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI video processing nodes with workflow metadata support",
-            "pip": ["mediapipe>=0.10.0", "opencv-python>=4.8.0", "scipy>=1.10.0", "color-matcher>=0.3.0"]
+            "pip": [
+                "mediapipe>=0.10.0",
+                "opencv-python>=4.8.0",
+                "scipy>=1.10.0",
+                "color-matcher>=0.3.0"
+            ]
         },
         {
             "author": "Dehypnotic",
@@ -33748,7 +33845,7 @@
                 "https://github.com/orion4d/Gemini_Banana_by_orion4d"
             ],
             "install_type": "git-clone",
-            "description": "This project is a custom node for ComfyUI that integrates the power of the Google Gemini 2.5 Flash Image (“Nano Banana”) API. It provides a single versatile node, the Gemini Nano Banana, which allows you to perform image generation and editing operations directly within your workflows."
+            "description": "This project is a custom node for ComfyUI that integrates the power of the Google Gemini 2.5 Flash Image (\u201cNano Banana\u201d) API. It provides a single versatile node, the Gemini Nano Banana, which allows you to perform image generation and editing operations directly within your workflows."
         },
         {
             "author": "Fabio Sarracino",
@@ -33760,7 +33857,14 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI wrapper for Microsoft VibeVoice TTS model. Supports single speaker, multi-speaker, and text file loading",
-            "pip": ["torch>=2.0.0", "torchaudio>=2.0.0", "numpy>=1.20.0", "transformers>=4.44.0", "librosa>=0.9.0", "soundfile>=0.12.0"]
+            "pip": [
+                "torch>=2.0.0",
+                "torchaudio>=2.0.0",
+                "numpy>=1.20.0",
+                "transformers>=4.44.0",
+                "librosa>=0.9.0",
+                "soundfile>=0.12.0"
+            ]
         },
         {
             "author": "mikheys",
@@ -33864,23 +33968,23 @@
         },
         {
             "author": "lucasgattas",
-            "title": "ComfyUI · Egregora: Divide & Enhance",
+            "title": "ComfyUI \u00b7 Egregora: Divide & Enhance",
             "reference": "https://github.com/lucasgattas/comfyui-egregora-divide-and-enhance",
             "files": [
                 "https://github.com/lucasgattas/comfyui-egregora-divide-and-enhance"
             ],
             "install_type": "git-clone",
-            "description": "Egregora: Divide & Enhance is a small suite of custom nodes that help you split, enhance, and recombine images, plus a clean SDXL prompt mixer that keeps things simple while staying robust with lot´s of customization."
+            "description": "Egregora: Divide & Enhance is a small suite of custom nodes that help you split, enhance, and recombine images, plus a clean SDXL prompt mixer that keeps things simple while staying robust with lot\u00b4s of customization."
         },
         {
             "author": "lucasgattas",
-            "title": "ComfyUI · Egregora Audio Super‑Resolution",
+            "title": "ComfyUI \u00b7 Egregora Audio Super\u2011Resolution",
             "reference": "https://github.com/lucasgattas/ComfyUI-Egregora-Audio-Super-Resolution",
             "files": [
                 "https://github.com/lucasgattas/ComfyUI-Egregora-Audio-Super-Resolution"
             ],
             "install_type": "git-clone",
-            "description": "High‑quality music audio enhancement for ComfyUI: FlashSR super‑resolution + Fat Llama spectral enhancement (GPU & CPU)."
+            "description": "High\u2011quality music audio enhancement for ComfyUI: FlashSR super\u2011resolution + Fat Llama spectral enhancement (GPU & CPU)."
         },
         {
             "author": "lucasgattas",
@@ -33971,7 +34075,7 @@
                 "https://github.com/BAIKEMARK/ComfyUI-Civitai-Recipe"
             ],
             "install_type": "git-clone",
-            "description": "Instantly explore Civitai community hits for your local AI models and apply full recipes with one click — or dive deep to uncover the best prompts, parameters, and LoRA combos."
+            "description": "Instantly explore Civitai community hits for your local AI models and apply full recipes with one click \u2014 or dive deep to uncover the best prompts, parameters, and LoRA combos."
         },
         {
             "author": "Jarcis-cy",
@@ -34242,7 +34346,12 @@
             ],
             "install_type": "git-clone",
             "description": "Adds `XY Input: LoRA Weight (simple)` for Efficiency Nodes. Outputs XY subtype 'LoRA' (name, weight, weight) with a linear sweep; works with `XY Input: Checkpoint`.",
-            "tags": ["xy-plot", "lora", "efficiency-nodes", "utility"]
+            "tags": [
+                "xy-plot",
+                "lora",
+                "efficiency-nodes",
+                "utility"
+            ]
         },
         {
             "author": "Shellishack",
@@ -34343,7 +34452,7 @@
                 "https://github.com/Justify87/ComfyUI-Multi-Analysis-Heatmaps"
             ],
             "install_type": "git-clone",
-            "description": "A custom ComfyUI node for visual comparison of two images using multiple perceptual and mathematical methods. The goal: make hidden differences visible as colorful heatmaps, so you can see where an upscaler, denoiser, or diffusion model changed your image — even when your eyes can’t tell at first glance."
+            "description": "A custom ComfyUI node for visual comparison of two images using multiple perceptual and mathematical methods. The goal: make hidden differences visible as colorful heatmaps, so you can see where an upscaler, denoiser, or diffusion model changed your image \u2014 even when your eyes can\u2019t tell at first glance."
         },
         {
             "author": "iguanesolutions",
@@ -34363,7 +34472,7 @@
                 "https://github.com/vantagewithai/Vantage-HunyuanFoley"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI custom node for generating high-fidelity, synchronized foley audio for any video, powered by Tencent’s HunyuanVideo-Foley model."
+            "description": "A ComfyUI custom node for generating high-fidelity, synchronized foley audio for any video, powered by Tencent\u2019s HunyuanVideo-Foley model."
         },
         {
             "author": "Vantage with AI",
@@ -34393,7 +34502,7 @@
                 "https://github.com/vantagewithai/Vantage-DreamOmni2"
             ],
             "install_type": "git-clone",
-            "description": "ntage-DreamOmni2 brings Qwen2.5-VL’s multimodal intelligence to ComfyUI, enabling unified text–image understanding for both generation and editing. Create context-aware prompts, perform reference-based visual edits, and build adaptive image grids — all with high consistency, abstraction, and creative control."
+            "description": "ntage-DreamOmni2 brings Qwen2.5-VL\u2019s multimodal intelligence to ComfyUI, enabling unified text\u2013image understanding for both generation and editing. Create context-aware prompts, perform reference-based visual edits, and build adaptive image grids \u2014 all with high consistency, abstraction, and creative control."
         },
         {
             "author": "vantagewithai",
@@ -34413,7 +34522,7 @@
                 "https://github.com/vantagewithai/Vantage-Step-Audio-EditX"
             ],
             "install_type": "git-clone",
-            "description": "This project is a custom node implementation built on top of Step-Audio-EditX. It adapts and extends EditX capabilities to support multi‑speaker, long‑format, voice cloning, and emotion/style/speed editing, enabling you to feed in a script with multiple speakers, inline pauses, paralinguistic cues, and get a concatenated audio output in one pass."
+            "description": "This project is a custom node implementation built on top of Step-Audio-EditX. It adapts and extends EditX capabilities to support multi\u2011speaker, long\u2011format, voice cloning, and emotion/style/speed editing, enabling you to feed in a script with multiple speakers, inline pauses, paralinguistic cues, and get a concatenated audio output in one pass."
         },
         {
             "author": "SatadalAI",
@@ -34488,7 +34597,7 @@
         },
         {
             "author": "leylahviolet",
-            "title": "iolet Tools 💅",
+            "title": "iolet Tools \ud83d\udc85",
             "reference": "https://github.com/leylahviolet/ComfyUI-Violet-Tools",
             "files": [
                 "https://github.com/leylahviolet/ComfyUI-Violet-Tools"
@@ -35097,7 +35206,7 @@
                 "https://github.com/DecartAI/Lucy-Edit-ComfyUI"
             ],
             "install_type": "git-clone",
-            "description": "Lucy Edit is a video editing model that performs instruction-guided edits on videos using free-text prompts — it supports a variety of edits, such as clothing & accessory changes, character changes, object insertions, and scene replacements while preserving the motion and composition perfectly."
+            "description": "Lucy Edit is a video editing model that performs instruction-guided edits on videos using free-text prompts \u2014 it supports a variety of edits, such as clothing & accessory changes, character changes, object insertions, and scene replacements while preserving the motion and composition perfectly."
         },
         {
             "author": "sbcode",
@@ -35108,9 +35217,13 @@
             ],
             "install_type": "git-clone",
             "description": "A Virtual Camera Output For ComfyUI. On Windows, it will use the OBS Virtual Camera driver. So make sure you have OBS installed. Then in your other webcam capable applications, such as Google Meet, Teams, Zoom and even OBS itself, you can connect to the OBS Virtual Camera option and see what you are outputting from ComfyUI.",
-			"tags": ["virtual-camera", "obs", "webcam"]
+            "tags": [
+                "virtual-camera",
+                "obs",
+                "webcam"
+            ]
         },
-		{
+        {
             "author": "sbcode",
             "title": "ComfyUI Image Compare",
             "reference": "https://github.com/Sean-Bradley/ComfyUI-Image-Compare",
@@ -35119,7 +35232,10 @@
             ],
             "install_type": "git-clone",
             "description": "Compare two images using ComfyUI. Connect images to both image_a and image_b inputs. Press RUN. Then use the slider to compare. Best used when two images are very similar and you want to see the differences very closely. Search for the manager for image compare, or imagecompare.",
-			"tags": ["image-compare", "imagecompare"]
+            "tags": [
+                "image-compare",
+                "imagecompare"
+            ]
         },
         {
             "author": "sbcode",
@@ -35130,7 +35246,10 @@
             ],
             "install_type": "git-clone",
             "description": "A tool to reverse the frames of video type files (MP4, WebM, WebP, Animated GIF) using ComfyUI. It gets the image batch tensor and returns the same tensor, but flipped.",
-            "tags": ["video-reverse", "image-batch-reverse"]
+            "tags": [
+                "video-reverse",
+                "image-batch-reverse"
+            ]
         },
         {
             "author": "sbcode",
@@ -35162,7 +35281,7 @@
             "install_type": "git-clone",
             "description": "A ComfyUI custom node used to get one line of string from a multi line string. Search in the manager for `get line`, or `getline` or `get-line`."
         },
-		{
+        {
             "author": "sbcode",
             "title": "ComfyUI-Sonic",
             "reference": "https://github.com/Sean-Bradley/ComfyUI-Sonic",
@@ -35469,12 +35588,17 @@
             "title": "RC Image Compositor",
             "author": "kj863257",
             "description": "A comprehensive ComfyUI plugin suite that brings professional Photoshop-style layer effects and advanced compositing capabilities. Features modular architecture, 24 blend modes, and enhanced positioning system.",
-			"reference": "https://github.com/kj863257/ComfyUI_RC_Image_Compositor",
+            "reference": "https://github.com/kj863257/ComfyUI_RC_Image_Compositor",
             "files": [
-            	"https://github.com/kj863257/ComfyUI_RC_Image_Compositor"
+                "https://github.com/kj863257/ComfyUI_RC_Image_Compositor"
             ],
             "install_type": "git-clone",
-            "tags": ["compositing", "layer", "blend modes", "photoshop-style"]
+            "tags": [
+                "compositing",
+                "layer",
+                "blend modes",
+                "photoshop-style"
+            ]
         },
         {
             "author": "Verolelb",
@@ -35667,7 +35791,7 @@
                 "https://github.com/9nate-drake/ComfyUI-PanoTools"
             ],
             "install_type": "git-clone",
-            "description": "Professional panorama generation tools for ComfyUI converting perspective images/video to equirectangular 360° panoramas with automatic camera calibration via AI, horizon detection, or vertical line detection."
+            "description": "Professional panorama generation tools for ComfyUI converting perspective images/video to equirectangular 360\u00b0 panoramas with automatic camera calibration via AI, horizon detection, or vertical line detection."
         },
         {
             "author": "Kishor900",
@@ -35758,7 +35882,7 @@
                 "https://github.com/BAIKEMARK/ComfyUI-Civitai-Toolkit"
             ],
             "install_type": "git-clone",
-            "description": "All-in-one Civitai integration center for ComfyUI — browse online models, manage local assets,analyze community trends, and instantly apply full recipes within your workflow."
+            "description": "All-in-one Civitai integration center for ComfyUI \u2014 browse online models, manage local assets,analyze community trends, and instantly apply full recipes within your workflow."
         },
         {
             "author": "synystersocks",
@@ -36031,7 +36155,7 @@
                 "https://github.com/Jairodaniel-17/ComfyUI-translate-offline"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI-translate-offline is a custom node for ComfyUI designed to perform offline text translations using ONNX–based translation models from Hugging Face. The project enables integrating multilingual translations into ComfyUI workflows, focusing on text prompts and conditioning for CLIP models. It supports direct translation between configured language pairs as well as pivot translation via English when no direct model exists. It uses lazy model loading to optimize performance and a SQLite-based caching system to avoid repeated translations."
+            "description": "ComfyUI-translate-offline is a custom node for ComfyUI designed to perform offline text translations using ONNX\u2013based translation models from Hugging Face. The project enables integrating multilingual translations into ComfyUI workflows, focusing on text prompts and conditioning for CLIP models. It supports direct translation between configured language pairs as well as pivot translation via English when no direct model exists. It uses lazy model loading to optimize performance and a SQLite-based caching system to avoid repeated translations."
         },
         {
             "author": "PiePieDesign",
@@ -36118,7 +36242,9 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced GRAG (Guided Region-Adaptive Guidance) implementation for ComfyUI. Features: Simple Controller (3 parameters) for beginners, Unified Controller (25+ parameters) for experts, Advanced Sampler with v2.2.1 contamination fix, Preset Manager with 54 curated presets, per-layer control, adaptive schedules, and multi-resolution support.",
-            "pip": ["PyYAML>=6.0"]
+            "pip": [
+                "PyYAML>=6.0"
+            ]
         },
         {
             "author": "pizurny",
@@ -36152,13 +36278,13 @@
         },
         {
             "author": "jonstreeter",
-            "title": "ComfyUI — Compressed Metadata",
+            "title": "ComfyUI \u2014 Compressed Metadata",
             "reference": "https://github.com/jonstreeter/comfyui-compressed-metadata",
             "files": [
                 "https://github.com/jonstreeter/comfyui-compressed-metadata"
             ],
             "install_type": "git-clone",
-            "description": "Load & save ComfyUI workflows embedded in image metadata — with optional zlib+base64 compression for JPEG/WEBP — and batch convert folders. PNG drops still work natively; JPEG/WEBP with compressed workflows are handled by this extension."
+            "description": "Load & save ComfyUI workflows embedded in image metadata \u2014 with optional zlib+base64 compression for JPEG/WEBP \u2014 and batch convert folders. PNG drops still work natively; JPEG/WEBP with compressed workflows are handled by this extension."
         },
         {
             "author": "jonstreeter",
@@ -36270,8 +36396,8 @@
                 "https://github.com/MichaelMaxAgent/comfyui_ML_nodes"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes for saving images/videos without metadata and GPU-accelerated frame rate processing (25fps→16fps). Includes 5 nodes: Save Image/Video (No Metadata), Frame Rate Resampler (CPU/GPU). Supports CUDA acceleration and multiple nterpolation methods. Requires ffmpeg."
-  		},
+            "description": "Custom nodes for saving images/videos without metadata and GPU-accelerated frame rate processing (25fps\u219216fps). Includes 5 nodes: Save Image/Video (No Metadata), Frame Rate Resampler (CPU/GPU). Supports CUDA acceleration and multiple nterpolation methods. Requires ffmpeg."
+        },
         {
             "author": "leewinder",
             "title": "Crop To Center",
@@ -36494,7 +36620,7 @@
                 "https://github.com/rookiestar28/ComfyUI-OpenClaw"
             ],
             "install_type": "git-clone",
-            "description": "Your own personal AIGC Factory. Any picture. Any reel. The Comfy way. ©️"
+            "description": "Your own personal AIGC Factory. Any picture. Any reel. The Comfy way. \u00a9\ufe0f"
         },
         {
             "author": "MoonMoon82",
@@ -36740,7 +36866,7 @@
                 "https://github.com/Boba-svg/ComfyUI-PromptSwitch"
             ],
             "install_type": "git-clone",
-            "description": "It’s a custom node that allows you to intuitively toggle prompts ON/OFF and adjust their weights — just like using a checklist."
+            "description": "It\u2019s a custom node that allows you to intuitively toggle prompts ON/OFF and adjust their weights \u2014 just like using a checklist."
         },
         {
             "author": "Boba-svg",
@@ -36891,7 +37017,7 @@
                 "https://github.com/guyouyue/ComfyUI_VideoAutoSplit"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI Video Auto-Cropping Tool — includes keyframe detection and automatic segmentation/saving based on keyframes."
+            "description": "ComfyUI Video Auto-Cropping Tool \u2014 includes keyframe detection and automatic segmentation/saving based on keyframes."
         },
         {
             "author": "Analaser",
@@ -37145,7 +37271,13 @@
             "install_type": "git-clone",
             "description": "Automatic image tagging using WD14 models with batch processing and GPU acceleration for ComfyUI",
             "category": "Image Processing",
-            "tags": ["image", "tagging", "wd14", "batch", "gpu"],
+            "tags": [
+                "image",
+                "tagging",
+                "wd14",
+                "batch",
+                "gpu"
+            ],
             "pip": [
                 "onnxruntime>=1.16.0",
                 "numpy>=1.24.0",
@@ -37181,7 +37313,7 @@
                 "https://github.com/Fossiel/ComfyUI-Fossiel-QoL-Nodes"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI-Fossiel-QoL-Nodes is (what will hopefully become) a suite of custom nodes for ComfyUI to improve quality of life. These nodes have been developed for personal use but maybe you’ll find them useful as well."
+            "description": "ComfyUI-Fossiel-QoL-Nodes is (what will hopefully become) a suite of custom nodes for ComfyUI to improve quality of life. These nodes have been developed for personal use but maybe you\u2019ll find them useful as well."
         },
         {
             "author": "Fossiel",
@@ -37372,7 +37504,7 @@
                 "https://github.com/petr-pr/ComfyUI-TranslationNode"
             ],
             "install_type": "git-clone",
-            "description": "Offline translation node for ComfyUI, powered by Facebook's M2M-100 multilingual model. Translate text between 100+ languages — completely offline and private."
+            "description": "Offline translation node for ComfyUI, powered by Facebook's M2M-100 multilingual model. Translate text between 100+ languages \u2014 completely offline and private."
         },
         {
             "author": "eRepublik-Labs",
@@ -37674,7 +37806,11 @@
             ],
             "install_type": "git-clone",
             "description": "Adds hotkeys (F8 / Ctrl+K) and a toolbar button to cycle node link styles (Spline / Linear / Straight).",
-            "tags": ["ui", "hotkey", "canvas"]
+            "tags": [
+                "ui",
+                "hotkey",
+                "canvas"
+            ]
         },
         {
             "author": "adambarbato",
@@ -37738,19 +37874,27 @@
             ],
             "install_type": "git-clone",
             "description": "A collection of custom utility nodes for ComfyUI, providing a variety of practical mini-tools with multiple functions.",
-            "tags": ["utility"]
+            "tags": [
+                "utility"
+            ]
         },
         {
             "author": "Owl-V",
             "title": "ComfyUI-MultiTranslator",
-			"id": "comfyui-multitranslator-owlv",
+            "id": "comfyui-multitranslator-owlv",
             "reference": "https://github.com/OwlvChirotha/ComfyUI-MultiTranslator",
-            "files":[
+            "files": [
                 "https://github.com/OwlvChirotha/ComfyUI-MultiTranslator"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI plug-in collection of basic translator, LLM translator and a series of LLM Service Connectors.",
-            "tags": ["translation", "llm", "ai", "connector", "utility"]
+            "tags": [
+                "translation",
+                "llm",
+                "ai",
+                "connector",
+                "utility"
+            ]
         },
         {
             "author": "Cyrostar",
@@ -37772,7 +37916,12 @@
             ],
             "install_type": "git-clone",
             "description": "Prompt generator from CSV files with randomization and external text input.",
-            "tags": ["prompt", "csv", "text", "random"]
+            "tags": [
+                "prompt",
+                "csv",
+                "text",
+                "random"
+            ]
         },
         {
             "author": "bulldog68",
@@ -37783,7 +37932,12 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced nodes for interaction with Olama (text, vision, image editing), with dynamic management of prompts via CSV.",
-            "tags": ["prompt", "csv", "text", "random"]
+            "tags": [
+                "prompt",
+                "csv",
+                "text",
+                "random"
+            ]
         },
         {
             "author": "bulldog68",
@@ -37794,7 +37948,10 @@
                 "https://github.com/bulldog68/ComfyUI_FMJ_SaveImageVersions"
             ],
             "install_type": "git-clone",
-            "tags": ["save image", "metadonne"],
+            "tags": [
+                "save image",
+                "metadonne"
+            ],
             "license": "GNU V3"
         },
         {
@@ -38057,7 +38214,12 @@
             ],
             "install_type": "git-clone",
             "description": "An enhanced Wan2.2 Image-to-Video node specifically designed to fix the slow-motion issue in 4-step LoRAs (like lightx2v).",
-            "tags": ["video", "image-to-video", "Wan2.2", "LoRA"]
+            "tags": [
+                "video",
+                "image-to-video",
+                "Wan2.2",
+                "LoRA"
+            ]
         },
         {
             "author": "princepainter",
@@ -38119,7 +38281,12 @@
             ],
             "install_type": "git-clone",
             "description": "Enhance first and last frames for smooth video loop generation in ComfyUI. Based on WAN Video workflow.",
-            "tags": ["video", "frame", "loop", "workflow"]
+            "tags": [
+                "video",
+                "frame",
+                "loop",
+                "workflow"
+            ]
         },
         {
             "author": "princepainter",
@@ -38260,7 +38427,7 @@
                 "https://github.com/rafacost/rafacost-comfy"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI custom node for DreamOmni2 GGUF multimodal models — powered directly by llama-cpp-python."
+            "description": "A ComfyUI custom node for DreamOmni2 GGUF multimodal models \u2014 powered directly by llama-cpp-python."
         },
         {
             "author": "yano",
@@ -38303,7 +38470,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI extension with several convenience nodes."
         },
-
         {
             "author": "AlexXia007",
             "title": "AIYang_TripleAPI",
@@ -38706,7 +38872,10 @@
             ],
             "install_type": "git-clone",
             "description": "Smart Image Saving Nodes - Offers intelligent folder management and image saving capabilities, supporting flexible folder hierarchy control, multiple metadata sources, various image formats, and metadata embedding. It includes two nodes: SmartFolderManager and SmartImageSaver.",
-            "pip": ["Pillow", "piexif"],
+            "pip": [
+                "Pillow",
+                "piexif"
+            ],
             "nodename_pattern": "Smart"
         },
         {
@@ -38748,7 +38917,7 @@
                 "https://github.com/FuryNocturn/ComfyUI-Studio-Fury"
             ],
             "install_type": "git-clone",
-            "description": "Nodos custom, al estilo fury, nodos que añaden versatilidad. con el tiempo ira creciendo los nodos."
+            "description": "Nodos custom, al estilo fury, nodos que a\u00f1aden versatilidad. con el tiempo ira creciendo los nodos."
         },
         {
             "author": "FuryNocturn",
@@ -38779,7 +38948,13 @@
             ],
             "install_type": "git-clone",
             "description": "Nodes for XY-style testing of parameters such as seed, steps, cfg, denoise, prompts, and LoRAs. Does not require a custom KSampler and works with any KSampler, including the default ComfyUI one.",
-            "tags": ["xy_plot", "xy", "xz", "testing", "ksampler"]
+            "tags": [
+                "xy_plot",
+                "xy",
+                "xz",
+                "testing",
+                "ksampler"
+            ]
         },
         {
             "author": "akawana",
@@ -38790,7 +38965,13 @@
             ],
             "install_type": "git-clone",
             "description": "Builds a folder-based tree from prompt lines. Lets you organize prompts into folders. Also adds several configurable keybindings for text editing (line commenting, regional prompting areas). Splits the prompt into regions for Regional Prompting.",
-            "tags": ["frontend", "shortcut", "regional", "folders", "bookmarks"]
+            "tags": [
+                "frontend",
+                "shortcut",
+                "regional",
+                "folders",
+                "bookmarks"
+            ]
         },
         {
             "author": "akawana",
@@ -38801,7 +38982,16 @@
             ],
             "install_type": "git-clone",
             "description": "UI extensions: Control Multiple Samplers, Project Settings. Nodes: AK Base,  AK Index Multiple, IsOneOfGroupsActive, RepeatGroupState group enable/disable like rg but without connection, Pipe, Getter, Setter.",
-            "tags": ["utility", "list", "batch", "get", "set", "pipe", "project", "sampler"]
+            "tags": [
+                "utility",
+                "list",
+                "batch",
+                "get",
+                "set",
+                "pipe",
+                "project",
+                "sampler"
+            ]
         },
         {
             "author": "akawana",
@@ -38811,8 +39001,13 @@
                 "https://github.com/akawana/ComfyUI-RGBYP-Mask-Editor"
             ],
             "install_type": "git-clone",
-            "description": "A JS editor for five-color masks (RGB + Yellow + Pink) that works with any nodes, with three helper nodes — RGBYPLoadImage, RGBYPMaskBridge, and RGBYPMaskToRegularMasks—for convenient RGBYP mask handling.",
-            "tags": ["utility", "mask", "rgb", "bridge"]
+            "description": "A JS editor for five-color masks (RGB + Yellow + Pink) that works with any nodes, with three helper nodes \u2014 RGBYPLoadImage, RGBYPMaskBridge, and RGBYPMaskToRegularMasks\u2014for convenient RGBYP mask handling.",
+            "tags": [
+                "utility",
+                "mask",
+                "rgb",
+                "bridge"
+            ]
         },
         {
             "author": "lovisdotio",
@@ -38984,7 +39179,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for integrating multiple external APIs including Gemini, OpenAI, Replicate, and ElevenLabs directly into local workflows. (Description by CC)"
         },
-
         {
             "author": "keghoang",
             "title": "ComfyUI-Charon",
@@ -39055,7 +39249,7 @@
             "install_type": "git-clone",
             "description": "Resolution picker and latent generator for ComfyUI. Select presets like HD, FullHD, 2K, 4K, 8K with aspect ratios (1:1, 9:16, 4:5, 21:9 etc.) via dropdowns. Automatically snaps width/height to latent-safe multiples of 64. Ideal for EmptyLatentImage, AnimateDiff, ControlNet, video formats, and KSampler workflows. Outputs clean INT values or ready-to-use LATENT tensor."
         },
-		{
+        {
             "author": "Bharanidharan",
             "title": "faceExtractor for ComfyUI",
             "reference": "https://github.com/llikethat/ComfyUI-faceExtractor",
@@ -39267,8 +39461,13 @@
                 "https://github.com/fredlef/Comfyui_FSL_Nodes"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes: FSLGeminiChat, FSLGeminiGenerateImage, Transparent Background helpers, and more." ,
-            "tags": ["image", "chat", "gemini", "fsl"]
+            "description": "Custom nodes: FSLGeminiChat, FSLGeminiGenerateImage, Transparent Background helpers, and more.",
+            "tags": [
+                "image",
+                "chat",
+                "gemini",
+                "fsl"
+            ]
         },
         {
             "author": "exedesign",
@@ -39281,7 +39480,14 @@
             "install_type": "git-clone",
             "description": "Text-to-3D and Image-to-3D generation using Tencent Cloud Hunyuan 3D Global API. Supports PBR materials, face count control (40K-1.5M faces), and multiple generation types (Normal/LowPoly/Geometry/Sketch). Outputs industry-standard GLB format. Requires Tencent Cloud account with API access.",
             "nodename_pattern": "Hunyuan",
-            "tags": ["3D", "generation", "text-to-3d", "image-to-3d", "hunyuan", "tencent"]
+            "tags": [
+                "3D",
+                "generation",
+                "text-to-3d",
+                "image-to-3d",
+                "hunyuan",
+                "tencent"
+            ]
         },
         {
             "author": "btitkin",
@@ -39366,7 +39572,7 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced nodes optimized for ACE-Step audio generation in ComfyUI."
-		},
+        },
         {
             "author": "jeankassio",
             "title": "ComfyUI-AceStep_SFT",
@@ -39380,7 +39586,7 @@
         },
         {
             "author": "ameyukisora",
-             "title": "ComfyUI Empty Latent Advanced",
+            "title": "ComfyUI Empty Latent Advanced",
             "reference": "https://github.com/ameyukisora/ComfyUI-Empty-Latent-Advanced",
             "files": [
                 "https://github.com/ameyukisora/ComfyUI-Empty-Latent-Advanced"
@@ -39451,7 +39657,12 @@
             ],
             "install_type": "git-clone",
             "description": "A collection of utility nodes for ComfyUI, including resolution presets for film and photography aspect ratios.",
-            "tags": ["utility", "presets", "aspect ratio", "film"]
+            "tags": [
+                "utility",
+                "presets",
+                "aspect ratio",
+                "film"
+            ]
         },
         {
             "author": "jomakaze",
@@ -39472,7 +39683,7 @@
                 "https://github.com/DayMan84/ComfyUI-Usgromana"
             ],
             "install_type": "git-clone",
-            "description": "The next-generation security, governance, permissions, and multi‑user control system for ComfyUI."
+            "description": "The next-generation security, governance, permissions, and multi\u2011user control system for ComfyUI."
         },
         {
             "author": "DayMan84",
@@ -39703,7 +39914,7 @@
                 "https://github.com/Zone-Roam/ComfyUI-Live-Search"
             ],
             "install_type": "git-clone",
-            "description": "🌐 Live Search: Real-time web search and AI summarization. Internet search, web scraping, fact checking, weather, news, GPS coordinate conversion. DuckDuckGo search with GPT-5.1, DeepSeek-V3, Gemini 3 Pro, Claude 4.5, Qwen3, Doubao, SiliconFlow (69+ models), Llama 4, Ollama. Modular architecture with API loader. Toggle web search on/off for pure LLM mode."
+            "description": "\ud83c\udf10 Live Search: Real-time web search and AI summarization. Internet search, web scraping, fact checking, weather, news, GPS coordinate conversion. DuckDuckGo search with GPT-5.1, DeepSeek-V3, Gemini 3 Pro, Claude 4.5, Qwen3, Doubao, SiliconFlow (69+ models), Llama 4, Ollama. Modular architecture with API loader. Toggle web search on/off for pure LLM mode."
         },
         {
             "author": "AJbeckliy",
@@ -39812,7 +40023,9 @@
             "files": [
                 "https://github.com/Braeden90000/comfyui-load-image-url"
             ],
-            "pip": ["requests"],
+            "pip": [
+                "requests"
+            ],
             "install_type": "git-clone",
             "description": "Load images from files or URLs with live preview and source switching."
         },
@@ -40411,7 +40624,7 @@
             "install_type": "git-clone",
             "description": "2 nodes for muting or bypassing a node by node ID. They are widget linkable and promotable to a Subgraph node as a switch to mute or bypass a node in it's own Subgraph, or any other Subgraph, or it can be used as a stand alone node anywhere"
         },
-		{
+        {
             "author": "pixelpainter",
             "title": "UI-Decorators [SubGraph]",
             "reference": "https://github.com/pixelpainter/UI-Decorators",
@@ -40618,7 +40831,7 @@
             "title": "ComfyUI-FlashVSR_Stable",
             "reference": "https://github.com/naxci1/ComfyUI-FlashVSR_Stable",
             "files": [
-            "https://github.com/naxci1/ComfyUI-FlashVSR_Stable"
+                "https://github.com/naxci1/ComfyUI-FlashVSR_Stable"
             ],
             "install_type": "git-clone",
             "description": "High-performance Video Super Resolution for ComfyUI with VRAM optimization."
@@ -40711,7 +40924,7 @@
                 "https://github.com/nawka12/comfyui-adaptive-noise-scale"
             ],
             "install_type": "git-clone",
-            "description": "Adaptive Noise Scale sampler wrapper for ComfyUI — port of sd-webui-adaptive-noise-scale"
+            "description": "Adaptive Noise Scale sampler wrapper for ComfyUI \u2014 port of sd-webui-adaptive-noise-scale"
         },
         {
             "author": "zhuyanan",
@@ -41209,7 +41422,7 @@
                 "https://github.com/kplkasteel/ComfyUI-Image-to-Prompt-Abacus.AI-"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom node that converts an input image into a Stable Diffusion-ready prompt using Abacus.AI’s OpenAI-compatible multimodal API (model dropdown fetched from /v1/models; supports route-llm and other available models). Requires an Abacus.AI API key and consumes API credits.",
+            "description": "ComfyUI custom node that converts an input image into a Stable Diffusion-ready prompt using Abacus.AI\u2019s OpenAI-compatible multimodal API (model dropdown fetched from /v1/models; supports route-llm and other available models). Requires an Abacus.AI API key and consumes API credits.",
             "tags": [
                 "prompt",
                 "image-to-prompt",
@@ -41255,7 +41468,7 @@
                 "https://github.com/tardigrade1001/latent-rotate-90"
             ],
             "install_type": "git-clone",
-            "description": "A minimal, opinionated ComfyUI custom node that emits portrait (0°) and/or landscape (90°) latent variants in a single run."
+            "description": "A minimal, opinionated ComfyUI custom node that emits portrait (0\u00b0) and/or landscape (90\u00b0) latent variants in a single run."
         },
         {
             "author": "tardigrade1001",
@@ -41285,7 +41498,7 @@
                 "https://github.com/tardigrade1001/send-to-comfyui"
             ],
             "install_type": "git-clone",
-            "description": "A lightweight browser extension + custom ComfyUI node that creates a seamless Web → ComfyUI pipeline for sending images directly from the browser into your workflows."
+            "description": "A lightweight browser extension + custom ComfyUI node that creates a seamless Web \u2192 ComfyUI pipeline for sending images directly from the browser into your workflows."
         },
         {
             "author": "zisb",
@@ -41707,7 +41920,7 @@
                 "https://github.com/MechaBabyAi/ComfyUI-MechaBaby-NodeLayout"
             ],
             "install_type": "git-clone",
-            "description": "A node layout helper extension for ComfyUI. Assists in arranging and aligning nodes on the canvas without modifying workflow files — all operations are frontend-only."
+            "description": "A node layout helper extension for ComfyUI. Assists in arranging and aligning nodes on the canvas without modifying workflow files \u2014 all operations are frontend-only."
         },
         {
             "author": "shmbatom",
@@ -41783,7 +41996,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI custom node for calculating tile dimensions in upscaling workflows"
         },
-
         {
             "author": "danielvw",
             "title": "ComfyUI-WanMove-Adapter",
@@ -41865,7 +42077,7 @@
                 "https://github.com/jianglinbin/ComfyUI-AnglesSelect"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom nodes for multi-angle LoRA prompt generation. Provides 3D visual angle selector and simple angle selector with support for 8 azimuths × 4 elevations × 3 distances = 96 view combinations."
+            "description": "ComfyUI custom nodes for multi-angle LoRA prompt generation. Provides 3D visual angle selector and simple angle selector with support for 8 azimuths \u00d7 4 elevations \u00d7 3 distances = 96 view combinations."
         },
         {
             "author": "3R3BOS",
@@ -41905,11 +42117,16 @@
             "id": "comfyui-vram-watcher",
             "reference": "https://github.com/zwaigani/ComfyUI-VRAM-watcher",
             "files": [
-            "https://github.com/zwaigani/ComfyUI-VRAM-watcher"
+                "https://github.com/zwaigani/ComfyUI-VRAM-watcher"
             ],
             "install_type": "git-clone",
             "description": "Displays GPU VRAM usage and system RAM usage as bar widgets in a ComfyUI node.",
-            "tags": ["utils", "ui", "vram", "ram"]
+            "tags": [
+                "utils",
+                "ui",
+                "vram",
+                "ram"
+            ]
         },
         {
             "author": "zwaigani",
@@ -41949,7 +42166,7 @@
                 "https://github.com/kantan-kanto/ComfyUI-LLM-Session"
             ],
             "install_type": "git-clone",
-            "description": "Local LLM session nodes for ComfyUI using GGUF and llama.cpp, supporting Llama, Mistral, Qwen, DeepSeek, GLM, Gemma, Phi, LLaVA and gpt-oss, enabling both user–model chat and model-to-model dialogue without external runtimes like Ollama."
+            "description": "Local LLM session nodes for ComfyUI using GGUF and llama.cpp, supporting Llama, Mistral, Qwen, DeepSeek, GLM, Gemma, Phi, LLaVA and gpt-oss, enabling both user\u2013model chat and model-to-model dialogue without external runtimes like Ollama."
         },
         {
             "author": "mingchoi",
@@ -42049,7 +42266,7 @@
                 "https://github.com/capitan01R/ComfyUI-CapitanZiT-Scheduler"
             ],
             "install_type": "git-clone",
-            "description": "A lightweight ComfyUI custom scheduler & sigma generator for Z-Image-Turbo. Delivers a stable linear sigma schedule (1.0 → 0.0) for rectified-flow/flow-matching, boosting few-step generation (8-9 steps) with superior consistency, reduced noise, and full compatibility with the model's distilled pipeline."
+            "description": "A lightweight ComfyUI custom scheduler & sigma generator for Z-Image-Turbo. Delivers a stable linear sigma schedule (1.0 \u2192 0.0) for rectified-flow/flow-matching, boosting few-step generation (8-9 steps) with superior consistency, reduced noise, and full compatibility with the model's distilled pipeline."
         },
         {
             "author": "capitan01R",
@@ -42139,7 +42356,7 @@
                 "https://github.com/NickPittas/ComfyUI_CameraAngleSelector"
             ],
             "install_type": "git-clone",
-            "description": "Interactive 3D interface for selecting camera angles for Qwen-Image-Edit-2511, supporting 96 unique camera angle combinations (8 directions × 4 heights × 3 shot sizes) with multi-selection and visual feedback."
+            "description": "Interactive 3D interface for selecting camera angles for Qwen-Image-Edit-2511, supporting 96 unique camera angle combinations (8 directions \u00d7 4 heights \u00d7 3 shot sizes) with multi-selection and visual feedback."
         },
         {
             "author": "asirihewage",
@@ -42231,7 +42448,7 @@
                 "https://github.com/migero/ComfyUI-Equirectangular-Strip"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes for ComfyUI to convert between equirectangular (360°) images and a strip of 6 cube faces (90° FOV each)."
+            "description": "Custom nodes for ComfyUI to convert between equirectangular (360\u00b0) images and a strip of 6 cube faces (90\u00b0 FOV each)."
         },
         {
             "author": "0nikod",
@@ -42742,7 +42959,11 @@
             ],
             "install_type": "git-clone",
             "description": "Adds a smart I/O status dock to stacked nodes for cleaner layouts.",
-            "tags": ["ui", "layout", "utils"]
+            "tags": [
+                "ui",
+                "layout",
+                "utils"
+            ]
         },
         {
             "author": "laowang",
@@ -42828,7 +43049,14 @@
             ],
             "install_type": "git-clone",
             "description": "A specialized toolkit for AI-based image captioning (reverse prompting), prompt enrichment, and automated batch generation. It streamlines LoRA dataset organization with native GGUF and Ollama support.",
-            "tags": ["llm", "vision", "prompt generation", "lora", "Qwen3", "reverse prompting"]
+            "tags": [
+                "llm",
+                "vision",
+                "prompt generation",
+                "lora",
+                "Qwen3",
+                "reverse prompting"
+            ]
         },
         {
             "author": "DevDuckFace",
@@ -43218,7 +43446,7 @@
                 "https://github.com/DanPli/ComfyUI-Flux2LatentPresets"
             ],
             "install_type": "git-clone",
-            "description": "A custom ComfyUI node that provides Flux 2–recommended resolution presets for quickly creating empty latents, without manually entering width and height values."
+            "description": "A custom ComfyUI node that provides Flux 2\u2013recommended resolution presets for quickly creating empty latents, without manually entering width and height values."
         },
         {
             "author": "pytraveler",
@@ -43248,7 +43476,7 @@
                 "https://github.com/JamesDanielDoss/JamesDossAI-EnhancedLinks"
             ],
             "install_type": "git-clone",
-            "description": "Simple animated arrows traveling along workflow links (input → output)"
+            "description": "Simple animated arrows traveling along workflow links (input \u2192 output)"
         },
         {
             "author": "kreonxv",
@@ -43452,16 +43680,16 @@
             "install_type": "git-clone",
             "description": "A ComfyUI Custom Node to backup workflows and their required models locally."
         },
-		{
+        {
             "author": "DVA",
             "title": "DVA_Qwen_TTS",
             "reference": "https://github.com/SLVGITHUB/QWEN3_TTS_DVA",
             "files": [
                 "https://github.com/SLVGITHUB/QWEN3_TTS_DVA"
-		    ],
+            ],
             "install_type": "git-clone",
             "description": "High-quality multilingual TTS with voice cloning, emotion control, and support for Qwen3-TTS models (CustomVoice, VoiceDesign, Base)."
-		},
+        },
         {
             "author": "boredcoderyt",
             "title": "Fibo Edit Node for ComfyUI",
@@ -43536,7 +43764,7 @@
                 "https://github.com/dennisvink/comfyui-outline"
             ],
             "install_type": "git-clone",
-            "description": "This node adds an outside-only outline around the opaque region of an image while cleaning up semi‑transparent edge pixels and removing stray islands."
+            "description": "This node adds an outside-only outline around the opaque region of an image while cleaning up semi\u2011transparent edge pixels and removing stray islands."
         },
         {
             "author": "NineKey1028",
@@ -43570,7 +43798,27 @@
             "install_type": "git-clone",
             "description": "Enhanced QwenVL node with Smart Prompt Caching, multilingual WAN 2.2 presets, comprehensive visual style detection, and NSFW support. Latest v2.0.8 with bug fixes and stability improvements for professional multimodal workflows.",
             "category": "image",
-            "tags": ["vision", "language", "multimodal", "qwen", "smart_caching", "prompt_caching", "multilingual", "style_detection", "performance", "wan2.2", "video", "i2v", "t2v", "cinematography", "abliterated", "nsfw", "enhanced", "fork", "stable"],
+            "tags": [
+                "vision",
+                "language",
+                "multimodal",
+                "qwen",
+                "smart_caching",
+                "prompt_caching",
+                "multilingual",
+                "style_detection",
+                "performance",
+                "wan2.2",
+                "video",
+                "i2v",
+                "t2v",
+                "cinematography",
+                "abliterated",
+                "nsfw",
+                "enhanced",
+                "fork",
+                "stable"
+            ],
             "version": "2.0.8"
         },
         {
@@ -43584,7 +43832,22 @@
             "install_type": "git-clone",
             "description": "Tag completion with a1111-sd-webui-tagcomplete style wildcard sub-selection, supporting CSV files and multiple wildcard sources. Features smart parsing, text overflow handling, and full compatibility with existing wildcard files. v2.0.0 with major wildcard workflow improvements.",
             "category": "utility",
-            "tags": ["tag", "completion", "autocomplete", "wildcard", "csv", "suggestion", "sub-selection", "a1111", "danbooru", "e621", "prompt", "utility", "enhanced", "stable"],
+            "tags": [
+                "tag",
+                "completion",
+                "autocomplete",
+                "wildcard",
+                "csv",
+                "suggestion",
+                "sub-selection",
+                "a1111",
+                "danbooru",
+                "e621",
+                "prompt",
+                "utility",
+                "enhanced",
+                "stable"
+            ],
             "version": "2.0.0"
         },
         {
@@ -43598,7 +43861,21 @@
             "install_type": "git-clone",
             "description": "Ultra fast frame interpolation using Rife TensorRT with fully automatic installation and optimization. Features automatic TensorRT engine building, CUDA toolkit detection, and resolution profiles for optimal performance. 2-4x faster than original RIFE implementation with enhanced stability and memory management.",
             "category": "video",
-            "tags": ["video", "interpolation", "rife", "tensorrt", "cuda", "performance", "frame", "motion", "automatic", "optimization", "enhanced", "fork", "stable"]
+            "tags": [
+                "video",
+                "interpolation",
+                "rife",
+                "tensorrt",
+                "cuda",
+                "performance",
+                "frame",
+                "motion",
+                "automatic",
+                "optimization",
+                "enhanced",
+                "fork",
+                "stable"
+            ]
         },
         {
             "author": "huchukato",
@@ -43611,7 +43888,23 @@
             "install_type": "git-clone",
             "description": "2-4x faster ComfyUI image upscaling using TensorRT with automatic installation and model optimization. Supports popular upscaling models with automatic TensorRT engine building, CUDA toolkit detection, and memory-efficient processing. Enhanced performance and stability over original implementation.",
             "category": "image",
-            "tags": ["image", "upscale", "tensorrt", "cuda", "performance", "enhancement", "automatic", "optimization", "esrgan", "edsr", "memory", "efficient", "enhanced", "fork", "stable"]
+            "tags": [
+                "image",
+                "upscale",
+                "tensorrt",
+                "cuda",
+                "performance",
+                "enhancement",
+                "automatic",
+                "optimization",
+                "esrgan",
+                "edsr",
+                "memory",
+                "efficient",
+                "enhanced",
+                "fork",
+                "stable"
+            ]
         },
         {
             "author": "huchukato",
@@ -43624,7 +43917,21 @@
             "install_type": "git-clone",
             "description": "HuggingFace model downloader for ComfyUI with advanced search and intelligent download system. Search, browse, and download models directly from HuggingFace repository without leaving ComfyUI interface. Features API token support, model type filtering, and migration path from Civicomfy with enhanced stability.",
             "category": "utility",
-            "tags": ["huggingface", "model", "download", "search", "browse", "api", "repository", "management", "interface", "migration", "civicomfy", "enhanced", "stable"]
+            "tags": [
+                "huggingface",
+                "model",
+                "download",
+                "search",
+                "browse",
+                "api",
+                "repository",
+                "management",
+                "interface",
+                "migration",
+                "civicomfy",
+                "enhanced",
+                "stable"
+            ]
         },
         {
             "author": "kadima-tech",
@@ -43880,12 +44187,12 @@
             "install_type": "git-clone",
             "description": "Local AI prompt generator using Qwen/SmolLM2 models. 100% offline and private. Supports 4-bit/8-bit quantization. Runs on 6GB VRAM GPUs alongside Stable Diffusion. Smart token management, Polish-English translation, embedding support, OOM protection.",
             "tags": [
-              "prompt",
-              "AI",
-              "LLM",
-              "offline",
-              "translation",
-              "privacy"
+                "prompt",
+                "AI",
+                "LLM",
+                "offline",
+                "translation",
+                "privacy"
             ]
         },
         {
@@ -44118,7 +44425,7 @@
                 "https://github.com/Nekodificador/ComfyUI-NKD-Sigmas-Curve"
             ],
             "install_type": "git-clone",
-            "description": "Interactive sigma schedule editor for ComfyUI — NURBS spline curve widget"
+            "description": "Interactive sigma schedule editor for ComfyUI \u2014 NURBS spline curve widget"
         },
         {
             "author": "nekodificador",
@@ -44152,14 +44459,14 @@
         },
         {
             "author": "rohit267",
-            "title":"Champdev Custom Nodes",
-            "id":"champdev",
-            "reference":"https://github.com/rohit267/champdev-comfyui-nodes",
+            "title": "Champdev Custom Nodes",
+            "id": "champdev",
+            "reference": "https://github.com/rohit267/champdev-comfyui-nodes",
             "files": [
                 "https://github.com/rohit267/champdev-comfyui-nodes"
             ],
-            "install_type":"git-clone",
-            "description":"Champdev Custom Nodes. Currently contains Champdev Save Image, auto delete image after input seconds, overwrite file, save to temp dir."
+            "install_type": "git-clone",
+            "description": "Champdev Custom Nodes. Currently contains Champdev Save Image, auto delete image after input seconds, overwrite file, save to temp dir."
         },
         {
             "author": "ChunkyPanda29",
@@ -44197,7 +44504,7 @@
             "id": "openimage",
             "reference": "https://github.com/nic-schi/ComfyUI-OpenImage",
             "files": [
-                  "https://github.com/nic-schi/ComfyUI-OpenImage"
+                "https://github.com/nic-schi/ComfyUI-OpenImage"
             ],
             "install_type": "git-clone",
             "description": "Lets you open a generated Image in a specified application after generation."
@@ -44223,7 +44530,13 @@
             ],
             "install_type": "git-clone",
             "description": "Load Qwen-VL and Qwen3-VL models locally and apply PEFT LoRA adapters for enhanced image captioning. Supports 4-bit and 8-bit quantization (BitsAndBytes), FP8 pre-quantized models, Flash Attention 2, SageAttention, and torch.compile. Includes a LoRA strength slider and configurable captioning prompts.",
-            "tags": ["captioning", "LLM", "VLM", "LoRA", "Qwen"]
+            "tags": [
+                "captioning",
+                "LLM",
+                "VLM",
+                "LoRA",
+                "Qwen"
+            ]
         },
         {
             "author": "SeanBRVFX",
@@ -44263,7 +44576,7 @@
                 "https://github.com/wobba/ComfyUI-ChatterBox-Turbo"
             ],
             "install_type": "git-clone",
-            "description": "ChatterBox Turbo TTS node for ComfyUI — fast 350M-param text-to-speech with emotion tags"
+            "description": "ChatterBox Turbo TTS node for ComfyUI \u2014 fast 350M-param text-to-speech with emotion tags"
         },
         {
             "author": "Manycore Tech",
@@ -44286,7 +44599,14 @@
             ],
             "install_type": "git-clone",
             "description": "Smart real-time token counter for CLIP-L, T5-XXL (Flux), Qwen + seed-controlled prompt mixer from custom CSV wildcards. Supports field overrides, flat/paragraph modes, thread-safe caching.",
-            "tags": ["prompt", "token", "csv", "wildcard", "utils", "text"]
+            "tags": [
+                "prompt",
+                "token",
+                "csv",
+                "wildcard",
+                "utils",
+                "text"
+            ]
         },
         {
             "author": "FugitiveExpert01",
@@ -44306,7 +44626,7 @@
                 "https://github.com/DanielBartolic/ComfyUI-Qwen3.5"
             ],
             "install_type": "git-clone",
-            "description": "Custom ComfyUI node for Qwen3.5-9B — a unified natively multimodal model with image, video, and text understanding capabilities including thinking mode."
+            "description": "Custom ComfyUI node for Qwen3.5-9B \u2014 a unified natively multimodal model with image, video, and text understanding capabilities including thinking mode."
         },
         {
             "author": "GIlinQ",
@@ -44326,7 +44646,7 @@
                 "https://github.com/vito0131/ComfyUI-DepthNormalizer"
             ],
             "install_type": "git-clone",
-            "description": "A ComfyUI custom node for normalizing depth maps to a specific range (0–230 by default)."
+            "description": "A ComfyUI custom node for normalizing depth maps to a specific range (0\u2013230 by default)."
         },
         {
             "author": "abc-lee",
@@ -44377,7 +44697,7 @@
                 "https://github.com/MONKEYFOREVER2/ComfyUI-ZenFaceDetailer"
             ],
             "install_type": "git-clone",
-            "description": "An all-in-one ComfyUI face detailing node that combines face detection, inpainting, and advanced sampling in a single node — no complex node chains required. (Description by CC)"
+            "description": "An all-in-one ComfyUI face detailing node that combines face detection, inpainting, and advanced sampling in a single node \u2014 no complex node chains required. (Description by CC)"
         },
         {
             "author": "MONKEYFOREVER2",
@@ -44618,7 +44938,7 @@
                 "https://github.com/aiolicollective/aioli-nodes"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes for ComfyUI — Ratio Outpaint Calc and BBox Multiple Fix"
+            "description": "Custom nodes for ComfyUI \u2014 Ratio Outpaint Calc and BBox Multiple Fix"
         },
         {
             "author": "deepme987",
@@ -44928,7 +45248,7 @@
                 "https://github.com/Rimor-dev/ComfyUI-Diana"
             ],
             "install_type": "git-clone",
-            "description": "🧝 Interactive assistant that lives in your ComfyUI workspace. Reacts to queue events with animated sprites, voice lines, and text bubbles. Features multiple personalities: Diana (calm), Kitty (cute), Kerrigan (dark). Includes audio toggle, idle timer, and smart error detection."
+            "description": "\ud83e\udddd Interactive assistant that lives in your ComfyUI workspace. Reacts to queue events with animated sprites, voice lines, and text bubbles. Features multiple personalities: Diana (calm), Kitty (cute), Kerrigan (dark). Includes audio toggle, idle timer, and smart error detection."
         },
         {
             "author": "fangzhengyu0704-dotcom",
@@ -44997,7 +45317,7 @@
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
             "files": [
-            	"https://github.com/senjinthedragon/comfyui-gender-tag-filter"
+                "https://github.com/senjinthedragon/comfyui-gender-tag-filter"
             ],
             "install_type": "git-clone",
             "category": "utils/tags",
@@ -45228,7 +45548,7 @@
                 "https://github.com/jeremieLouvaert/comfyui-prompt-assembler"
             ],
             "install_type": "git-clone",
-            "description": "Modular prompt assembly nodes for ComfyUI — 8-slot, compact 4-slot, and weighted 6-slot with attention syntax"
+            "description": "Modular prompt assembly nodes for ComfyUI \u2014 8-slot, compact 4-slot, and weighted 6-slot with attention syntax"
         },
         {
             "author": "jeremieLouvaert",
@@ -45238,7 +45558,7 @@
                 "https://github.com/jeremieLouvaert/ComfyUI-Prompt-Vault"
             ],
             "install_type": "git-clone",
-            "description": "Photographic prompt arsenal — curated templates and component builder with real camera gear, lighting, film stocks"
+            "description": "Photographic prompt arsenal \u2014 curated templates and component builder with real camera gear, lighting, film stocks"
         },
         {
             "author": "jeremieLouvaert",
@@ -45248,7 +45568,7 @@
                 "https://github.com/jeremieLouvaert/ComfyUI-Darkroom"
             ],
             "install_type": "git-clone",
-            "description": "Professional color grading and film emulation suite — 29 nodes: 161 film stocks with real Capture One curve data, Camera Raw tools, Resolve-level grading (LGG, Log Wheels, Hue vs Hue, Color Warper), lens optics with 102 real lens profiles. Zero API costs."
+            "description": "Professional color grading and film emulation suite \u2014 29 nodes: 161 film stocks with real Capture One curve data, Camera Raw tools, Resolve-level grading (LGG, Log Wheels, Hue vs Hue, Color Warper), lens optics with 102 real lens profiles. Zero API costs."
         },
         {
             "author": "jeremieLouvaert",
@@ -45258,7 +45578,7 @@
                 "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Direct"
             ],
             "install_type": "git-clone",
-            "description": "Direct Google Gemini image generation for ComfyUI — use your own API key, bypass credits. Supports Gemini 2.0 Flash, 2.5 Flash, 2.5 Pro. Includes Prompt Studio and photographer style transfer."
+            "description": "Direct Google Gemini image generation for ComfyUI \u2014 use your own API key, bypass credits. Supports Gemini 2.0 Flash, 2.5 Flash, 2.5 Pro. Includes Prompt Studio and photographer style transfer."
         },
         {
             "author": "jeremieLouvaert",
@@ -45278,7 +45598,7 @@
                 "https://github.com/jeremieLouvaert/ComfyUI-Gemini-Conversation-Canvas"
             ],
             "install_type": "git-clone",
-            "description": "Multi-turn conversational image editing powered by Google Gemini — persistent sessions, edit chaining, and visual gallery with full scene coherence across turns."
+            "description": "Multi-turn conversational image editing powered by Google Gemini \u2014 persistent sessions, edit chaining, and visual gallery with full scene coherence across turns."
         },
         {
             "author": "jeremieLouvaert",
@@ -45288,7 +45608,7 @@
                 "https://github.com/jeremieLouvaert/comfyui-wireless-link-simple"
             ],
             "install_type": "git-clone",
-            "description": "Simple wireless data transmission nodes for ComfyUI — send and receive any data type without visible wires using named channels. Inspired by Blackmagic Fusion."
+            "description": "Simple wireless data transmission nodes for ComfyUI \u2014 send and receive any data type without visible wires using named channels. Inspired by Blackmagic Fusion."
         },
         {
             "author": "jeremieLouvaert",
@@ -45298,7 +45618,7 @@
                 "https://github.com/jeremieLouvaert/ComfyUI-Higgsfield-Direct"
             ],
             "install_type": "git-clone",
-            "description": "Direct Higgsfield API integration for ComfyUI — multi-model image and video generation with Soul 2.0, Seedream 4, Kling 2.1, Seedance, and more. Use your own API key."
+            "description": "Direct Higgsfield API integration for ComfyUI \u2014 multi-model image and video generation with Soul 2.0, Seedream 4, Kling 2.1, Seedance, and more. Use your own API key."
         },
         {
             "author": "vpominchuk",
@@ -45328,7 +45648,7 @@
                 "https://github.com/TakkunRed/comfyui_checkpoint_preset_manager"
             ],
             "install_type": "git-clone",
-            "description": "A custom node for ComfyUI designed to manage and automate optimal settings for different Checkpoints. It allows you to save and recall specific parameters—including steps, CFG, samplers, schedulers, and resolutions—linked directly to the model name."
+            "description": "A custom node for ComfyUI designed to manage and automate optimal settings for different Checkpoints. It allows you to save and recall specific parameters\u2014including steps, CFG, samplers, schedulers, and resolutions\u2014linked directly to the model name."
         },
         {
             "author": "krishnancr",
@@ -45345,11 +45665,11 @@
             "author": "HalfikCode",
             "title": "Prompt DB",
             "reference": "https://github.com/HalfikCode/ComfyUI-Prompt-DB",
-            "files":[
+            "files": [
                 "https://github.com/HalfikCode/ComfyUI-Prompt-DB"
             ],
             "install_type": "git-clone",
-            "description": "A powerful prompt management system for ComfyUI. Store, categorize, search, and combine prompts with full LoRA integration — all from a beautiful built-in web UI."
+            "description": "A powerful prompt management system for ComfyUI. Store, categorize, search, and combine prompts with full LoRA integration \u2014 all from a beautiful built-in web UI."
         },
         {
             "author": "Stibo",
@@ -45371,7 +45691,7 @@
                 "https://github.com/mvnt-app/ComfyUI-MVNT"
             ],
             "install_type": "git-clone",
-            "description": "AI dance choreography from music. Generate full-body dance motion (BVH/FBX/JSON) from any audio track using MVNT's diffusion model trained with 100+ professional choreographers. Create rigged 3D characters from images, preview motion as stick-figure animations, and export photorealistic AI music videos — all inside ComfyUI. Nodes: MVNT Generate Dance, MVNT Generate Character, MVNT Export Video, MVNT Preview BVH, MVNT List Styles, MVNT Estimate Cost, MVNT Load Motion."
+            "description": "AI dance choreography from music. Generate full-body dance motion (BVH/FBX/JSON) from any audio track using MVNT's diffusion model trained with 100+ professional choreographers. Create rigged 3D characters from images, preview motion as stick-figure animations, and export photorealistic AI music videos \u2014 all inside ComfyUI. Nodes: MVNT Generate Dance, MVNT Generate Character, MVNT Export Video, MVNT Preview BVH, MVNT List Styles, MVNT Estimate Cost, MVNT Load Motion."
         },
         {
             "author": "yhryzy",
@@ -45382,7 +45702,7 @@
                 "https://github.com/vulca-org/comfyui-vulca"
             ],
             "install_type": "git-clone",
-            "description": "Cultural art evaluation nodes — L1-L5 scoring across 13 traditions, Layered Generation + Inpainting, Brief-driven creative workflows. Evaluate AI-generated art for cultural accuracy and get actionable improvement suggestions. Requires: pip install vulca",
+            "description": "Cultural art evaluation nodes \u2014 L1-L5 scoring across 13 traditions, Layered Generation + Inpainting, Brief-driven creative workflows. Evaluate AI-generated art for cultural accuracy and get actionable improvement suggestions. Requires: pip install vulca",
             "tags": [
                 "evaluation",
                 "cultural",
@@ -45411,7 +45731,10 @@
             ],
             "install_type": "git-clone",
             "description": "Intel Arc-first ComfyUI monitor with real-time GPU/CPU/RAM stats and an exclusive workflow execution success rate predictor. NVIDIA (CUDA) fully supported.",
-            "pip": ["psutil", "pynvml"]
+            "pip": [
+                "psutil",
+                "pynvml"
+            ]
         },
         {
             "author": "darksidewalker",
@@ -45472,7 +45795,7 @@
                 "https://github.com/sorryhyun/comfyui-flex-attention"
             ],
             "install_type": "git-clone",
-            "description": "Flex Attention (torch.compile) node for ComfyUI. Uses PyTorch's built-in flex_attention with torch.compile — no extra dependencies, works on any GPU. Falls back to PyTorch SDPA when masks are present."
+            "description": "Flex Attention (torch.compile) node for ComfyUI. Uses PyTorch's built-in flex_attention with torch.compile \u2014 no extra dependencies, works on any GPU. Falls back to PyTorch SDPA when masks are present."
         },
         {
             "author": "spacewarpstudio",
@@ -45582,7 +45905,7 @@
                 "https://github.com/katsut/ComfyUI-AlphaVAE"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom nodes for AlphaVAE — native RGBA transparent image generation using FLUX"
+            "description": "ComfyUI custom nodes for AlphaVAE \u2014 native RGBA transparent image generation using FLUX"
         },
         {
             "author": "jkmq-f",
@@ -45613,7 +45936,7 @@
                 "https://github.com/starfieldscreensaver/comfyui-batch-blend"
             ],
             "install_type": "git-clone",
-            "description": "Blends two image batches frame-by-frame using vectorised tensor ops. Supports 15 blend modes (normal, add, multiply, screen, overlay, soft light, and more). No loops or workarounds needed — works natively with batches."
+            "description": "Blends two image batches frame-by-frame using vectorised tensor ops. Supports 15 blend modes (normal, add, multiply, screen, overlay, soft light, and more). No loops or workarounds needed \u2014 works natively with batches."
         },
         {
             "author": "tennantje",
@@ -45795,7 +46118,7 @@
                 "https://github.com/zaochuan5854/ComfyUI-TensorRT-Reforge"
             ],
             "install_type": "git-clone",
-            "description": "Building upon the excellent foundation of ComfyUI_TensorRT, this version focuses on full support for the Anima architecture and advanced TensorRT acceleration. It aims to push NVIDIA RTX™ GPU performance to its limits for the next generation of Stable Diffusion workflows."
+            "description": "Building upon the excellent foundation of ComfyUI_TensorRT, this version focuses on full support for the Anima architecture and advanced TensorRT acceleration. It aims to push NVIDIA RTX\u2122 GPU performance to its limits for the next generation of Stable Diffusion workflows."
         },
         {
             "author": "MSXYZ",
@@ -45845,7 +46168,7 @@
             "author": "artyclaw",
             "title": "ArtyClaw Comfy Nodes",
             "reference": "https://github.com/artyclaw/artyclaw-comfy",
-            "files":[
+            "files": [
                 "https://github.com/artyclaw/artyclaw-comfy"
             ],
             "install_type": "git-clone",
@@ -45896,7 +46219,7 @@
         },
         {
             "author": "vladgohn",
-            "title": "🦄 MurMur",
+            "title": "\ud83e\udd84 MurMur",
             "reference": "https://github.com/vladgohn/ComfyUI-MurMur",
             "files": [
                 "https://github.com/vladgohn/ComfyUI-MurMur"
@@ -45947,20 +46270,6 @@
             "install_type": "git-clone",
             "description": "Area-based LoRA and conditioning workflow tools for ComfyUI with multi-region control."
         },
-
-
-
-
-
-
-
-
-
-
-
-
-
-
         {
             "author": "Ser-Hilary",
             "title": "SDXL_sizing",
@@ -46338,6 +46647,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "sequencer-media",
+            "title": "Sequencer AI Nodes",
+            "reference": "https://github.com/sequencer-media/sequencer-comfy-nodes",
+            "files": [
+                "https://github.com/sequencer-media/sequencer-comfy-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "One universal node for all 50+ Sequencer AI models. Generate images, videos, and audio (Veo 3.1, Flux 1.1 Pro, Kling, Ideogram, etc). dynamically populates model lists and I/O sockets."
         }
     ]
 }


### PR DESCRIPTION
Hi there! This adds `sequencer-comfy-nodes` to the manager.

It provides a single universal node that automatically gives users access to all 50+ models from the Sequencer AI catalog (Flux Pro, Veo 3.1, Ideogram, Recraft, Kling, ElevenLabs, etc) using dynamic model resolution and V3 generation backend.