### PR TITLE
chore(release): 4.2.1 — register extension.manager.supports_csrf_post feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to **ComfyUI-Manager** are documented in this file.
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.2.1] - 2026-04-22
 
-Security-hardening release on branch `fix/csrf-post-conversion`. Contains
-breaking-ish API changes for state-mutating endpoints. See **Migration notes**
-below before upgrading programmatic clients.
+Security-hardening release. Contains breaking-ish API changes for
+state-mutating endpoints. See **Migration notes** below before upgrading
+programmatic clients.
 
 ### Security
 
@@ -65,6 +65,12 @@ below before upgrading programmatic clients.
 
 ### Added
 
+- **Server-push feature flag `extension.manager.supports_csrf_post`** registered
+  at startup, allowing ComfyUI-frontend (and other clients) to detect
+  CSRF-POST backend support as a semantic capability contract, without
+  relying on version string parsing. Manager versions prior to 4.2.1 do not
+  set the flag — clients should treat its absence as 'incompatible with
+  POST-only state-mutation endpoints'.
 - **E2E test harness variants** for security-level and legacy-mode scenarios:
   `tests/e2e/scripts/start_comfyui_legacy.sh`,
   `tests/e2e/scripts/start_comfyui_permissive.sh`,
@@ -120,4 +126,4 @@ below before upgrading programmatic clients.
   perform the change from a trusted entry point. Read access via `GET` is
   unaffected.
 
-[Unreleased]: https://github.com/Comfy-Org/ComfyUI-Manager/compare/v4.1b6...HEAD
+[4.2.1]: https://github.com/Comfy-Org/ComfyUI-Manager/compare/v4.1b6...v4.2.1

--- a/comfyui_manager/__init__.py
+++ b/comfyui_manager/__init__.py
@@ -6,6 +6,26 @@ from .common import manager_security
 from comfy.cli_args import args
 
 
+# Register server-push feature flag so ComfyUI_frontend (and other clients)
+# can detect CSRF-POST backend capability as a semantic contract (vs version
+# string parsing). See PR #2818 for context; clients use this flag to decide
+# whether to invoke POST state-mutation endpoints. Manager versions prior to
+# 4.2.1 do not set this flag — clients should treat its absence as
+# 'incompatible with POST-only state-mutation endpoints'.
+try:
+    from comfy_api import feature_flags as _core_feature_flags
+    _mgr_flags = (
+        _core_feature_flags.SERVER_FEATURE_FLAGS
+        .setdefault('extension', {})
+        .setdefault('manager', {})
+    )
+    _mgr_flags['supports_csrf_post'] = True
+except ImportError:
+    # Older ComfyUI core without comfy_api.feature_flags module.
+    # Manager functions but clients will not observe the flag.
+    pass
+
+
 def prestartup():
     from . import prestartup_script  # noqa: F401
     logging.info('[PRE] ComfyUI-Manager')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-manager"
 license = { text = "GPL-3.0-only" }
-version = "4.2"
+version = "4.2.1"
 requires-python = ">= 3.9"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
 readme = "README.md"


### PR DESCRIPTION
## Summary

Follow-up to #2818. Registers a server-push feature flag so clients can detect CSRF-POST backend capability via ComfyUI core's `feature_flags` mechanism instead of parsing version strings.

- Flag: `extension.manager.supports_csrf_post = True`, registered at Manager import time in `comfyui_manager/__init__.py` via `comfy_api.feature_flags.SERVER_FEATURE_FLAGS`.
- Manager versions prior to 4.2.1 do not set the flag. Clients (ComfyUI_frontend, third-party extensions) observe its absence and should treat the backend as incompatible with POST-only state-mutation endpoints, prompting the user to upgrade.
- `ImportError` on older ComfyUI cores without `comfy_api.feature_flags` is swallowed silently — Manager continues to function, clients simply do not observe the flag.
- No endpoint or security behavior change. Pure capability advertisement.

## Version bump

- `pyproject.toml`: 4.2.0 → **4.2.1** (SSOT; `importlib.metadata.version("comfyui-manager")` reads from here)
- `CHANGELOG.md`: new `## [4.2.1] - 2026-04-22` entry

## Test plan

- [ ] Verify flag is registered at import time: `python -c "from comfy_api import feature_flags; import comfyui_manager; print(feature_flags.SERVER_FEATURE_FLAGS['extension']['manager']['supports_csrf_post'])"` -> True
- [ ] Verify graceful fallback on older ComfyUI core without `comfy_api.feature_flags` (Manager still imports, no exception propagated).
- [ ] Verify frontend can observe the flag via existing feature_flags WebSocket/HTTP channel.
- [ ] Confirm no behavior change on any state-mutation POST handler.