### PR TITLE
Add ComfyUI_RP_Cast to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46047,7 +46047,17 @@
             "install_type": "git-clone",
             "description": "Personal ComfyUI custom nodes."
         },
-
+        {
+            "author": "AISeDam",
+            "title": "ComfyUI_RP_Cast",
+            "id": "comfyui_rp_cast",
+            "reference": "https://github.com/AISeDam/ComfyUI_RP_Cast",
+            "files": [
+                "https://github.com/AISeDam/ComfyUI_RP_Cast"
+            ],
+            "install_type": "git-clone",
+            "description": "Per-region prompt and LoRA control for SD1.5, SDXL, Z-Image, and Qwen — compatible with multiple model architectures."
+        },
 
 
 


### PR DESCRIPTION
## Summary

Adds `ComfyUI_RP_Cast` entry to `custom-node-list.json`.

The node is already published on the Comfy Registry (publisher: AISeDam).

The `id` field matches the registry node ID (`comfyui_rp_cast`) for proper cross-referencing.

---

## Overview

A ComfyUI port and adaptation of [sd-webui-regional-prompter](https://github.com/hako-mikan/sd-webui-regional-prompter)
by hako-mikan. Provides per-region prompt and LoRA control across multiple model architectures.

Supports SDXL / SD1.5 with mask-based latent blending (denoised callback),
and Z-Image / Qwen with unified prompt sampling.

---

## Nodes (8 total)

| Node | Description |
|------|-------------|
| `RPPromptParser` | Parses multi-region prompts (ADDCOMM / ADDBASE / ADDCOL / ADDROW). Auto-calculates divide_ratio with canvas visualization. |
| `RPRatioParser` | Converts divide_ratio + divide_mode + threshold into region structs. Canvas visualization of splits. |
| `RPKSampler` | Regional KSampler for SDXL / SD1.5. Per-step region blending via denoised callback. |
| `RPRegionalDetailer` | YOLO bbox-based regional inpainting for SDXL / SD1.5. Per-region LoRA isolation. |
| `RPKSamplerZImage` | Regional KSampler for Z-Image. Merges region prompts with position labels into a single pass. |
| `RPRegionalDetailerZImage` | YOLO + WD14 gender classification for Z-Image. Per-region LoRA isolation at inpaint stage. |
| `RPKSamplerQwen` | Regional KSampler for Qwen. Builds scene-narrative prompt for natural multi-character composition. |
| `RPRegionalDetailerQwen` | Delegates to RPRegionalDetailerZImage with Qwen VAE tensor normalization (5D → 4D). |

---

## Node details

- **Repository**: https://github.com/AISeDam/ComfyUI_RP_Cast
- **Registry**: https://registry.comfy.org/nodes/comfyui_rp_cast
- **Author**: AISeDam
- **License**: AGPL-3.0
- **Supported models**: SDXL, SD1.5, Z-Image, Qwen