### PR TITLE
Add ComfyUI-MotifVideo2B to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46467,6 +46467,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Motif Technologies",
+            "title": "ComfyUI-MotifVideo2B",
+            "reference": "https://github.com/MotifTechnologies/ComfyUI-MotifVideo2B",
+            "files": [
+                "https://github.com/MotifTechnologies/ComfyUI-MotifVideo2B"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for Motif-Video 2B (Motif Technologies) text-to-video and image-to-video diffusion model. Includes model loaders, samplers, and a workflow-driven automatic model download dialog."
         }
     ]
 }


### PR DESCRIPTION
Adds [ComfyUI-MotifVideo2B](https://github.com/MotifTechnologies/ComfyUI-MotifVideo2B) to `custom-node-list.json`.

`ComfyUI-MotifVideo2B` is the official ComfyUI integration for [Motif Technologies](https://motiftech.io)'s **Motif-Video 2B** flow-matching text-to-video / image-to-video diffusion transformer ([Hugging Face](https://huggingface.co/Motif-Technologies/Motif-Video-2B), [tech report](https://arxiv.org/abs/2604.16503)). The custom node ships:

- `Load MotifVideo Text Encoder` (T5Gemma2)
- `MotifVideo Text Encode` (positive + negative in one node)
- `Empty MotifVideo Latent`
- `Load MotifVideo VAE` (3D VAE in diffusers layout, auto-remapped to ComfyUI's WAN VAE keys)
- `MotifVideo Image Encode` (I2V branch)
- T2V / I2V example workflows with a `models[]` manifest so the first time you load the workflow, ComfyUI's automatic model-download dialog pulls the three weight files directly from Hugging Face.

Entry details:

- `install_type`: `git-clone`
- `reference` / `files`: `https://github.com/MotifTechnologies/ComfyUI-MotifVideo2B`
- repo also ships `pyproject.toml` with `[tool.comfy]` metadata (`DisplayName = "Motif-Video 2B"`, `requires-comfyui = ">=0.18.0"`).

Tested on ComfyUI v0.18.0 (frontend v1.25.3) with ComfyUI-Manager v3.39.2 — manual `git clone` install path works end-to-end. The Manager **Install via Git URL** path is currently rejected on the default `normal` security level for unregistered repos (`This action is not allowed with this security level configuration.`); this PR is the registration step that resolves it.