### PR TITLE
Add ComfyUI Claude CLI (Vision+Text) node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46467,6 +46467,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "RandyHaylor",
+            "title": "Claude CLI (Vision+Text)",
+            "id": "comfyui-claude-cli-vision-text-node",
+            "reference": "https://github.com/RandyHaylor/comfyui-claude-cli-vision-text-node",
+            "files": [
+                "https://github.com/RandyHaylor/comfyui-claude-cli-vision-text-node"
+            ],
+            "install_type": "git-clone",
+            "description": "Call the local `claude` CLI from ComfyUI for vision+text or text-only completions. Uses your existing `claude login` OAuth (no API key required). Supports UUID session reuse for prompt-cache savings, with session token-usage tracking. Additional utility nodes: `Split Image Batch to List of Image Batches` (takes a large incoming batch and splits it into a list of smaller sub-batches with start/end index outputs, so you can send N images at a time — e.g. pairs — to the Claude CLI node along with their original batch indices for tracking), `Indexed 2x2 Grid from Batch`, `Select Images (Bounds Safe)`, and `Image Batch Current Index`. Optional headless API-key mode."
         }
     ]
 }


### PR DESCRIPTION
Adds RandyHaylor/comfyui-claude-cli-vision-text-node to the custom-node-list. Calls the local claude CLI for vision+text completions using existing OAuth credentials, plus several batch/list utility nodes (batch→list-of-sub-batches splitter with indices, indexed 2x2 grid assembly, bounds-safe image selection, batch current-index).