### PR TITLE
Add Eagle Metadata Bridge to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46618,6 +46618,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "NNNebel",
+            "title": "Eagle Metadata Bridge",
+            "id": "eagle-metadata-bridge",
+            "reference": "https://github.com/NNNebel/eagle-metadata-bridge",
+            "files": [
+                "https://github.com/NNNebel/eagle-metadata-bridge"
+            ],
+            "install_type": "git-clone",
+            "description": "Embeds eagle_bridge signal into PNG/WebP/JPEG outputs and sends auto-tags/annotations to the Eagle app."
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds [Eagle Metadata Bridge](https://github.com/NNNebel/eagle-metadata-bridge) to `custom-node-list.json`
- Embeds `eagle_bridge` signal into PNG/WebP/JPEG outputs and automatically sends tags/annotations to the [Eagle](https://eagle.cool) app
- `json-checker.py` validation passed

## Node info

| Field | Value |
|-------|-------|
| author | NNNebel |
| install_type | git-clone |
| reference | https://github.com/NNNebel/eagle-metadata-bridge |