### PR TITLE
Wrap original_*.flush() in sync_write with try/except (OSError, ValueError)

### DIFF
--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -332,8 +332,14 @@ try:
                     if '100%' in message:
                         self.sync_write(message)
                     else:
-                        write_stderr(message)
-                        original_stderr.flush()
+                        # Wrap flush() to match the safer behaviour of
+                        # self.flush() below — a broken pipe must not
+                        # kill the calling print() (and thus the node).
+                        try:
+                            write_stderr(message)
+                            original_stderr.flush()
+                        except (OSError, ValueError):
+                            pass
                 else:
                     self.sync_write(message)
             else:
@@ -356,12 +362,20 @@ try:
 
             if not file_only:
                 with std_log_lock:
-                    if self.is_stdout:
-                        write_stdout(message)
-                        original_stdout.flush()
-                    else:
-                        write_stderr(message)
-                        original_stderr.flush()
+                    # Wrap flush() in try/except to match self.flush()
+                    # below. Without this, an OSError from a broken
+                    # stdio pipe (e.g. Windows [Errno 22] Invalid argument)
+                    # propagates up through every print() call in every
+                    # custom node, killing prompt execution.
+                    try:
+                        if self.is_stdout:
+                            write_stdout(message)
+                            original_stdout.flush()
+                        else:
+                            write_stderr(message)
+                            original_stderr.flush()
+                    except (OSError, ValueError):
+                        pass
 
         def flush(self):
             try:


### PR DESCRIPTION
## Summary
- `ComfyUIManagerLogger.sync_write()` calls `original_stdout.flush()` / `original_stderr.flush()` without exception guards. Any failing flush (e.g. Windows [Errno 22] Invalid argument on a broken stdio pipe) propagates all the way back up through `print()` in every custom node's `INPUT_TYPES()` / `__init__`.
- The sibling `flush()` method already wraps these exact calls in `try/except (OSError, ValueError): pass` — this PR extends the same pattern to `sync_write()` and the tqdm branch in `write()`, which is where the exception path actually hits for non-progress output.

## Repro (what we hit repeatedly)
On Windows with ComfyUI launched as a child process (piped stdio, which is how most desktop wrappers run it):

1. A crashing custom node — in our case `comfyui-ollamagemini` hitting an invalid Gemini API key on every `/object_info` call — calls `print(traceback)` inside its `INPUT_TYPES()`.
2. That print goes through this logger wrapper, hits the unguarded `original_stderr.flush()`, and raises `OSError: [Errno 22] Invalid argument` once the pipe gets into a bad state.
3. From that point on, **every other** custom node's `print()` raises the same `[Errno 22]` — even on benign lines like `print("Dependencies already installed from previous run")` inside `ComfyUI-LatentSyncWrapper`.
4. Prompt execution dies with a traceback that points at the innocent node, not the real culprit. Very hard to diagnose from logs.

## Fix
Wrap the two unguarded `original_*.flush()` call sites in `try/except (OSError, ValueError): pass` — identical to the pattern already used at lines 378–379 inside `flush()`:

- `sync_write()` — the main path for all `print()` output
- the tqdm branch in `write()` — `progress bars that don't end in 100%`

Both changes are minimal and preserve existing behavior on healthy pipes. On a broken pipe, the log line is silently dropped (same as `flush()` already does) instead of crashing the caller.

## Why not fix the offending custom node upstream?
- We did (locally disabled the specific bad actors), but this bug is a general-purpose resilience fix: **any** node whose `print()` lands during a transient stdio hiccup can currently take down `[Errno 22]` the entire custom-node load across the install. Guarding the logger wrapper is the correct defense-in-depth layer.

## Risk
Low. The change is purely defensive:
- Error-free runs are identical
- Error runs lose the print line instead of crashing — which is what `flush()` already does two dozen lines below

## Notes for a reviewer
- The parallel at `flush()` (lines 366–379 of the unmodified file) was my reference — same approach, same exceptions caught
- Comments explain the Windows pipe failure mode so future readers understand why the guard is there

Discovered while debugging LatentSync on Windows in a ComfyUI-wrapping desktop app where the stdio-pipe path made the failure mode unavoidable. Once this PR lands, the upstream-included LatentSyncWrapper, Sonic, Hallo 2, and any other `print()`-heavy node becomes robust against transient pipe corruption.