### PR TITLE
Add: ComfyUI-DCW (SNR-t bias correction)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46467,6 +46467,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "namemechan",
+            "title": "ComfyUI-DCW",
+            "id": "comfyui-dcw",
+            "reference": "https://github.com/namemechan/ComfyUI-DCW",
+            "files": [
+                "https://github.com/namemechan/ComfyUI-DCW"
+            ],
+            "install_type": "git-clone",
+            "description": "Near implementation of Differential Correction in Wavelet domain (DCW) for SNR-t bias correction. Based on arXiv:2604.16044 (Yu et al., 2026). No external dependencies. Compatible with SDXL, SD1.5, Flux, Cosmos, EDM, DiT. (README in Korean)"
         }
     ]
 }


### PR DESCRIPTION
## Description
Adds ComfyUI-DCW node — a wavelet-domain SNR-t bias correction plugin.

Based on: Elucidating the SNR-t Bias of Diffusion Probabilistic Models (Yu et al., arXiv:2604.16044)

- This is a near implementation adapted for ComfyUI compatibility.
- No external dependencies (pure PyTorch)
- Compatible with SDXL, SD1.5, Flux, Cosmos, EDM, DiT
- Works alongside LoRA, FreeU, IPAdapter without conflict
- Overhead: ~0.1% per step