### PR TITLE
Add ComfyUI-GPT-image

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46477,7 +46477,7 @@
                 "https://github.com/magicwang1111/ComfyUI-GPT-image"
             ],
             "install_type": "git-clone",
-            "description": "ComfyUI custom nodes for OpenAI GPT Image generation and editing, with support for both the official OpenAI API and OpenAI-compatible relay endpoints."
+            "description": "Generate and edit images in ComfyUI with OpenAI GPT Image models. Includes dedicated Generate and Edit nodes, multi-image reference input, size presets, and support for both the official OpenAI API and OpenAI-compatible relay endpoints."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46467,6 +46467,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "magicwang1111",
+            "title": "ComfyUI-GPT-image (OpenAI/Relay)",
+            "id": "comfyui-gpt-image-openai-relay",
+            "reference": "https://github.com/magicwang1111/ComfyUI-GPT-image",
+            "files": [
+                "https://github.com/magicwang1111/ComfyUI-GPT-image"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for OpenAI GPT Image generation and editing, with support for both the official OpenAI API and OpenAI-compatible relay endpoints."
         }
     ]
 }


### PR DESCRIPTION
## Node overview
`ComfyUI-GPT-image` is a ComfyUI custom node pack for OpenAI GPT Image generation and editing.

It currently provides:
- a `Generate` node for text-to-image
- an `Edit` node for image-to-image
- multi-image reference input
- size presets
- support for both the official OpenAI API and OpenAI-compatible relay endpoints

## Registry entry
This PR adds a `git-clone` entry for:
- `https://github.com/magicwang1111/ComfyUI-GPT-image`

A unique title and id are used so it does not conflict with the existing `lceric/comfyui-gpt-image` entry.

## Validation
- Ran `python -X utf8 json-checker.py custom-node-list.json`
- Ran `python -X utf8 cm-cli.py simple-show all --mode local`
- Confirmed the local DB can load `ComfyUI-GPT-image (OpenAI/Relay)` successfully