### PR TITLE
Add kontext-controlnet-fix by VixDreamer

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -41,7 +41,9 @@
             ],
             "install_type": "git-clone",
             "description": "This node pack offers various detector nodes and detailer nodes that allow you to configure a workflow that automatically enhances facial details. And provide iterative upscaler.\nNOTE: To use the UltralyticsDetectorProvider, you must install the 'ComfyUI Impact Subpack' separately.",
-            "preemptions":["SAMLoader"]
+            "preemptions": [
+                "SAMLoader"
+            ]
         },
         {
             "author": "Dr.Lt.Data",
@@ -172,7 +174,7 @@
             "files": [
                 "https://github.com/Fannovel16/comfyui_controlnet_aux"
             ],
-            "preemptions":[
+            "preemptions": [
                 "AIO_Preprocessor",
                 "AnimalPosePreprocessor",
                 "AnimeFace_SemSegPreprocessor",
@@ -221,7 +223,8 @@
                 "UniFormer-SemSegPreprocessor",
                 "Unimatch_OptFlowPreprocessor",
                 "Zoe-DepthMapPreprocessor",
-                "Zoe_DepthAnythingPreprocessor"],
+                "Zoe_DepthAnythingPreprocessor"
+            ],
             "install_type": "git-clone",
             "description": "Plug-and-play ComfyUI node sets for making ControlNet hint images."
         },
@@ -651,7 +654,9 @@
             "files": [
                 "https://github.com/city96/SD-Latent-Upscaler"
             ],
-            "pip": ["huggingface-hub"],
+            "pip": [
+                "huggingface-hub"
+            ],
             "install_type": "git-clone",
             "description": "Upscaling stable diffusion latents using a small neural network."
         },
@@ -663,7 +668,9 @@
             "files": [
                 "https://github.com/city96/ComfyUI_DiT"
             ],
-            "pip": ["huggingface-hub"],
+            "pip": [
+                "huggingface-hub"
+            ],
             "install_type": "git-clone",
             "description": "Testbed for [a/DiT(Scalable Diffusion Models with Transformers)](https://github.com/facebookresearch/DiT). [w/None of this code is stable, expect breaking changes if for some reason you want to use this.]"
         },
@@ -697,7 +704,7 @@
             "files": [
                 "https://github.com/city96/ComfyUI-GGUF"
             ],
-            "preemptions":[
+            "preemptions": [
                 "CLIPLoaderGGUF",
                 "DualCLIPLoaderGGUF",
                 "TripleCLIPLoaderGGUF",
@@ -1241,7 +1248,9 @@
                 "IPAdapterWeightsFromStrategy",
                 "PrepImageForClipVision"
             ],
-            "pip": ["insightface"],
+            "pip": [
+                "insightface"
+            ],
             "install_type": "git-clone",
             "description": "ComfyUI reference implementation for IPAdapter models. The code is mostly taken from the original IPAdapter repository and laksjdjf's implementation, all credit goes to them. I just made the extension closer to ComfyUI philosophy."
         },
@@ -1437,7 +1446,10 @@
             "files": [
                 "https://github.com/andersxa/comfyui-PromptAttention"
             ],
-            "pip": ["scikit-learn", "matplotlib"],
+            "pip": [
+                "scikit-learn",
+                "matplotlib"
+            ],
             "install_type": "git-clone",
             "description": "Nodes: CLIP Directional Prompt Attention Encode. Direction prompt attention tries to solve the problem of contextual words (or parts of the prompt) having an effect on much later or irrelevant parts of the prompt."
         },
@@ -1445,7 +1457,9 @@
             "author": "ArtVentureX",
             "title": "AnimateDiff",
             "reference": "https://github.com/SipherAGI/comfyui-animatediff",
-            "pip": ["flash_attn"],
+            "pip": [
+                "flash_attn"
+            ],
             "files": [
                 "https://github.com/SipherAGI/comfyui-animatediff"
             ],
@@ -2489,7 +2503,9 @@
                 "https://github.com/Ttl/ComfyUi_NNLatentUpscale"
             ],
             "install_type": "git-clone",
-            "preemptions": ["NNLatentUpscale"],
+            "preemptions": [
+                "NNLatentUpscale"
+            ],
             "description": "Nodes:NNLatentUpscale, A custom ComfyUI node designed for rapid latent upscaling using a compact neural network, eliminating the need for VAE-based decoding and encoding."
         },
         {
@@ -2541,7 +2557,9 @@
             "title": "comfy_PoP",
             "id": "pop",
             "reference": "https://github.com/picturesonpictures/comfy_PoP",
-            "files": ["https://github.com/picturesonpictures/comfy_PoP"],
+            "files": [
+                "https://github.com/picturesonpictures/comfy_PoP"
+            ],
             "install_type": "git-clone",
             "description": "A collection of custom nodes for ComfyUI. Includes a quick canny edge detection node with unconventional settings, simple LoRA stack nodes for workflow efficiency, and a customizable aspect ratio node."
         },
@@ -3150,7 +3168,7 @@
             "files": [
                 "https://github.com/kijai/ComfyUI-Florence2"
             ],
-            "preemptions":[
+            "preemptions": [
                 "DownloadAndLoadFlorence2Lora",
                 "DownloadAndLoadFlorence2Model",
                 "Florence2ModelLoader",
@@ -3222,7 +3240,7 @@
             "files": [
                 "https://github.com/kijai/ComfyUI-segment-anything-2"
             ],
-            "preemptions":[
+            "preemptions": [
                 "DownloadAndLoadSAM2Model",
                 "Florence2toCoordinates",
                 "Sam2AutoSegmentation",
@@ -4856,9 +4874,13 @@
             "author": "vanillacode314",
             "title": "Simple Wildcard",
             "reference": "https://github.com/vanillacode314/SimpleWildcardsComfyUI",
-            "files": ["https://github.com/vanillacode314/SimpleWildcardsComfyUI"],
+            "files": [
+                "https://github.com/vanillacode314/SimpleWildcardsComfyUI"
+            ],
             "install_type": "git-clone",
-            "pip": ["pipe"],
+            "pip": [
+                "pipe"
+            ],
             "description": "A simple wildcard node for ComfyUI. Can also be used a style prompt node."
         },
         {
@@ -5008,7 +5030,9 @@
             "files": [
                 "https://github.com/ningxiaoxiao/comfyui-NDI"
             ],
-            "pip": ["ndi-python"],
+            "pip": [
+                "ndi-python"
+            ],
             "install_type": "git-clone",
             "description": "Real-time input output node for ComfyUI by NDI. Leveraging the powerful linking capabilities of NDI, you can access NDI video stream frames and send images generated by the model to NDI video streams."
         },
@@ -6047,7 +6071,9 @@
             "title": "ComfyUI-Paint-by-Example",
             "id": "paint-by-example",
             "reference": "https://github.com/Kangkang625/ComfyUI-paint-by-example",
-            "pip": ["diffusers"],
+            "pip": [
+                "diffusers"
+            ],
             "files": [
                 "https://github.com/Kangkang625/ComfyUI-paint-by-example"
             ],
@@ -6955,7 +6981,9 @@
             "files": [
                 "https://github.com/aws-samples/comfyui-llm-node-for-amazon-bedrock"
             ],
-            "pip": ["boto3"],
+            "pip": [
+                "boto3"
+            ],
             "install_type": "git-clone",
             "description": "Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models (FMs) from leading AI companies. This repo is the ComfyUI nodes for Bedrock service. You could invoke the foundation model in your ComfyUI pipeline."
         },
@@ -7350,7 +7378,7 @@
             "title": "comfyui_overly_complicated_sampling",
             "reference": "https://github.com/blepping/comfyui_overly_complicated_sampling",
             "files": [
-                  "https://github.com/blepping/comfyui_overly_complicated_sampling"
+                "https://github.com/blepping/comfyui_overly_complicated_sampling"
             ],
             "install_type": "git-clone",
             "description": "Experimental and mathematically unsound (but fun!) sampling for ComfyUI.\nFeel free create a question in Discussions for usage help: OCS Q&A Discussion[w/Status: In flux, may be useful but likely to change/break workflows frequently. Mainly for advanced users.]"
@@ -7360,7 +7388,7 @@
             "title": "ComfyUI-ApplyResAdapterUnet",
             "reference": "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet",
             "files": [
-                  "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet"
+                "https://github.com/blepping/ComfyUI-ApplyResAdapterUnet"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI node to apply the ResAdapter Unet patch for SD1.5 models"
@@ -9552,7 +9580,7 @@
             "id": "impactframes-videoprompts",
             "reference": "https://github.com/if-ai/ComfyUI-IF_VideoPrompts",
             "files": [
-              "https://github.com/if-ai/ComfyUI-IF_VideoPrompts"
+                "https://github.com/if-ai/ComfyUI-IF_VideoPrompts"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI extension for video-based prompting and processing with support for various models and video processing capabilities"
@@ -9563,7 +9591,7 @@
             "id": "impactframes-llm",
             "reference": "https://github.com/if-ai/ComfyUI-IF_LLM",
             "files": [
-              "https://github.com/if-ai/ComfyUI-IF_LLM"
+                "https://github.com/if-ai/ComfyUI-IF_LLM"
             ],
             "install_type": "git-clone",
             "description": "Run Local and API LLMs, Features Conditioning manipulation via Omost, supports Ollama, LlamaCPP LMstudio, Koboldcpp, TextGen, Transformers or via APIs Anthropic, Groq, OpenAI, Google Gemini, Mistral, xAI and create your own charcters assistants (SystemPrompts) with custom presets and muchmore"
@@ -9574,7 +9602,7 @@
             "id": "impactframes-loadimages",
             "reference": "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages",
             "files": [
-              "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages"
+                "https://github.com/if-ai/ComfyUI_IF_AI_LoadImages"
             ],
             "install_type": "git-clone",
             "description": "It Load Images with subfolders form arbitrary folders previous on node outputs lists- convinient selection via file browser"
@@ -9890,7 +9918,9 @@
             "title": "ComfyUI-RGT",
             "id": "rgt",
             "reference": "https://github.com/viperyl/ComfyUI-RGT",
-            "pip": ["loguru"],
+            "pip": [
+                "loguru"
+            ],
             "files": [
                 "https://github.com/viperyl/ComfyUI-RGT"
             ],
@@ -12116,7 +12146,9 @@
             "files": [
                 "https://github.com/MinusZoneAI/ComfyUI-Flux1Quantize-MZ"
             ],
-            "pip": ["git+https://github.com/IST-DASLab/marlin"],
+            "pip": [
+                "git+https://github.com/IST-DASLab/marlin"
+            ],
             "install_type": "git-clone",
             "description": "Quantization tools are from [a/https://github.com/casper-hansen/AutoAWQ](https://github.com/casper-hansen/AutoAWQ) and [a/https://github.com/IST-DASLab/marlin](https://github.com/IST-DASLab/marlin)\nOnly applicable to graphics cards with sm_80 and above (30 series and above)\nNeed to install marlin dependencies first"
         },
@@ -13790,9 +13822,9 @@
             "reference": "https://github.com/risunobushi/ComfyUI_DisplacementMapTools",
             "files": [
                 "https://github.com/risunobushi/ComfyUI_DisplacementMapTools"
-             ],
-             "install_type": "git-clone",
-             "description": "NODES: Extract Displacement Map Node, Displace Logo"
+            ],
+            "install_type": "git-clone",
+            "description": "NODES: Extract Displacement Map Node, Displace Logo"
         },
         {
             "author": "risunobushi",
@@ -16784,8 +16816,7 @@
             "title": "ControlAltAI Nodes",
             "id": "controlaltai",
             "reference": "https://github.com/gseth/ControlAltAI-Nodes",
-            "files":
-            [
+            "files": [
                 "https://github.com/gseth/ControlAltAI-Nodes"
             ],
             "install_type": "git-clone",
@@ -17783,15 +17814,15 @@
             "description": "This repository encapsulates the BAGEL model as ComfyUI nodes for use, including image editing and image inversion features, but it does not include text-to-image functionality."
         },
         {
-           "author": "GrenKain",
-           "title": "PixelArt Processing Nodes",
-           "id": "gk_pixelart",
-           "reference": "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI",
-           "files": [
-               "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI"
-           ],
-           "install_type": "git-clone",
-           "description": "This repository provides custom nodes for ComfyUI that enable pixel art style image processing, including downscaling, upscaling, color quantization, and resolution adjustments."
+            "author": "GrenKain",
+            "title": "PixelArt Processing Nodes",
+            "id": "gk_pixelart",
+            "reference": "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI",
+            "files": [
+                "https://github.com/GENKAIx/PixelArt-Processing-Nodes-for-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "This repository provides custom nodes for ComfyUI that enable pixel art style image processing, including downscaling, upscaling, color quantization, and resolution adjustments."
         },
         {
             "author": "Trgtuan10",
@@ -18007,7 +18038,9 @@
             "files": [
                 "https://github.com/MetaGLM/ComfyUI-ZhipuAI-Platform"
             ],
-            "pip": ["zhipuai-platform-video"],
+            "pip": [
+                "zhipuai-platform-video"
+            ],
             "install_type": "git-clone",
             "description": "This platform extension provides ZhipuAI nodes, enabling you to configure a workflow for online video generation."
         },
@@ -18467,15 +18500,15 @@
             "description": "Custom nodes for MiniCPM language models in ComfyUI. Provides advanced text generation and image understanding functions."
         },
         {
-             "author": "CY-CHENYUE",
-             "title": "ComfyUI-Molmo",
-             "id": "comfyui-molmo",
-             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Molmo",
-             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Molmo"
-             ],
-             "install_type": "git-clone",
-             "description": "Use of the molmo model.Generate detailed image descriptions and analysis using Molmo models in ComfyUI."
+            "author": "CY-CHENYUE",
+            "title": "ComfyUI-Molmo",
+            "id": "comfyui-molmo",
+            "reference": "https://github.com/CY-CHENYUE/ComfyUI-Molmo",
+            "files": [
+                "https://github.com/CY-CHENYUE/ComfyUI-Molmo"
+            ],
+            "install_type": "git-clone",
+            "description": "Use of the molmo model.Generate detailed image descriptions and analysis using Molmo models in ComfyUI."
         },
         {
             "author": "CY-CHENYUE",
@@ -18483,9 +18516,13 @@
             "id": "ComfyUI-InpaintEasy",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy"
+                "https://github.com/CY-CHENYUE/ComfyUI-InpaintEasy"
             ],
-            "tags": ["inpaint", "crop", "image"],
+            "tags": [
+                "inpaint",
+                "crop",
+                "image"
+            ],
             "install_type": "git-clone",
             "description": "InpaintEasy is a set of optimized local repainting (Inpaint) nodes that provide a simpler and more powerful local repainting workflow. It makes local repainting work easier and more efficient with intelligent cropping and merging functions."
         },
@@ -18495,7 +18532,7 @@
             "id": "ComfyUI-OmniGenX",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX"
+                "https://github.com/CY-CHENYUE/ComfyUI-OmniGenX"
             ],
             "install_type": "git-clone",
             "description": "OmniGen Unified Image Generation Model Integration."
@@ -18506,9 +18543,13 @@
             "id": "ComfyUI-Redux-Prompt",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt"
+                "https://github.com/CY-CHENYUE/ComfyUI-Redux-Prompt"
             ],
-            "tags": ["Flux", "redux", "prompt"],
+            "tags": [
+                "Flux",
+                "redux",
+                "prompt"
+            ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node that provides fine-grained control over style transfer using Redux style models."
         },
@@ -18518,7 +18559,7 @@
             "id": "ComfyUI-MiniCPM-o",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o"
+                "https://github.com/CY-CHENYUE/ComfyUI-MiniCPM-o"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for MiniCPM"
@@ -18529,7 +18570,7 @@
             "id": "ComfyUI-Janus-Pro",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro"
+                "https://github.com/CY-CHENYUE/ComfyUI-Janus-Pro"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Janus-Pro, a unified multimodal understanding and generation framework."
@@ -18540,7 +18581,7 @@
             "id": "ComfyUI-Free-GPU",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU"
+                "https://github.com/CY-CHENYUE/ComfyUI-Free-GPU"
             ],
             "description": "ComfyUI-Free-GPU provides a node for releasing RAM and VRAM in ComfyUI.",
             "install_type": "git-clone"
@@ -18551,7 +18592,7 @@
             "id": "ComfyUI-Gemini-API",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API"
+                "https://github.com/CY-CHENYUE/ComfyUI-Gemini-API"
             ],
             "description": "A custom node for ComfyUI to integrate Google Gemini API.",
             "install_type": "git-clone"
@@ -18562,7 +18603,7 @@
             "id": "ComfyUI-GPT-API",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-GPT-API",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-GPT-API"
+                "https://github.com/CY-CHENYUE/ComfyUI-GPT-API"
             ],
             "description": "A custom node for ComfyUI to integrate GPT API.",
             "install_type": "git-clone"
@@ -18573,7 +18614,7 @@
             "id": "ComfyUI-FramePack-HY",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY"
+                "https://github.com/CY-CHENYUE/ComfyUI-FramePack-HY"
             ],
             "description": "A custom node for ComfyUI to FramePack.",
             "install_type": "git-clone"
@@ -18584,7 +18625,7 @@
             "id": "ComfyUI-ImageCompositionCy",
             "reference": "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy",
             "files": [
-               "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy"
+                "https://github.com/CY-CHENYUE/ComfyUI-ImageCompositionCy"
             ],
             "description": "A powerful ComfyUI multi-image composition node that supports real-time adjustment of image position, size, and rotation angle on an interactive Canvas, with freehand drawing capabilities and real-time preview of composition effects.",
             "install_type": "git-clone"
@@ -19586,7 +19627,9 @@
             "files": [
                 "https://github.com/TZOOTZ/ComfyUI-TZOOTZ_VHS"
             ],
-            "pip": ["numpy<2"],
+            "pip": [
+                "numpy<2"
+            ],
             "install_type": "git-clone",
             "description": "The TZOOTZ VHS Effect Node is designed for multimedia creators who want to blend digital precision with analog imperfection ↔️. Inspired by retro VHS aesthetics, this node lets you apply grain, color bleeding, saturation adjustments, and more, giving any image a touch of analog warmth and noise."
         },
@@ -19805,211 +19848,211 @@
             "description": "Fork of [a/sd_webui_stealth_pnginfo](https://github.com/ashen-sensored/sd_webui_stealth_pnginfo) with ComfyUI support."
         },
         {
-           "author": "dafeng012",
-           "title": "comfyui-imgmake",
-           "reference": "https://github.com/dafeng012/comfyui-imgmake",
-           "files": [
-               "https://github.com/dafeng012/comfyui-imgmake"
-           ],
-           "install_type": "git-clone",
-           "description": "This extension integrates ebsynth_utility into comfyui, and I've written some of my own nodes for secondary use."
-       },
-       {
-           "author": "zubenelakrab",
-           "title": "ComfyUI-ASV-Nodes Node",
-           "id": "ComfyUI-ASV-Nodes",
-           "reference": "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes",
-           "files": [
-               "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes"
-           ],
-           "install_type": "git-clone",
-           "description": "ComfyUI-ASV-Nodes make prompting easier."
-       },
-       {
-           "author": "zubenelakrab",
-           "title": "ComfyUI Neural Nodes",
-           "reference": "https://github.com/xobiomesh/ComfyUI_xObiomesh",
-           "files": [
-               "https://github.com/xobiomesh/ComfyUI_xObiomesh"
-           ],
-           "install_type": "git-clone",
-           "description": "An advanced ComfyUI extension that enables multi-agent LLM conversations using Ollama models."
-       },
-       {
-           "author": "KohakuBlueleaf",
-           "title": "TIPO-extension",
-           "reference": "https://github.com/KohakuBlueleaf/z-tipo-extension",
-           "files": [
-               "https://github.com/KohakuBlueleaf/z-tipo-extension"
-           ],
-           "install_type": "git-clone",
-           "description": "A general extension to utilize TIPO or DanTagGen to do 'text-presampling' based on KGen library: [a/https://github.com/KohakuBlueleaf/KGen](https://github.com/KohakuBlueleaf/KGen)"
-       },
-       {
-           "author": "KohakuBlueleaf",
-           "title": "HDM-ext",
-           "id": "HDM",
-           "reference": "https://github.com/KohakuBlueleaf/HDM-ext",
-           "files": [
-               "https://github.com/KohakuBlueleaf/HDM-ext"
-           ],
-           "install_type": "git-clone",
-           "description": "HDM model loader for ComfyUI"
-       },
-       {
-           "author": "hanoixan",
-           "title": "ComfyUI DataBeast",
-           "reference": "https://github.com/hanoixan/ComfyUI-DataBeast",
-           "files": [
-               "https://github.com/hanoixan/ComfyUI-DataBeast"
-           ],
-           "install_type": "git-clone",
-           "description": "This extension provides convenience nodes for batch processing."
-       },
-       {
-           "author": "HelloVision",
-           "title": "ComfyUI_HelloMeme",
-           "reference": "https://github.com/HelloVision/ComfyUI_HelloMeme",
-           "files": [
-               "https://github.com/HelloVision/ComfyUI_HelloMeme"
-           ],
-           "install_type": "git-clone",
-           "description": "This repository is the official implementation of the [a/HelloMeme](https://arxiv.org/pdf/2410.22901) ComfyUI interface, featuring both image and video generation functionalities. Example workflow files can be found in the ComfyUI_HelloMeme/workflows directory. Test images and videos are saved in the ComfyUI_HelloMeme/examples directory. Below are screenshots of the interfaces for image and video generation.\nNOTE: 'HelloMeme: Integrating Spatial Knitting Attentions to Embed High-Level and Fidelity-Rich Conditions in Diffusion Models'"
-       },
-       {
-           "author": "recraftai",
-           "title": "ComfyUI-RecraftAI",
-           "id": "comfyui-recraftai",
-           "reference": "https://github.com/recraft-ai/ComfyUI-RecraftAI",
-           "files": [
-               "https://github.com/recraft-ai/ComfyUI-RecraftAI"
-           ],
-           "install_type": "git-clone",
-           "description": "Recraft AI API Custom Nodes"
-       },
-       {
-           "author": "basix",
-           "title": "Basix Image Filters",
-           "id": "basix_image_filters",
-           "reference": "https://github.com/maludwig/basix_image_filters",
-           "files": [
-               "https://github.com/maludwig/basix_image_filters"
-           ],
-           "install_type": "git-clone",
-           "description": "A handful of image filters for ComfyUI (darken, lighten, levels, saturate, hue)"
-       },
-       {
-           "author": "Frost Ming",
-           "title": "Comfy-Pack",
-           "reference": "https://github.com/bentoml/comfy-pack",
-           "files": [
-              "https://github.com/bentoml/comfy-pack"
-           ],
-           "description": "A comprehensive toolkit for standardizing, packaging and deploying ComfyUI workflows as reproducible environments and production-ready REST services",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "Poseidon-fan",
-           "title": "ComfyUI-RabbitMQ-Publisher",
-           "reference": "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher",
-           "files": [
-              "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher"
-           ],
-           "description": "ComfyUI custom_node that publish output image to rabbit_mq",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "1zhangyy1",
-           "title": "ComfyUI VIDU",
-           "reference": "https://github.com/1zhangyy1/comfyui-vidu-nodes",
-           "files": [
-              "https://github.com/1zhangyy1/comfyui-vidu-nodes"
-           ],
-           "description": "This is a ComfyUI node package that integrates with VIDU API, supporting features such as text-to-video, image-to-video, character-to-video generation, and video super-resolution.",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "LevelPixel",
-           "title": "ComfyUI Level Pixel",
-           "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel",
-           "files": [
-               "https://github.com/LevelPixel/ComfyUI-LevelPixel"
-           ],
-           "install_type": "git-clone",
-           "description": "Main nodes of the Level Pixel company (aka levelpixel, LP). Includes convenient nodes for working with images from folders; counting files in a folder; cleaning memory; tag filters. Model Unloader, LLM Unloader, Free memory, Tag Filters, Tag Category Filters, Tag Choice Parser, File counter, Image Loader From Path (with counters), Image Remove Background based on RemBG, Autotagger."
-       },
-       {
-           "author": "LevelPixel",
-           "title": "ComfyUI Level Pixel Advanced",
-           "id": "comfyui-levelpixel-advanced",
-           "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced",
-           "files": [
-               "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced"
-           ],
-           "install_type": "git-clone",
-           "description": "Advanced nodes of the Level Pixel company (levelpixel, LP). Includes convenient advanced nodes for working with LLM и VLM models (LLaVa) with GGUF format. Qwen2.5-VL and Qwen2.5 supported. Also included is a node for the RAM model. Nodes have the ability to automatically unload models from VRAM."
-       },
-       {
-           "author": "morino-kumasan",
-           "title": "comfyui-toml-prompt",
-           "reference": "https://github.com/morino-kumasan/comfyui-toml-prompt",
-           "files": [
-              "https://github.com/morino-kumasan/comfyui-toml-prompt"
-           ],
-           "install_type": "git-clone",
-           "description": "Encode Prompt in TOML for ComfyUI."
-       },
-       {
-           "author": "wentao-uw",
-           "title": "ComfyUI template matching",
-           "reference": "https://github.com/wentao-uw/ComfyUI-template-matching",
-           "files": [
-              "https://github.com/wentao-uw/ComfyUI-template-matching"
-           ],
-           "description": "This project is a ComfyUI version of [a/https://github.com/cozheyuanzhangde/Invariant-TemplateMatching](https://github.com/cozheyuanzhangde/Invariant-TemplateMatching).",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "w00dycomfyuirun",
-           "title": "ComfyUI_Appstore",
-           "id": "ComfyUI_Appstore",
-           "reference": "https://github.com/ronaldzgithub/ComfyUI_Appstore",
-           "files": [
-               "https://github.com/ronaldzgithub/ComfyUI_Appstore"
-           ],
-           "install_type": "git-clone",
-           "description": "ComfyUI_Appstore, a tool that converts ComfyUI workflows into web apps on huaxiaobao.net with one click, and supports payments, like ComfyUI_Bxb (Bxb) does. Providing a way for the comfyui authors to get profit from."
-       },
-       {
-           "author": "kycg",
-           "title": "Kw_Json_Lora_CivitAIDownloader",
-           "reference": "https://github.com/kycg/comfyui-Lora-auto-downloader",
-           "files": [
-              "https://github.com/kycg/comfyui-Lora-auto-downloader"
-           ],
-           "description": "This tool allows you to download models from CivitAI based on a JSON configuration that defines LORA and checkpoint models. It uses token-based authentication to download files from specified URLs and saves them to specified directories. based on CivitAIDownloader",
-           "install_type": "git-clone"
-       },
-       {
-           "author": "VangengLab",
-           "title": "ComfyUI-LivePortrait_v2",
-           "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v2",
-           "files": [
-               "https://github.com/VangengLab/ComfyUI-LivePortrait_v2"
-           ],
-           "install_type": "git-clone",
-           "description": "We developed a custom_node for Liveportrait_v2 that enables flexible use on Comfyui to drive animal image-based emoji generation from videos."
-       },
-       {
-           "author": "VangengLab",
-           "title": "ComfyUI-LivePortrait_v3",
-           "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v3",
-           "files": [
-               "https://github.com/VangengLab/ComfyUI-LivePortrait_v3"
-           ],
-           "install_type": "git-clone",
-           "description": "We developed a custom_node for Liveportrait_v3 that enables flexible use on Comfyui to drive image-based emoji generation from photos."
-       },
+            "author": "dafeng012",
+            "title": "comfyui-imgmake",
+            "reference": "https://github.com/dafeng012/comfyui-imgmake",
+            "files": [
+                "https://github.com/dafeng012/comfyui-imgmake"
+            ],
+            "install_type": "git-clone",
+            "description": "This extension integrates ebsynth_utility into comfyui, and I've written some of my own nodes for secondary use."
+        },
+        {
+            "author": "zubenelakrab",
+            "title": "ComfyUI-ASV-Nodes Node",
+            "id": "ComfyUI-ASV-Nodes",
+            "reference": "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes",
+            "files": [
+                "https://github.com/zubenelakrab/ComfyUI-ASV-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-ASV-Nodes make prompting easier."
+        },
+        {
+            "author": "zubenelakrab",
+            "title": "ComfyUI Neural Nodes",
+            "reference": "https://github.com/xobiomesh/ComfyUI_xObiomesh",
+            "files": [
+                "https://github.com/xobiomesh/ComfyUI_xObiomesh"
+            ],
+            "install_type": "git-clone",
+            "description": "An advanced ComfyUI extension that enables multi-agent LLM conversations using Ollama models."
+        },
+        {
+            "author": "KohakuBlueleaf",
+            "title": "TIPO-extension",
+            "reference": "https://github.com/KohakuBlueleaf/z-tipo-extension",
+            "files": [
+                "https://github.com/KohakuBlueleaf/z-tipo-extension"
+            ],
+            "install_type": "git-clone",
+            "description": "A general extension to utilize TIPO or DanTagGen to do 'text-presampling' based on KGen library: [a/https://github.com/KohakuBlueleaf/KGen](https://github.com/KohakuBlueleaf/KGen)"
+        },
+        {
+            "author": "KohakuBlueleaf",
+            "title": "HDM-ext",
+            "id": "HDM",
+            "reference": "https://github.com/KohakuBlueleaf/HDM-ext",
+            "files": [
+                "https://github.com/KohakuBlueleaf/HDM-ext"
+            ],
+            "install_type": "git-clone",
+            "description": "HDM model loader for ComfyUI"
+        },
+        {
+            "author": "hanoixan",
+            "title": "ComfyUI DataBeast",
+            "reference": "https://github.com/hanoixan/ComfyUI-DataBeast",
+            "files": [
+                "https://github.com/hanoixan/ComfyUI-DataBeast"
+            ],
+            "install_type": "git-clone",
+            "description": "This extension provides convenience nodes for batch processing."
+        },
+        {
+            "author": "HelloVision",
+            "title": "ComfyUI_HelloMeme",
+            "reference": "https://github.com/HelloVision/ComfyUI_HelloMeme",
+            "files": [
+                "https://github.com/HelloVision/ComfyUI_HelloMeme"
+            ],
+            "install_type": "git-clone",
+            "description": "This repository is the official implementation of the [a/HelloMeme](https://arxiv.org/pdf/2410.22901) ComfyUI interface, featuring both image and video generation functionalities. Example workflow files can be found in the ComfyUI_HelloMeme/workflows directory. Test images and videos are saved in the ComfyUI_HelloMeme/examples directory. Below are screenshots of the interfaces for image and video generation.\nNOTE: 'HelloMeme: Integrating Spatial Knitting Attentions to Embed High-Level and Fidelity-Rich Conditions in Diffusion Models'"
+        },
+        {
+            "author": "recraftai",
+            "title": "ComfyUI-RecraftAI",
+            "id": "comfyui-recraftai",
+            "reference": "https://github.com/recraft-ai/ComfyUI-RecraftAI",
+            "files": [
+                "https://github.com/recraft-ai/ComfyUI-RecraftAI"
+            ],
+            "install_type": "git-clone",
+            "description": "Recraft AI API Custom Nodes"
+        },
+        {
+            "author": "basix",
+            "title": "Basix Image Filters",
+            "id": "basix_image_filters",
+            "reference": "https://github.com/maludwig/basix_image_filters",
+            "files": [
+                "https://github.com/maludwig/basix_image_filters"
+            ],
+            "install_type": "git-clone",
+            "description": "A handful of image filters for ComfyUI (darken, lighten, levels, saturate, hue)"
+        },
+        {
+            "author": "Frost Ming",
+            "title": "Comfy-Pack",
+            "reference": "https://github.com/bentoml/comfy-pack",
+            "files": [
+                "https://github.com/bentoml/comfy-pack"
+            ],
+            "description": "A comprehensive toolkit for standardizing, packaging and deploying ComfyUI workflows as reproducible environments and production-ready REST services",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "Poseidon-fan",
+            "title": "ComfyUI-RabbitMQ-Publisher",
+            "reference": "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher",
+            "files": [
+                "https://github.com/Poseidon-fan/ComfyUI-RabbitMQ-Publisher"
+            ],
+            "description": "ComfyUI custom_node that publish output image to rabbit_mq",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "1zhangyy1",
+            "title": "ComfyUI VIDU",
+            "reference": "https://github.com/1zhangyy1/comfyui-vidu-nodes",
+            "files": [
+                "https://github.com/1zhangyy1/comfyui-vidu-nodes"
+            ],
+            "description": "This is a ComfyUI node package that integrates with VIDU API, supporting features such as text-to-video, image-to-video, character-to-video generation, and video super-resolution.",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "LevelPixel",
+            "title": "ComfyUI Level Pixel",
+            "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel",
+            "files": [
+                "https://github.com/LevelPixel/ComfyUI-LevelPixel"
+            ],
+            "install_type": "git-clone",
+            "description": "Main nodes of the Level Pixel company (aka levelpixel, LP). Includes convenient nodes for working with images from folders; counting files in a folder; cleaning memory; tag filters. Model Unloader, LLM Unloader, Free memory, Tag Filters, Tag Category Filters, Tag Choice Parser, File counter, Image Loader From Path (with counters), Image Remove Background based on RemBG, Autotagger."
+        },
+        {
+            "author": "LevelPixel",
+            "title": "ComfyUI Level Pixel Advanced",
+            "id": "comfyui-levelpixel-advanced",
+            "reference": "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced",
+            "files": [
+                "https://github.com/LevelPixel/ComfyUI-LevelPixel-Advanced"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced nodes of the Level Pixel company (levelpixel, LP). Includes convenient advanced nodes for working with LLM и VLM models (LLaVa) with GGUF format. Qwen2.5-VL and Qwen2.5 supported. Also included is a node for the RAM model. Nodes have the ability to automatically unload models from VRAM."
+        },
+        {
+            "author": "morino-kumasan",
+            "title": "comfyui-toml-prompt",
+            "reference": "https://github.com/morino-kumasan/comfyui-toml-prompt",
+            "files": [
+                "https://github.com/morino-kumasan/comfyui-toml-prompt"
+            ],
+            "install_type": "git-clone",
+            "description": "Encode Prompt in TOML for ComfyUI."
+        },
+        {
+            "author": "wentao-uw",
+            "title": "ComfyUI template matching",
+            "reference": "https://github.com/wentao-uw/ComfyUI-template-matching",
+            "files": [
+                "https://github.com/wentao-uw/ComfyUI-template-matching"
+            ],
+            "description": "This project is a ComfyUI version of [a/https://github.com/cozheyuanzhangde/Invariant-TemplateMatching](https://github.com/cozheyuanzhangde/Invariant-TemplateMatching).",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "w00dycomfyuirun",
+            "title": "ComfyUI_Appstore",
+            "id": "ComfyUI_Appstore",
+            "reference": "https://github.com/ronaldzgithub/ComfyUI_Appstore",
+            "files": [
+                "https://github.com/ronaldzgithub/ComfyUI_Appstore"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI_Appstore, a tool that converts ComfyUI workflows into web apps on huaxiaobao.net with one click, and supports payments, like ComfyUI_Bxb (Bxb) does. Providing a way for the comfyui authors to get profit from."
+        },
+        {
+            "author": "kycg",
+            "title": "Kw_Json_Lora_CivitAIDownloader",
+            "reference": "https://github.com/kycg/comfyui-Lora-auto-downloader",
+            "files": [
+                "https://github.com/kycg/comfyui-Lora-auto-downloader"
+            ],
+            "description": "This tool allows you to download models from CivitAI based on a JSON configuration that defines LORA and checkpoint models. It uses token-based authentication to download files from specified URLs and saves them to specified directories. based on CivitAIDownloader",
+            "install_type": "git-clone"
+        },
+        {
+            "author": "VangengLab",
+            "title": "ComfyUI-LivePortrait_v2",
+            "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v2",
+            "files": [
+                "https://github.com/VangengLab/ComfyUI-LivePortrait_v2"
+            ],
+            "install_type": "git-clone",
+            "description": "We developed a custom_node for Liveportrait_v2 that enables flexible use on Comfyui to drive animal image-based emoji generation from videos."
+        },
+        {
+            "author": "VangengLab",
+            "title": "ComfyUI-LivePortrait_v3",
+            "reference": "https://github.com/VangengLab/ComfyUI-LivePortrait_v3",
+            "files": [
+                "https://github.com/VangengLab/ComfyUI-LivePortrait_v3"
+            ],
+            "install_type": "git-clone",
+            "description": "We developed a custom_node for Liveportrait_v3 that enables flexible use on Comfyui to drive image-based emoji generation from photos."
+        },
         {
             "author": "Comflowy",
             "title": "Comflowy's Custom Nodes",
@@ -21512,7 +21555,7 @@
             "title": "ComfyUI-MVAdapter",
             "reference": "https://github.com/huanngzh/ComfyUI-MVAdapter",
             "files": [
-               "https://github.com/huanngzh/ComfyUI-MVAdapter"
+                "https://github.com/huanngzh/ComfyUI-MVAdapter"
             ],
             "description": "This extension integrates [a/MV-Adapter](https://github.com/huanngzh/MV-Adapter) into ComfyUI, allowing users to generate multi-view consistent images from text prompts or single images directly within the ComfyUI interface.",
             "install_type": "git-clone"
@@ -21522,7 +21565,7 @@
             "title": "ComfyUI-Seed-Nodes",
             "reference": "https://github.com/Aerse/ComfyUI-Seed-Nodes",
             "files": [
-               "https://github.com/Aerse/ComfyUI-Seed-Nodes"
+                "https://github.com/Aerse/ComfyUI-Seed-Nodes"
             ],
             "description": "ComfyUI-Seed-Nodes is a custom node library that extends the functionality of ComfyUI, offering advanced image loading and pixelation tools.",
             "install_type": "git-clone"
@@ -21532,7 +21575,7 @@
             "title": "ComfyUI-InstantX-IPAdapter-SD3",
             "reference": "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3",
             "files": [
-               "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3"
+                "https://github.com/Slickytail/ComfyUI-InstantX-IPAdapter-SD3"
             ],
             "description": "ComfyUI implementation of the [a/InstantX IP-Adapter for SD3.5 Large](https://huggingface.co/InstantX/SD3.5-Large-IP-Adapter).",
             "install_type": "git-clone"
@@ -21542,7 +21585,7 @@
             "title": "ComfyUI-RegionalAdaptiveSampling",
             "reference": "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling",
             "files": [
-               "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling"
+                "https://github.com/Slickytail/ComfyUI-RegionalAdaptiveSampling"
             ],
             "description": "ComfyUI implementation of Regional Adaptive Sampling, (original implementation at https://github.com/microsoft/RAS).",
             "install_type": "git-clone"
@@ -21553,7 +21596,7 @@
             "reference": "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl",
             "reference2": "https://github.com/sourceful-official/ComfyUI_LoadLoraModelOnlyWithUrl",
             "files": [
-               "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl"
+                "https://github.com/sourceful-official/LoadLoraModelOnlyWithUrl"
             ],
             "description": "ComfyUI-LoadLoraModelOnlyWithUrl",
             "install_type": "git-clone"
@@ -21563,7 +21606,7 @@
             "title": "Kimara.ai's Advanced Watermarking Tools",
             "reference": "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks",
             "files": [
-               "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks"
+                "https://github.com/kimara-ai/ComfyUI-Kimara-AI-Advanced-Watermarks"
             ],
             "description": "The KimaraAIWatermarker custom node allows you to apply watermark text and logo overlays to images. Optionally, the watermark can be moved by the move_watermark_step amount of pixels after each generated image. To apply a moving watermark to a list of images, use the KimaraAIBatchImages node to concatenate the list into a single tensor, then use that as an input for the watermark node, as shown in the example image below.",
             "install_type": "git-clone"
@@ -22377,7 +22420,10 @@
             "files": [
                 "https://github.com/ciga2011/ComfyUI-MarkItDown"
             ],
-            "pip": ["markitdown", "openai"],
+            "pip": [
+                "markitdown",
+                "openai"
+            ],
             "install_type": "git-clone",
             "description": "This node pack helps to convert various files to Markdown. It supports pdf, pptx, xlsx, docx, html and image files."
         },
@@ -22432,7 +22478,9 @@
             "files": [
                 "https://github.com/jurdnisglobby/ComfyUI-Jurdns-Groq-Node"
             ],
-            "pip": ["groq"],
+            "pip": [
+                "groq"
+            ],
             "install_type": "git-clone",
             "description": "This node utilizes the Groq.com API to enhance prompts. (Place API key and main system prompt in the groq_config.json)"
         },
@@ -23030,7 +23078,7 @@
             "files": [
                 "https://github.com/calcuis/gguf"
             ],
-            "preemptions":[
+            "preemptions": [
                 "LoaderGGUF",
                 "ClipLoaderGGUF",
                 "DualClipLoaderGGUF",
@@ -23547,7 +23595,7 @@
             "description": "A custom node for ComfyUI that generates creative and detailed prompts using OpenAI's GPT models."
         },
         {
-            "author" : "ngosset",
+            "author": "ngosset",
             "title": "ImageSimilarity",
             "id": "imageSimilarity",
             "reference": "https://github.com/ngosset/ComfyUI-ImageSimilarity",
@@ -23568,7 +23616,7 @@
             "description": "The plug-in is designed to automatically save the association between the LoRA model and Trigger words to a Local JSON file so that when the LoRA model is loaded, the associated trigger words can be automatically loaded via the node 'LoRA Trigger Local' without manual input."
         },
         {
-            "author" : "strand1",
+            "author": "strand1",
             "title": "ComfyUI-Autogen",
             "reference": "https://github.com/strand1/ComfyUI-Autogen",
             "files": [
@@ -23829,9 +23877,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-DatasetHelper",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-DatasetHelper"
-             ],
-             "install_type": "git-clone",
-             "description": "This custom node set for ComfyUI provides a DatasetBatchNode for automated, sequential processing of datasets, particularly useful for iterative training or batched image/video generation workflows."
+            ],
+            "install_type": "git-clone",
+            "description": "This custom node set for ComfyUI provides a DatasetBatchNode for automated, sequential processing of datasets, particularly useful for iterative training or batched image/video generation workflows."
         },
         {
             "author": "fblissjr",
@@ -23839,9 +23887,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-WanSeamlessFlow",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-WanSeamlessFlow"
-             ],
-             "install_type": "git-clone",
-             "description": "experimental wanvideo comfyui node with a singular goal - visually seamless transitions between context windows"
+            ],
+            "install_type": "git-clone",
+            "description": "experimental wanvideo comfyui node with a singular goal - visually seamless transitions between context windows"
         },
         {
             "author": "fblissjr",
@@ -23849,9 +23897,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-WanActivationEditor",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-WanActivationEditor"
-             ],
-             "install_type": "git-clone",
-             "description": "editing activations in wanvideo"
+            ],
+            "install_type": "git-clone",
+            "description": "editing activations in wanvideo"
         },
         {
             "author": "fblissjr",
@@ -23859,9 +23907,9 @@
             "reference": "https://github.com/fblissjr/shrug-prompter",
             "files": [
                 "https://github.com/fblissjr/shrug-prompter"
-             ],
-             "install_type": "git-clone",
-             "description": "A comprehensive Vision-Language Model (VLM) integration system for ComfyUI with more intelligent prompt optimization, object detection, template support, and performance optimizations. Optimized for Wan2.1, Flux Kontext, and general purpose. Goes well with my other project, an MLX/llama.cpp server with hot swappable models and ollama api compatibility, (heylookitsanllm)[a/https://github.com/fblissjr/heylookitsanllm](https://github.com/fblissjr/heylookitsanllm)"
+            ],
+            "install_type": "git-clone",
+            "description": "A comprehensive Vision-Language Model (VLM) integration system for ComfyUI with more intelligent prompt optimization, object detection, template support, and performance optimizations. Optimized for Wan2.1, Flux Kontext, and general purpose. Goes well with my other project, an MLX/llama.cpp server with hot swappable models and ollama api compatibility, (heylookitsanllm)[a/https://github.com/fblissjr/heylookitsanllm](https://github.com/fblissjr/heylookitsanllm)"
         },
         {
             "author": "fblissjr",
@@ -23869,9 +23917,9 @@
             "reference": "https://github.com/fblissjr/ComfyUI-QwenImageWanBridge",
             "files": [
                 "https://github.com/fblissjr/ComfyUI-QwenImageWanBridge"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for bridging Qwen-Image and WAN video models in ComfyUI."
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for bridging Qwen-Image and WAN video models in ComfyUI."
         },
         {
             "author": "vincentfs",
@@ -24044,9 +24092,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-LMStudio",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-LMStudio"
-             ],
-             "install_type": "git-clone",
-             "description": "This ComfyUI extension provides custom nodes for integrating with LM Studio, allowing for loading, managing, and making requests of LLM models through the LMStudio local server and command-line interface."
+            ],
+            "install_type": "git-clone",
+            "description": "This ComfyUI extension provides custom nodes for integrating with LM Studio, allowing for loading, managing, and making requests of LLM models through the LMStudio local server and command-line interface."
         },
         {
             "author": "burnsbert",
@@ -24055,9 +24103,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-Workflow",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-Workflow"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for general workflow quality of life including resolutions sorted by aspect ratio, upscaling helps, and unique file names"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for general workflow quality of life including resolutions sorted by aspect ratio, upscaling helps, and unique file names"
         },
         {
             "author": "burnsbert",
@@ -24066,9 +24114,9 @@
             "reference": "https://github.com/burnsbert/ComfyUI-EBU-PromptHelper",
             "files": [
                 "https://github.com/burnsbert/ComfyUI-EBU-PromptHelper"
-             ],
-             "install_type": "git-clone",
-             "description": "Custom nodes for enhancing and manipulating prompts in ComfyUI. Includes nodes for random color palette generation following different color theory methodologies, prompt text replacement and randomization, list sampling, loading files into strings, and season/weather/time-of-day generation."
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for enhancing and manipulating prompts in ComfyUI. Includes nodes for random color palette generation following different color theory methodologies, prompt text replacement and randomization, list sampling, loading files into strings, and season/weather/time-of-day generation."
         },
         {
             "author": "SykkoAtHome",
@@ -24076,9 +24124,9 @@
             "reference": "https://github.com/SykkoAtHome/ComfyUI_FaceProcessor",
             "files": [
                 "https://github.com/SykkoAtHome/ComfyUI_FaceProcessor"
-             ],
-             "install_type": "git-clone",
-             "description": "A custom node collection for ComfyUI that provides advanced face detection, alignment, and transformation capabilities using MediaPipe Face Mesh."
+            ],
+            "install_type": "git-clone",
+            "description": "A custom node collection for ComfyUI that provides advanced face detection, alignment, and transformation capabilities using MediaPipe Face Mesh."
         },
         {
             "author": "Mattabyte",
@@ -24086,9 +24134,9 @@
             "reference": "https://github.com/Mattabyte/ComfyUI-SecureApiCall",
             "files": [
                 "https://github.com/Mattabyte/ComfyUI-SecureApiCall"
-             ],
-             "install_type": "git-clone",
-             "description": "This package provides custom nodes to ComfyUI to POST data to a secure API."
+            ],
+            "install_type": "git-clone",
+            "description": "This package provides custom nodes to ComfyUI to POST data to a secure API."
         },
         {
             "author": "oxysoft",
@@ -24097,9 +24145,9 @@
             "reference2": "https://github.com/oxysoft/ComfyUI-gowiththeflow",
             "files": [
                 "https://github.com/oxysoft/ComfyUI-gowiththeflow"
-             ],
-             "install_type": "git-clone",
-             "description": "Implementation of GoWithTheFlow, original code at [a/https://github.com/Eyeline-Research/Go-with-the-Flow/](https://github.com/Eyeline-Research/Go-with-the-Flow/) and [a/https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py](https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py)"
+            ],
+            "install_type": "git-clone",
+            "description": "Implementation of GoWithTheFlow, original code at [a/https://github.com/Eyeline-Research/Go-with-the-Flow/](https://github.com/Eyeline-Research/Go-with-the-Flow/) and [a/https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py](https://github.com/RyannDaGreat/CommonSource/blob/master/noise_warp.py)"
         },
         {
             "author": "willmiao",
@@ -24107,9 +24155,9 @@
             "reference": "https://github.com/willmiao/ComfyUI-Lora-Manager",
             "files": [
                 "https://github.com/willmiao/ComfyUI-Lora-Manager"
-             ],
-             "install_type": "git-clone",
-             "description": "Revolutionize your workflow with the ultimate LoRA companion for ComfyUI!"
+            ],
+            "install_type": "git-clone",
+            "description": "Revolutionize your workflow with the ultimate LoRA companion for ComfyUI!"
         },
         {
             "author": "tigeryy2",
@@ -24117,9 +24165,9 @@
             "reference": "https://github.com/tigeryy2/comfyui-structured-outputs",
             "files": [
                 "https://github.com/tigeryy2/comfyui-structured-outputs"
-             ],
-             "install_type": "git-clone",
-             "description": "ComfyUI nodes for LLM Structured Outputs with integration for prompting"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for LLM Structured Outputs with integration for prompting"
         },
         {
             "author": "Conor-Collins",
@@ -24127,9 +24175,9 @@
             "reference": "https://github.com/Conor-Collins/ComfyUI-CoCoTools_IO",
             "files": [
                 "https://github.com/Conor-Collins/ComfyUI-CoCoTools_IO"
-             ],
-             "install_type": "git-clone",
-             "description": "Advanced image input and output: EXR, 32 bit support and more"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced image input and output: EXR, 32 bit support and more"
         },
         {
             "author": "852wa",
@@ -24137,9 +24185,9 @@
             "reference": "https://github.com/852wa/ComfyUI-ColorshiftColor",
             "files": [
                 "https://github.com/852wa/ComfyUI-ColorshiftColor"
-             ],
-             "install_type": "git-clone",
-             "description": "This is a custom node for ComfyUI.\nIt reduces colors based on a specified number and allows for adjustments to hue, saturation, and brightness.\nFeatures:Each parameter can be set to random, You can toggle masking (not changing colors) using color numbers, Mask inversion can also be toggled on or off."
+            ],
+            "install_type": "git-clone",
+            "description": "This is a custom node for ComfyUI.\nIt reduces colors based on a specified number and allows for adjustments to hue, saturation, and brightness.\nFeatures:Each parameter can be set to random, You can toggle masking (not changing colors) using color numbers, Mask inversion can also be toggled on or off."
         },
         {
             "author": "852wa",
@@ -24147,9 +24195,9 @@
             "reference": "https://github.com/852wa/ComfyUI-AAP",
             "files": [
                 "https://github.com/852wa/ComfyUI-AAP"
-             ],
-             "install_type": "git-clone",
-             "description": "This is a custom node for ComfyUI.\nFeatures:Removes white areas in the input image by making them transparent based on brightness, Outputs in black and transparent, Outputs in gray and transparent.\nThis is a simple node with the above functionalities implemented. It also supports sequential processing."
+            ],
+            "install_type": "git-clone",
+            "description": "This is a custom node for ComfyUI.\nFeatures:Removes white areas in the input image by making them transparent based on brightness, Outputs in black and transparent, Outputs in gray and transparent.\nThis is a simple node with the above functionalities implemented. It also supports sequential processing."
         },
         {
             "author": "ReBeating",
@@ -24157,9 +24205,9 @@
             "reference": "https://github.com/ReBeating/ComfyUI-Artist-Selector",
             "files": [
                 "https://github.com/ReBeating/ComfyUI-Artist-Selector"
-             ],
-             "install_type": "git-clone",
-             "description": "A useful comfyui node named LoadArtistTag for selecting artist tags, including 1000+ single-artist tags and 300 mixed-artists tags."
+            ],
+            "install_type": "git-clone",
+            "description": "A useful comfyui node named LoadArtistTag for selecting artist tags, including 1000+ single-artist tags and 300 mixed-artists tags."
         },
         {
             "author": "gmorks",
@@ -24167,9 +24215,9 @@
             "reference": "https://github.com/gmorks/ComfyUI-SendToDiscord",
             "files": [
                 "https://github.com/gmorks/ComfyUI-SendToDiscord"
-             ],
-             "install_type": "git-clone",
-             "description": "ComfyUI-SendToDiscord is a custom node for ComfyUI that simplifies sending preview images to Discord via webhooks. It supports both single-image uploads and batch mode, making it an efficient tool for sharing your generated images directly with your Discord server."
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-SendToDiscord is a custom node for ComfyUI that simplifies sending preview images to Discord via webhooks. It supports both single-image uploads and batch mode, making it an efficient tool for sharing your generated images directly with your Discord server."
         },
         {
             "author": "gmorks",
@@ -24177,9 +24225,9 @@
             "reference": "https://github.com/gmorks/ComfyUI-Animagine-Prompt",
             "files": [
                 "https://github.com/gmorks/ComfyUI-Animagine-Prompt"
-             ],
-             "install_type": "git-clone",
-             "description": "Comfy UI node to prompt build for https://huggingface.co/cagliostrolab/animagine-xl-4.0 model"
+            ],
+            "install_type": "git-clone",
+            "description": "Comfy UI node to prompt build for https://huggingface.co/cagliostrolab/animagine-xl-4.0 model"
         },
         {
             "author": "gmorks",
@@ -24198,9 +24246,9 @@
             "reference2": "https://github.com/derekluo/ComfyUI-Prompt-Expander",
             "files": [
                 "https://github.com/jinanlongen/ComfyUI-Prompt-Expander"
-             ],
-             "install_type": "git-clone",
-             "description": "A custom node for ComfyUI that expands text prompts using the SuperPrompt-v1 T5 model. This node helps generate more detailed and descriptive prompts from simple input text, which can be particularly useful for image generation workflows."
+            ],
+            "install_type": "git-clone",
+            "description": "A custom node for ComfyUI that expands text prompts using the SuperPrompt-v1 T5 model. This node helps generate more detailed and descriptive prompts from simple input text, which can be particularly useful for image generation workflows."
         },
         {
             "author": "Style-Mosaic",
@@ -24208,9 +24256,9 @@
             "reference": "https://github.com/Style-Mosaic/dino-x-comfyui-node",
             "files": [
                 "https://github.com/Style-Mosaic/dino-x-comfyui-node"
-             ],
-             "install_type": "git-clone",
-             "description": "A ComfyUI node that integrates DINO-X API for object detection and segmentation. This node allows you to detect and segment objects in images using text prompts."
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI node that integrates DINO-X API for object detection and segmentation. This node allows you to detect and segment objects in images using text prompts."
         },
         {
             "author": "checkbins",
@@ -24263,7 +24311,13 @@
             ],
             "description": "Node for compositing multiple images with interactive preview and layer management",
             "install_type": "git-clone",
-            "tags": ["image", "composite", "layer", "blend", "transform"]
+            "tags": [
+                "image",
+                "composite",
+                "layer",
+                "blend",
+                "transform"
+            ]
         },
         {
             "author": "zentrocdot",
@@ -24534,9 +24588,9 @@
             "reference": "https://github.com/ShinChven/sc-comfy-nodes",
             "files": [
                 "https://github.com/ShinChven/sc-comfy-nodes"
-             ],
-             "install_type": "git-clone",
-             "description": "This project contains custom nodes for ComfyUI, developed by ShinChven. The nodes in this package extend the functionality of ComfyUI by providing additional features and utilities."
+            ],
+            "install_type": "git-clone",
+            "description": "This project contains custom nodes for ComfyUI, developed by ShinChven. The nodes in this package extend the functionality of ComfyUI by providing additional features and utilities."
         },
         {
             "author": "vkff5833",
@@ -24544,9 +24598,9 @@
             "reference": "https://github.com/vkff5833/ComfyUI-MobileClient",
             "files": [
                 "https://github.com/vkff5833/ComfyUI-MobileClient"
-             ],
-             "install_type": "git-clone",
-             "description": "Add a mobile-friendly web interface to ComfyUI."
+            ],
+            "install_type": "git-clone",
+            "description": "Add a mobile-friendly web interface to ComfyUI."
         },
         {
             "author": "mediocreatmybest",
@@ -24554,9 +24608,9 @@
             "reference": "https://github.com/mediocreatmybest/ComfyUI-Transformers-Pipeline",
             "files": [
                 "https://github.com/mediocreatmybest/ComfyUI-Transformers-Pipeline"
-             ],
-             "install_type": "git-clone",
-             "description": "Additional ComfyUI nodes to utilise the Transformers pipeline in a simple and modular way."
+            ],
+            "install_type": "git-clone",
+            "description": "Additional ComfyUI nodes to utilise the Transformers pipeline in a simple and modular way."
         },
         {
             "author": "IrisRainbowNeko",
@@ -24564,9 +24618,9 @@
             "reference": "https://github.com/Deep-Neko/ComfyUI_ascii_art",
             "files": [
                 "https://github.com/Deep-Neko/ComfyUI_ascii_art"
-             ],
-             "install_type": "git-clone",
-             "description": "ascii art preprocessors in ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ascii art preprocessors in ComfyUI"
         },
         {
             "author": "mie",
@@ -25092,7 +25146,7 @@
             "title": "ComfyUI-MultiCutAndDrag",
             "reference": "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag"
+                "https://github.com/Pablerdo/ComfyUI-MultiCutAndDrag"
             ],
             "install_type": "git-clone",
             "description": "Cut and and drag that allows you to cut and drag multiple images on a path"
@@ -25102,7 +25156,7 @@
             "title": "ComfyUI-ZeptaframePromptMerger",
             "reference": "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger"
+                "https://github.com/Pablerdo/ComfyUI-ZeptaframePromptMerger"
             ],
             "install_type": "git-clone",
             "description": "Custom node that merges general and subject-specific prompts"
@@ -25112,7 +25166,7 @@
             "title": "ComfyUI-ResizeZeptaPayload",
             "reference": "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload"
+                "https://github.com/Pablerdo/ComfyUI-ResizeZeptaPayload"
             ],
             "install_type": "git-clone",
             "description": "Resize a batch of trajectories or images"
@@ -25122,7 +25176,7 @@
             "title": "Stable Virtual Camera",
             "reference": "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper",
             "files": [
-               "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper"
+                "https://github.com/Pablerdo/ComfyUI-StableVirtualCameraWrapper"
             ],
             "install_type": "git-clone",
             "description": "Generative View Synthesis with Diffusion Models"
@@ -25730,7 +25784,7 @@
             "title": "ComfyUI_depthMapOperation",
             "reference": "https://github.com/chri002/ComfyUI_depthMapOperation",
             "files": [
-               "https://github.com/chri002/ComfyUI_depthMapOperation"
+                "https://github.com/chri002/ComfyUI_depthMapOperation"
             ],
             "description": "A simple set of nodes to generate a point cloud from an image and its depth map, perform transformations and some basic operations.",
             "install_type": "git-clone"
@@ -25740,7 +25794,7 @@
             "title": "comfyui-piq",
             "reference": "https://github.com/Laurent2916/comfyui-piq",
             "files": [
-               "https://github.com/Laurent2916/comfyui-piq"
+                "https://github.com/Laurent2916/comfyui-piq"
             ],
             "description": "PIQ ComfyUI custom nodes",
             "install_type": "git-clone"
@@ -25750,7 +25804,7 @@
             "title": "ComfyUI-CSM-Nodes",
             "reference": "https://github.com/thezveroboy/ComfyUI-CSM-Nodes",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI-CSM-Nodes"
+                "https://github.com/thezveroboy/ComfyUI-CSM-Nodes"
             ],
             "description": "Custom nodes for ComfyUI implementing the csm model for text-to-speech generation.",
             "install_type": "git-clone"
@@ -25760,7 +25814,7 @@
             "title": "ComfyUI-WAN-ClipSkip",
             "reference": "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip"
+                "https://github.com/thezveroboy/ComfyUI-WAN-ClipSkip"
             ],
             "description": "Custom nodes for ComfyUI implementing the csm model for text-to-speech generation.",
             "install_type": "git-clone"
@@ -25770,7 +25824,7 @@
             "title": "ComfyUI_ACE-Step-zveroboy",
             "reference": "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy",
             "files": [
-               "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy"
+                "https://github.com/thezveroboy/ComfyUI_ACE-Step-zveroboy"
             ],
             "description": "I took the original source code from the repository [a/ComfyUI_ACE-Step](https://github.com/billwuhao/ComfyUI_ACE-Step) and modified it to make the model loading explicit instead of hidden.",
             "install_type": "git-clone"
@@ -25850,7 +25904,7 @@
             "title": "comfyui_ssl_gemini_EXP",
             "reference": "https://github.com/tatookan/comfyui_ssl_gemini_EXP",
             "files": [
-               "https://github.com/tatookan/comfyui_ssl_gemini_EXP"
+                "https://github.com/tatookan/comfyui_ssl_gemini_EXP"
             ],
             "description": "Calling gemini2.0 at comfyui . The project will continue to organize good APIs!",
             "install_type": "git-clone"
@@ -25860,7 +25914,7 @@
             "title": "comfyui_arcane_style_trans",
             "reference": "https://github.com/atluslin/comfyui_arcane_style_trans",
             "files": [
-               "https://github.com/atluslin/comfyui_arcane_style_trans"
+                "https://github.com/atluslin/comfyui_arcane_style_trans"
             ],
             "description": "ComfyUI's Arcane stylization plugin",
             "install_type": "git-clone"
@@ -25870,7 +25924,7 @@
             "title": "ComfyUI-AlphaFlatten",
             "reference": "https://github.com/pixelworldai/ComfyUI-AlphaFlatten",
             "files": [
-               "https://github.com/pixelworldai/ComfyUI-AlphaFlatten"
+                "https://github.com/pixelworldai/ComfyUI-AlphaFlatten"
             ],
             "install_type": "git-clone",
             "description": "This node takes a batch of images with alpha channels (RGBA format) and combines them into a single image, respecting the transparency of each layer. It's particularly useful for compositing multiple masked elements (like faces) into a single image."
@@ -25880,7 +25934,7 @@
             "title": "ComfyUI-WorkflowGraphics",
             "reference": "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics",
             "files": [
-               "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics"
+                "https://github.com/pixelworldai/ComfyUI-WorkflowGraphics"
             ],
             "install_type": "git-clone",
             "description": "Embed images directly in your workflow JSONs"
@@ -26525,7 +26579,7 @@
             "title": "ComfyUI-HF-Model-Downloader",
             "reference": "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader",
             "files": [
-              "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader"
+                "https://github.com/michaelgold/ComfyUI-HF-Model-Downloader"
             ],
             "install_type": "git-clone",
             "description": "Easily download and install 2D to 3D and Flux models from Hugging Face."
@@ -26626,7 +26680,7 @@
             "id": "load-image-from-http-url",
             "reference": "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL",
             "files": [
-              "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL"
+                "https://github.com/jerrywap/ComfyUI_LoadImageFromHttpURL"
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI node that fetches an image from an HTTP URL and returns it as an image tensor. Useful for API-based workflows."
@@ -27712,7 +27766,15 @@
             ],
             "install_type": "git-clone",
             "description": "Node2.0-based professional alignment & real-time node color picker - innovative first support: A must-have plugin for managing node layout and color schemes in ComfyUI. Features a real-time color picker, alignment, 7 preset colors, grayscale/custom modes, and one-click reverse alignment.",
-            "tags": ["node2.0", "alignment", "color-picker", "node-utility", "ui", "organizer", "frontend"]
+            "tags": [
+                "node2.0",
+                "alignment",
+                "color-picker",
+                "node-utility",
+                "ui",
+                "organizer",
+                "frontend"
+            ]
         },
         {
             "author": "matorzhin",
@@ -27834,7 +27896,11 @@
                 "https://github.com/Irsalistic/comfyui-dam-object-extractor"
             ],
             "description": "A ComfyUI node that uses NVIDIA's DAM model to identify objects in masked regions",
-            "tags": ["object recognition", "vision", "image analysis"],
+            "tags": [
+                "object recognition",
+                "vision",
+                "image analysis"
+            ],
             "install_type": "git-clone"
         },
         {
@@ -29342,10 +29408,10 @@
         {
             "author": "LingSss9",
             "title": "comfyui-merge",
-             "id": "comfyui-merge",
-             "reference": "https://github.com/LingSss9/comfyui-merge",
-             "files": [
-                 "https://github.com/LingSss9/comfyui-merge"
+            "id": "comfyui-merge",
+            "reference": "https://github.com/LingSss9/comfyui-merge",
+            "files": [
+                "https://github.com/LingSss9/comfyui-merge"
             ],
             "install_type": "git-clone",
             "description": "Merge up to 4 LoRA models with balanced, order-independent logic. Inspired by WebUI SuperMerger."
@@ -29353,9 +29419,9 @@
         {
             "author": "p1atdev",
             "title": "comfyui-timm-backbone",
-             "reference": "https://github.com/p1atdev/comfyui-timm-backbone",
-             "files": [
-                 "https://github.com/p1atdev/comfyui-timm-backbone"
+            "reference": "https://github.com/p1atdev/comfyui-timm-backbone",
+            "files": [
+                "https://github.com/p1atdev/comfyui-timm-backbone"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI Timm Backbone Nodes is a custom node set that enables you to load and use pre-trained models from the [a/timm](https://github.com/huggingface/pytorch-image-models) library within ComfyUI workflows."
@@ -29363,9 +29429,9 @@
         {
             "author": "p1atdev",
             "title": "TKG-DM (Training-free Chroma Key Content Generation Diffusion Model) for ComfyUI",
-             "reference": "https://github.com/p1atdev/comfyui-tkg-chroma-key",
-             "files": [
-                 "https://github.com/p1atdev/comfyui-tkg-chroma-key"
+            "reference": "https://github.com/p1atdev/comfyui-tkg-chroma-key",
+            "files": [
+                "https://github.com/p1atdev/comfyui-tkg-chroma-key"
             ],
             "install_type": "git-clone",
             "description": "This repository provides an unofficial ComfyUI custom node implementation of the paper TKG-DM: Training-free Chroma Key Content Generation Diffusion Model."
@@ -29373,9 +29439,9 @@
         {
             "author": "Zch6111",
             "title": "AI_Text_Comfyui",
-             "reference": "https://github.com/Zch6111/AI_Text_Comfyui",
-             "files": [
-                 "https://github.com/Zch6111/AI_Text_Comfyui"
+            "reference": "https://github.com/Zch6111/AI_Text_Comfyui",
+            "files": [
+                "https://github.com/Zch6111/AI_Text_Comfyui"
             ],
             "install_type": "git-clone",
             "description": "AI_Text_Comfyui is a custom node for ComfyUI that connects to the OpenAI Chat API and automatically generates creative text prompts for AI workflows. This simplified version removes external dependencies like dotenv, requiring the OpenAI key to be set using a system environment variable."
@@ -29383,9 +29449,9 @@
         {
             "author": "mrcuddle",
             "title": "Underage Filter",
-             "reference": "https://github.com/T-Ph525/ComfyUI-Underage-Filter",
-             "files": [
-                 "https://github.com/T-Ph525/ComfyUI-Underage-Filter"
+            "reference": "https://github.com/T-Ph525/ComfyUI-Underage-Filter",
+            "files": [
+                "https://github.com/T-Ph525/ComfyUI-Underage-Filter"
             ],
             "install_type": "git-clone",
             "description": "An implementation to detect underage subjects in images for ComfyUI."
@@ -29393,9 +29459,9 @@
         {
             "author": "ToTheBeginning",
             "title": "DreamO Comfyui",
-             "reference": "https://github.com/ToTheBeginning/ComfyUI-DreamO",
-             "files": [
-                 "https://github.com/ToTheBeginning/ComfyUI-DreamO"
+            "reference": "https://github.com/ToTheBeginning/ComfyUI-DreamO",
+            "files": [
+                "https://github.com/ToTheBeginning/ComfyUI-DreamO"
             ],
             "install_type": "git-clone",
             "description": "[a/DreamO](https://github.com/bytedance/DreamO) ComfyUI native implementation."
@@ -29403,9 +29469,9 @@
         {
             "author": "XWAVEart",
             "title": "ComfyUI XWAVE Nodes",
-             "reference": "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes",
-             "files": [
-                 "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes"
+            "reference": "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes",
+            "files": [
+                "https://github.com/XWAVEart/comfyui-xwave-xlitch-nodes"
             ],
             "install_type": "git-clone",
             "description": "A collection of artistic glitch and image manipulation nodes for ComfyUI, featuring advanced noise effects, color manipulations, distortions, and more."
@@ -30080,7 +30146,7 @@
             "title": "Notification Bridge",
             "reference": "https://github.com/INuBq8/ComfyUI-NotificationBridge",
             "files": [
-                        "https://github.com/INuBq8/ComfyUI-NotificationBridge"
+                "https://github.com/INuBq8/ComfyUI-NotificationBridge"
             ],
             "install_type": "git-clone",
             "description": "Bridge nodes for ComfyUI that send messages through WhatsApp (Twilio) and Discord when a workflow completes."
@@ -30501,9 +30567,18 @@
             "files": [
                 "https://github.com/casterpollux/MiniMax-bmo"
             ],
-            "nodename_pattern":  "MiniMax.*BMO|BMO.*MiniMax",
-            "pip":  ["segment-anything"],
-            "tags": ["video", "inpainting", "object-removal", "suite", "professional", "BMO"],
+            "nodename_pattern": "MiniMax.*BMO|BMO.*MiniMax",
+            "pip": [
+                "segment-anything"
+            ],
+            "tags": [
+                "video",
+                "inpainting",
+                "object-removal",
+                "suite",
+                "professional",
+                "BMO"
+            ],
             "install_type": "git-clone",
             "description": "Professional video object removal suite using MiniMax optimization. Includes BMO-enhanced nodes with VAE normalization, temporal preservation, and 6-step inference. Complete video inpainting solution for ComfyUI."
         },
@@ -31266,15 +31341,15 @@
             "description": "DiffusionLight (Turbo) implemented in ComfyUI"
         },
         {
-          "author": "sunx.ai",
-          "title": "SunxAI Custom Nodes for ComfyUI",
-          "id": "comfyui_sun_nodes",
-          "reference": "https://github.com/upseem/comfyui_sun_nodes",
-          "files": [
-            "https://github.com/upseem/comfyui_sun_nodes"
-          ],
-          "install_type": "git-clone",
-          "description": "A set of custom nodes developed by SunxAI for ComfyUI, including image loop processing and more. "
+            "author": "sunx.ai",
+            "title": "SunxAI Custom Nodes for ComfyUI",
+            "id": "comfyui_sun_nodes",
+            "reference": "https://github.com/upseem/comfyui_sun_nodes",
+            "files": [
+                "https://github.com/upseem/comfyui_sun_nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "A set of custom nodes developed by SunxAI for ComfyUI, including image loop processing and more. "
         },
         {
             "author": "sunx.ai",
@@ -31409,15 +31484,15 @@
             "description": "Advanced seed diversity enhancement for ComfyUI with intelligent noise injection and directional biasing."
         },
         {
-          "author": "vrgamegirl19",
-          "title": "VRGameDevGirl Video Enhancement Nodes",
-          "id": "vrgamedev_video_nodes",
-          "reference": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
-          "files": [
-              "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl"
-          ],
-          "install_type": "git-clone",
-          "description": "Film grain and color match nodes designed for high-quality frame-by-frame video enhancement in ComfyUI."
+            "author": "vrgamegirl19",
+            "title": "VRGameDevGirl Video Enhancement Nodes",
+            "id": "vrgamedev_video_nodes",
+            "reference": "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl",
+            "files": [
+                "https://github.com/vrgamegirl19/comfyui-vrgamedevgirl"
+            ],
+            "install_type": "git-clone",
+            "description": "Film grain and color match nodes designed for high-quality frame-by-frame video enhancement in ComfyUI."
         },
         {
             "author": "namtb96",
@@ -31686,8 +31761,8 @@
             "id": "comfyui-exloadout",
             "reference": "https://github.com/IsItDanOrAi/ComfyUI-exLoadout",
             "files": [
-                    "https://github.com/IsItDanOrAi/ComfyUI-exLoadout"
-                ],
+                "https://github.com/IsItDanOrAi/ComfyUI-exLoadout"
+            ],
             "install_type": "git-clone",
             "description": "Excel spreadsheet-driven ComfyUI nodes that let you load models, values, and workflows based on saved rows in Excel. Great for organizing and switching between CLIPs, VAEs, LoRAs, and more."
         },
@@ -31883,8 +31958,15 @@
             "install_type": "git-clone",
             "description": "A comprehensive VRAM management tool for ComfyUI. Includes automatic cleanup and GPU monitoring.",
             "nodename_pattern": "StFist",
-            "pip": ["GPUtil>=1.4.0"],
-            "tags": ["vram", "gpu", "optimizer", "monitoring"]
+            "pip": [
+                "GPUtil>=1.4.0"
+            ],
+            "tags": [
+                "vram",
+                "gpu",
+                "optimizer",
+                "monitoring"
+            ]
         },
         {
             "author": "blird",
@@ -32018,7 +32100,7 @@
                 "https://github.com/brucew4yn3rp/ComfyUI_FrontEndCleanup"
             ],
             "install_type": "git-clone",
-             "description": "This node customizes the ComfyUI frontend by relocating the action bar into the top bar and hiding selected UI elements to reduce visual clutter."
+            "description": "This node customizes the ComfyUI frontend by relocating the action bar into the top bar and hiding selected UI elements to reduce visual clutter."
         },
         {
             "author": "cedarconnor",
@@ -32277,7 +32359,13 @@
             ],
             "install_type": "git-clone",
             "description": "🧩 Aspect Ratio Image Size Calculator, 🖼️ Aspect Ratio Resizer, and 📄 Markdown Link Generator for ComfyUI.",
-            "tags": ["image", "resize", "aspect-ratio", "markdown", "utils"]
+            "tags": [
+                "image",
+                "resize",
+                "aspect-ratio",
+                "markdown",
+                "utils"
+            ]
         },
         {
             "author": "jenn",
@@ -33210,7 +33298,11 @@
                 "https://github.com/marco-zanella/ComfyUI-BooleanExpression"
             ],
             "install_type": "git-clone",
-            "tags": ["boolean", "logic", "comparison"],
+            "tags": [
+                "boolean",
+                "logic",
+                "comparison"
+            ],
             "description": "A collection of logic and comparison nodes for ComfyUI. This package adds building blocks for boolean logic, arithmetic comparisons, and string comparisons, making it easier to design conditional workflows directly in ComfyUI."
         },
         {
@@ -33336,7 +33428,7 @@
             "install_type": "git-clone",
             "description": "Smart dynamic layer swapping between GPU and CPU for optimal inference performance with comprehensive mixed precision handling and copy-compute overlap optimization. Enables running much larger models on limited VRAM setups."
         },
-		{
+        {
             "author": "Dehypnotic",
             "title": "NumberedText",
             "reference": "https://github.com/Dehypnotic/comfyui-numbered-text",
@@ -33475,7 +33567,12 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI video processing nodes with workflow metadata support",
-            "pip": ["mediapipe>=0.10.0", "opencv-python>=4.8.0", "scipy>=1.10.0", "color-matcher>=0.3.0"]
+            "pip": [
+                "mediapipe>=0.10.0",
+                "opencv-python>=4.8.0",
+                "scipy>=1.10.0",
+                "color-matcher>=0.3.0"
+            ]
         },
         {
             "author": "Dehypnotic",
@@ -33750,7 +33847,14 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI wrapper for Microsoft VibeVoice TTS model. Supports single speaker, multi-speaker, and text file loading",
-            "pip": ["torch>=2.0.0", "torchaudio>=2.0.0", "numpy>=1.20.0", "transformers>=4.44.0", "librosa>=0.9.0", "soundfile>=0.12.0"]
+            "pip": [
+                "torch>=2.0.0",
+                "torchaudio>=2.0.0",
+                "numpy>=1.20.0",
+                "transformers>=4.44.0",
+                "librosa>=0.9.0",
+                "soundfile>=0.12.0"
+            ]
         },
         {
             "author": "mikheys",
@@ -34242,7 +34346,12 @@
             ],
             "install_type": "git-clone",
             "description": "Adds `XY Input: LoRA Weight (simple)` for Efficiency Nodes. Outputs XY subtype 'LoRA' (name, weight, weight) with a linear sweep; works with `XY Input: Checkpoint`.",
-            "tags": ["xy-plot", "lora", "efficiency-nodes", "utility"]
+            "tags": [
+                "xy-plot",
+                "lora",
+                "efficiency-nodes",
+                "utility"
+            ]
         },
         {
             "author": "Shellishack",
@@ -35108,9 +35217,13 @@
             ],
             "install_type": "git-clone",
             "description": "A Virtual Camera Output For ComfyUI. On Windows, it will use the OBS Virtual Camera driver. So make sure you have OBS installed. Then in your other webcam capable applications, such as Google Meet, Teams, Zoom and even OBS itself, you can connect to the OBS Virtual Camera option and see what you are outputting from ComfyUI.",
-			"tags": ["virtual-camera", "obs", "webcam"]
+            "tags": [
+                "virtual-camera",
+                "obs",
+                "webcam"
+            ]
         },
-		{
+        {
             "author": "sbcode",
             "title": "ComfyUI Image Compare",
             "reference": "https://github.com/Sean-Bradley/ComfyUI-Image-Compare",
@@ -35119,7 +35232,10 @@
             ],
             "install_type": "git-clone",
             "description": "Compare two images using ComfyUI. Connect images to both image_a and image_b inputs. Press RUN. Then use the slider to compare. Best used when two images are very similar and you want to see the differences very closely. Search for the manager for image compare, or imagecompare.",
-			"tags": ["image-compare", "imagecompare"]
+            "tags": [
+                "image-compare",
+                "imagecompare"
+            ]
         },
         {
             "author": "sbcode",
@@ -35130,7 +35246,10 @@
             ],
             "install_type": "git-clone",
             "description": "A tool to reverse the frames of video type files (MP4, WebM, WebP, Animated GIF) using ComfyUI. It gets the image batch tensor and returns the same tensor, but flipped.",
-            "tags": ["video-reverse", "image-batch-reverse"]
+            "tags": [
+                "video-reverse",
+                "image-batch-reverse"
+            ]
         },
         {
             "author": "sbcode",
@@ -35162,7 +35281,7 @@
             "install_type": "git-clone",
             "description": "A ComfyUI custom node used to get one line of string from a multi line string. Search in the manager for `get line`, or `getline` or `get-line`."
         },
-		{
+        {
             "author": "sbcode",
             "title": "ComfyUI-Sonic",
             "reference": "https://github.com/Sean-Bradley/ComfyUI-Sonic",
@@ -35479,12 +35598,17 @@
             "title": "RC Image Compositor",
             "author": "kj863257",
             "description": "A comprehensive ComfyUI plugin suite that brings professional Photoshop-style layer effects and advanced compositing capabilities. Features modular architecture, 24 blend modes, and enhanced positioning system.",
-			"reference": "https://github.com/kj863257/ComfyUI_RC_Image_Compositor",
+            "reference": "https://github.com/kj863257/ComfyUI_RC_Image_Compositor",
             "files": [
-            	"https://github.com/kj863257/ComfyUI_RC_Image_Compositor"
+                "https://github.com/kj863257/ComfyUI_RC_Image_Compositor"
             ],
             "install_type": "git-clone",
-            "tags": ["compositing", "layer", "blend modes", "photoshop-style"]
+            "tags": [
+                "compositing",
+                "layer",
+                "blend modes",
+                "photoshop-style"
+            ]
         },
         {
             "author": "Verolelb",
@@ -36128,7 +36252,9 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced GRAG (Guided Region-Adaptive Guidance) implementation for ComfyUI. Features: Simple Controller (3 parameters) for beginners, Unified Controller (25+ parameters) for experts, Advanced Sampler with v2.2.1 contamination fix, Preset Manager with 54 curated presets, per-layer control, adaptive schedules, and multi-resolution support.",
-            "pip": ["PyYAML>=6.0"]
+            "pip": [
+                "PyYAML>=6.0"
+            ]
         },
         {
             "author": "pizurny",
@@ -36281,7 +36407,7 @@
             ],
             "install_type": "git-clone",
             "description": "Custom nodes for saving images/videos without metadata and GPU-accelerated frame rate processing (25fps→16fps). Includes 5 nodes: Save Image/Video (No Metadata), Frame Rate Resampler (CPU/GPU). Supports CUDA acceleration and multiple nterpolation methods. Requires ffmpeg."
-  		},
+        },
         {
             "author": "leewinder",
             "title": "Crop To Center",
@@ -37145,7 +37271,13 @@
             "install_type": "git-clone",
             "description": "Automatic image tagging using WD14 models with batch processing and GPU acceleration for ComfyUI",
             "category": "Image Processing",
-            "tags": ["image", "tagging", "wd14", "batch", "gpu"],
+            "tags": [
+                "image",
+                "tagging",
+                "wd14",
+                "batch",
+                "gpu"
+            ],
             "pip": [
                 "onnxruntime>=1.16.0",
                 "numpy>=1.24.0",
@@ -37674,7 +37806,11 @@
             ],
             "install_type": "git-clone",
             "description": "Adds hotkeys (F8 / Ctrl+K) and a toolbar button to cycle node link styles (Spline / Linear / Straight).",
-            "tags": ["ui", "hotkey", "canvas"]
+            "tags": [
+                "ui",
+                "hotkey",
+                "canvas"
+            ]
         },
         {
             "author": "adambarbato",
@@ -37738,19 +37874,27 @@
             ],
             "install_type": "git-clone",
             "description": "A collection of custom utility nodes for ComfyUI, providing a variety of practical mini-tools with multiple functions.",
-            "tags": ["utility"]
+            "tags": [
+                "utility"
+            ]
         },
         {
             "author": "Owl-V",
             "title": "ComfyUI-MultiTranslator",
-			"id": "comfyui-multitranslator-owlv",
+            "id": "comfyui-multitranslator-owlv",
             "reference": "https://github.com/OwlvChirotha/ComfyUI-MultiTranslator",
-            "files":[
+            "files": [
                 "https://github.com/OwlvChirotha/ComfyUI-MultiTranslator"
             ],
             "install_type": "git-clone",
             "description": "ComfyUI plug-in collection of basic translator, LLM translator and a series of LLM Service Connectors.",
-            "tags": ["translation", "llm", "ai", "connector", "utility"]
+            "tags": [
+                "translation",
+                "llm",
+                "ai",
+                "connector",
+                "utility"
+            ]
         },
         {
             "author": "Cyrostar",
@@ -37772,7 +37916,12 @@
             ],
             "install_type": "git-clone",
             "description": "Prompt generator from CSV files with randomization and external text input.",
-            "tags": ["prompt", "csv", "text", "random"]
+            "tags": [
+                "prompt",
+                "csv",
+                "text",
+                "random"
+            ]
         },
         {
             "author": "bulldog68",
@@ -37783,7 +37932,12 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced nodes for interaction with Olama (text, vision, image editing), with dynamic management of prompts via CSV.",
-            "tags": ["prompt", "csv", "text", "random"]
+            "tags": [
+                "prompt",
+                "csv",
+                "text",
+                "random"
+            ]
         },
         {
             "author": "bulldog68",
@@ -37794,7 +37948,10 @@
                 "https://github.com/bulldog68/ComfyUI_FMJ_SaveImageVersions"
             ],
             "install_type": "git-clone",
-            "tags": ["save image", "metadonne"],
+            "tags": [
+                "save image",
+                "metadonne"
+            ],
             "license": "GNU V3"
         },
         {
@@ -38057,7 +38214,12 @@
             ],
             "install_type": "git-clone",
             "description": "An enhanced Wan2.2 Image-to-Video node specifically designed to fix the slow-motion issue in 4-step LoRAs (like lightx2v).",
-            "tags": ["video", "image-to-video", "Wan2.2", "LoRA"]
+            "tags": [
+                "video",
+                "image-to-video",
+                "Wan2.2",
+                "LoRA"
+            ]
         },
         {
             "author": "princepainter",
@@ -38119,7 +38281,12 @@
             ],
             "install_type": "git-clone",
             "description": "Enhance first and last frames for smooth video loop generation in ComfyUI. Based on WAN Video workflow.",
-            "tags": ["video", "frame", "loop", "workflow"]
+            "tags": [
+                "video",
+                "frame",
+                "loop",
+                "workflow"
+            ]
         },
         {
             "author": "princepainter",
@@ -38303,7 +38470,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI extension with several convenience nodes."
         },
-
         {
             "author": "AlexXia007",
             "title": "AIYang_TripleAPI",
@@ -38706,7 +38872,10 @@
             ],
             "install_type": "git-clone",
             "description": "Smart Image Saving Nodes - Offers intelligent folder management and image saving capabilities, supporting flexible folder hierarchy control, multiple metadata sources, various image formats, and metadata embedding. It includes two nodes: SmartFolderManager and SmartImageSaver.",
-            "pip": ["Pillow", "piexif"],
+            "pip": [
+                "Pillow",
+                "piexif"
+            ],
             "nodename_pattern": "Smart"
         },
         {
@@ -38779,7 +38948,13 @@
             ],
             "install_type": "git-clone",
             "description": "Nodes for XY-style testing of parameters such as seed, steps, cfg, denoise, prompts, and LoRAs. Does not require a custom KSampler and works with any KSampler, including the default ComfyUI one.",
-            "tags": ["xy_plot", "xy", "xz", "testing", "ksampler"]
+            "tags": [
+                "xy_plot",
+                "xy",
+                "xz",
+                "testing",
+                "ksampler"
+            ]
         },
         {
             "author": "akawana",
@@ -38790,7 +38965,13 @@
             ],
             "install_type": "git-clone",
             "description": "Builds a folder-based tree from prompt lines. Lets you organize prompts into folders. Also adds several configurable keybindings for text editing (line commenting, regional prompting areas). Splits the prompt into regions for Regional Prompting.",
-            "tags": ["frontend", "shortcut", "regional", "folders", "bookmarks"]
+            "tags": [
+                "frontend",
+                "shortcut",
+                "regional",
+                "folders",
+                "bookmarks"
+            ]
         },
         {
             "author": "akawana",
@@ -38801,7 +38982,16 @@
             ],
             "install_type": "git-clone",
             "description": "UI extensions: Control Multiple Samplers, Project Settings. Nodes: AK Base,  AK Index Multiple, IsOneOfGroupsActive, RepeatGroupState group enable/disable like rg but without connection, Pipe, Getter, Setter.",
-            "tags": ["utility", "list", "batch", "get", "set", "pipe", "project", "sampler"]
+            "tags": [
+                "utility",
+                "list",
+                "batch",
+                "get",
+                "set",
+                "pipe",
+                "project",
+                "sampler"
+            ]
         },
         {
             "author": "akawana",
@@ -38812,7 +39002,12 @@
             ],
             "install_type": "git-clone",
             "description": "A JS editor for five-color masks (RGB + Yellow + Pink) that works with any nodes, with three helper nodes — RGBYPLoadImage, RGBYPMaskBridge, and RGBYPMaskToRegularMasks—for convenient RGBYP mask handling.",
-            "tags": ["utility", "mask", "rgb", "bridge"]
+            "tags": [
+                "utility",
+                "mask",
+                "rgb",
+                "bridge"
+            ]
         },
         {
             "author": "lovisdotio",
@@ -38984,7 +39179,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for integrating multiple external APIs including Gemini, OpenAI, Replicate, and ElevenLabs directly into local workflows. (Description by CC)"
         },
-
         {
             "author": "keghoang",
             "title": "ComfyUI-Charon",
@@ -39055,7 +39249,7 @@
             "install_type": "git-clone",
             "description": "Resolution picker and latent generator for ComfyUI. Select presets like HD, FullHD, 2K, 4K, 8K with aspect ratios (1:1, 9:16, 4:5, 21:9 etc.) via dropdowns. Automatically snaps width/height to latent-safe multiples of 64. Ideal for EmptyLatentImage, AnimateDiff, ControlNet, video formats, and KSampler workflows. Outputs clean INT values or ready-to-use LATENT tensor."
         },
-		{
+        {
             "author": "Bharanidharan",
             "title": "faceExtractor for ComfyUI",
             "reference": "https://github.com/llikethat/ComfyUI-faceExtractor",
@@ -39267,8 +39461,13 @@
                 "https://github.com/fredlef/Comfyui_FSL_Nodes"
             ],
             "install_type": "git-clone",
-            "description": "Custom nodes: FSLGeminiChat, FSLGeminiGenerateImage, Transparent Background helpers, and more." ,
-            "tags": ["image", "chat", "gemini", "fsl"]
+            "description": "Custom nodes: FSLGeminiChat, FSLGeminiGenerateImage, Transparent Background helpers, and more.",
+            "tags": [
+                "image",
+                "chat",
+                "gemini",
+                "fsl"
+            ]
         },
         {
             "author": "exedesign",
@@ -39281,7 +39480,14 @@
             "install_type": "git-clone",
             "description": "Text-to-3D and Image-to-3D generation using Tencent Cloud Hunyuan 3D Global API. Supports PBR materials, face count control (40K-1.5M faces), and multiple generation types (Normal/LowPoly/Geometry/Sketch). Outputs industry-standard GLB format. Requires Tencent Cloud account with API access.",
             "nodename_pattern": "Hunyuan",
-            "tags": ["3D", "generation", "text-to-3d", "image-to-3d", "hunyuan", "tencent"]
+            "tags": [
+                "3D",
+                "generation",
+                "text-to-3d",
+                "image-to-3d",
+                "hunyuan",
+                "tencent"
+            ]
         },
         {
             "author": "btitkin",
@@ -39366,7 +39572,7 @@
             ],
             "install_type": "git-clone",
             "description": "Advanced nodes optimized for ACE-Step audio generation in ComfyUI."
-		},
+        },
         {
             "author": "jeankassio",
             "title": "ComfyUI-AceStep_SFT",
@@ -39380,7 +39586,7 @@
         },
         {
             "author": "ameyukisora",
-             "title": "ComfyUI Empty Latent Advanced",
+            "title": "ComfyUI Empty Latent Advanced",
             "reference": "https://github.com/ameyukisora/ComfyUI-Empty-Latent-Advanced",
             "files": [
                 "https://github.com/ameyukisora/ComfyUI-Empty-Latent-Advanced"
@@ -39451,7 +39657,12 @@
             ],
             "install_type": "git-clone",
             "description": "A collection of utility nodes for ComfyUI, including resolution presets for film and photography aspect ratios.",
-            "tags": ["utility", "presets", "aspect ratio", "film"]
+            "tags": [
+                "utility",
+                "presets",
+                "aspect ratio",
+                "film"
+            ]
         },
         {
             "author": "jomakaze",
@@ -39812,7 +40023,9 @@
             "files": [
                 "https://github.com/Braeden90000/comfyui-load-image-url"
             ],
-            "pip": ["requests"],
+            "pip": [
+                "requests"
+            ],
             "install_type": "git-clone",
             "description": "Load images from files or URLs with live preview and source switching."
         },
@@ -40411,7 +40624,7 @@
             "install_type": "git-clone",
             "description": "2 nodes for muting or bypassing a node by node ID. They are widget linkable and promotable to a Subgraph node as a switch to mute or bypass a node in it's own Subgraph, or any other Subgraph, or it can be used as a stand alone node anywhere"
         },
-		{
+        {
             "author": "pixelpainter",
             "title": "UI-Decorators [SubGraph]",
             "reference": "https://github.com/pixelpainter/UI-Decorators",
@@ -40618,7 +40831,7 @@
             "title": "ComfyUI-FlashVSR_Stable",
             "reference": "https://github.com/naxci1/ComfyUI-FlashVSR_Stable",
             "files": [
-            "https://github.com/naxci1/ComfyUI-FlashVSR_Stable"
+                "https://github.com/naxci1/ComfyUI-FlashVSR_Stable"
             ],
             "install_type": "git-clone",
             "description": "High-performance Video Super Resolution for ComfyUI with VRAM optimization."
@@ -41773,7 +41986,6 @@
             "install_type": "git-clone",
             "description": "ComfyUI custom node for calculating tile dimensions in upscaling workflows"
         },
-
         {
             "author": "danielvw",
             "title": "ComfyUI-WanMove-Adapter",
@@ -41895,11 +42107,16 @@
             "id": "comfyui-vram-watcher",
             "reference": "https://github.com/zwaigani/ComfyUI-VRAM-watcher",
             "files": [
-            "https://github.com/zwaigani/ComfyUI-VRAM-watcher"
+                "https://github.com/zwaigani/ComfyUI-VRAM-watcher"
             ],
             "install_type": "git-clone",
             "description": "Displays GPU VRAM usage and system RAM usage as bar widgets in a ComfyUI node.",
-            "tags": ["utils", "ui", "vram", "ram"]
+            "tags": [
+                "utils",
+                "ui",
+                "vram",
+                "ram"
+            ]
         },
         {
             "author": "zwaigani",
@@ -42732,7 +42949,11 @@
             ],
             "install_type": "git-clone",
             "description": "Adds a smart I/O status dock to stacked nodes for cleaner layouts.",
-            "tags": ["ui", "layout", "utils"]
+            "tags": [
+                "ui",
+                "layout",
+                "utils"
+            ]
         },
         {
             "author": "laowang",
@@ -42818,7 +43039,14 @@
             ],
             "install_type": "git-clone",
             "description": "A specialized toolkit for AI-based image captioning (reverse prompting), prompt enrichment, and automated batch generation. It streamlines LoRA dataset organization with native GGUF and Ollama support.",
-            "tags": ["llm", "vision", "prompt generation", "lora", "Qwen3", "reverse prompting"]
+            "tags": [
+                "llm",
+                "vision",
+                "prompt generation",
+                "lora",
+                "Qwen3",
+                "reverse prompting"
+            ]
         },
         {
             "author": "DevDuckFace",
@@ -43442,16 +43670,16 @@
             "install_type": "git-clone",
             "description": "A ComfyUI Custom Node to backup workflows and their required models locally."
         },
-		{
+        {
             "author": "DVA",
             "title": "DVA_Qwen_TTS",
             "reference": "https://github.com/SLVGITHUB/QWEN3_TTS_DVA",
             "files": [
                 "https://github.com/SLVGITHUB/QWEN3_TTS_DVA"
-		    ],
+            ],
             "install_type": "git-clone",
             "description": "High-quality multilingual TTS with voice cloning, emotion control, and support for Qwen3-TTS models (CustomVoice, VoiceDesign, Base)."
-		},
+        },
         {
             "author": "boredcoderyt",
             "title": "Fibo Edit Node for ComfyUI",
@@ -43560,7 +43788,27 @@
             "install_type": "git-clone",
             "description": "Enhanced QwenVL node with Smart Prompt Caching, multilingual WAN 2.2 presets, comprehensive visual style detection, and NSFW support. Latest v2.0.8 with bug fixes and stability improvements for professional multimodal workflows.",
             "category": "image",
-            "tags": ["vision", "language", "multimodal", "qwen", "smart_caching", "prompt_caching", "multilingual", "style_detection", "performance", "wan2.2", "video", "i2v", "t2v", "cinematography", "abliterated", "nsfw", "enhanced", "fork", "stable"],
+            "tags": [
+                "vision",
+                "language",
+                "multimodal",
+                "qwen",
+                "smart_caching",
+                "prompt_caching",
+                "multilingual",
+                "style_detection",
+                "performance",
+                "wan2.2",
+                "video",
+                "i2v",
+                "t2v",
+                "cinematography",
+                "abliterated",
+                "nsfw",
+                "enhanced",
+                "fork",
+                "stable"
+            ],
             "version": "2.0.8"
         },
         {
@@ -43574,7 +43822,22 @@
             "install_type": "git-clone",
             "description": "Tag completion with a1111-sd-webui-tagcomplete style wildcard sub-selection, supporting CSV files and multiple wildcard sources. Features smart parsing, text overflow handling, and full compatibility with existing wildcard files. v2.0.0 with major wildcard workflow improvements.",
             "category": "utility",
-            "tags": ["tag", "completion", "autocomplete", "wildcard", "csv", "suggestion", "sub-selection", "a1111", "danbooru", "e621", "prompt", "utility", "enhanced", "stable"],
+            "tags": [
+                "tag",
+                "completion",
+                "autocomplete",
+                "wildcard",
+                "csv",
+                "suggestion",
+                "sub-selection",
+                "a1111",
+                "danbooru",
+                "e621",
+                "prompt",
+                "utility",
+                "enhanced",
+                "stable"
+            ],
             "version": "2.0.0"
         },
         {
@@ -43588,7 +43851,21 @@
             "install_type": "git-clone",
             "description": "Ultra fast frame interpolation using Rife TensorRT with fully automatic installation and optimization. Features automatic TensorRT engine building, CUDA toolkit detection, and resolution profiles for optimal performance. 2-4x faster than original RIFE implementation with enhanced stability and memory management.",
             "category": "video",
-            "tags": ["video", "interpolation", "rife", "tensorrt", "cuda", "performance", "frame", "motion", "automatic", "optimization", "enhanced", "fork", "stable"]
+            "tags": [
+                "video",
+                "interpolation",
+                "rife",
+                "tensorrt",
+                "cuda",
+                "performance",
+                "frame",
+                "motion",
+                "automatic",
+                "optimization",
+                "enhanced",
+                "fork",
+                "stable"
+            ]
         },
         {
             "author": "huchukato",
@@ -43601,7 +43878,23 @@
             "install_type": "git-clone",
             "description": "2-4x faster ComfyUI image upscaling using TensorRT with automatic installation and model optimization. Supports popular upscaling models with automatic TensorRT engine building, CUDA toolkit detection, and memory-efficient processing. Enhanced performance and stability over original implementation.",
             "category": "image",
-            "tags": ["image", "upscale", "tensorrt", "cuda", "performance", "enhancement", "automatic", "optimization", "esrgan", "edsr", "memory", "efficient", "enhanced", "fork", "stable"]
+            "tags": [
+                "image",
+                "upscale",
+                "tensorrt",
+                "cuda",
+                "performance",
+                "enhancement",
+                "automatic",
+                "optimization",
+                "esrgan",
+                "edsr",
+                "memory",
+                "efficient",
+                "enhanced",
+                "fork",
+                "stable"
+            ]
         },
         {
             "author": "huchukato",
@@ -43614,7 +43907,21 @@
             "install_type": "git-clone",
             "description": "HuggingFace model downloader for ComfyUI with advanced search and intelligent download system. Search, browse, and download models directly from HuggingFace repository without leaving ComfyUI interface. Features API token support, model type filtering, and migration path from Civicomfy with enhanced stability.",
             "category": "utility",
-            "tags": ["huggingface", "model", "download", "search", "browse", "api", "repository", "management", "interface", "migration", "civicomfy", "enhanced", "stable"]
+            "tags": [
+                "huggingface",
+                "model",
+                "download",
+                "search",
+                "browse",
+                "api",
+                "repository",
+                "management",
+                "interface",
+                "migration",
+                "civicomfy",
+                "enhanced",
+                "stable"
+            ]
         },
         {
             "author": "kadima-tech",
@@ -43870,12 +44177,12 @@
             "install_type": "git-clone",
             "description": "Local AI prompt generator using Qwen/SmolLM2 models. 100% offline and private. Supports 4-bit/8-bit quantization. Runs on 6GB VRAM GPUs alongside Stable Diffusion. Smart token management, Polish-English translation, embedding support, OOM protection.",
             "tags": [
-              "prompt",
-              "AI",
-              "LLM",
-              "offline",
-              "translation",
-              "privacy"
+                "prompt",
+                "AI",
+                "LLM",
+                "offline",
+                "translation",
+                "privacy"
             ]
         },
         {
@@ -44142,14 +44449,14 @@
         },
         {
             "author": "rohit267",
-            "title":"Champdev Custom Nodes",
-            "id":"champdev",
-            "reference":"https://github.com/rohit267/champdev-comfyui-nodes",
+            "title": "Champdev Custom Nodes",
+            "id": "champdev",
+            "reference": "https://github.com/rohit267/champdev-comfyui-nodes",
             "files": [
                 "https://github.com/rohit267/champdev-comfyui-nodes"
             ],
-            "install_type":"git-clone",
-            "description":"Champdev Custom Nodes. Currently contains Champdev Save Image, auto delete image after input seconds, overwrite file, save to temp dir."
+            "install_type": "git-clone",
+            "description": "Champdev Custom Nodes. Currently contains Champdev Save Image, auto delete image after input seconds, overwrite file, save to temp dir."
         },
         {
             "author": "ChunkyPanda29",
@@ -44187,7 +44494,7 @@
             "id": "openimage",
             "reference": "https://github.com/nic-schi/ComfyUI-OpenImage",
             "files": [
-                  "https://github.com/nic-schi/ComfyUI-OpenImage"
+                "https://github.com/nic-schi/ComfyUI-OpenImage"
             ],
             "install_type": "git-clone",
             "description": "Lets you open a generated Image in a specified application after generation."
@@ -44213,7 +44520,13 @@
             ],
             "install_type": "git-clone",
             "description": "Load Qwen-VL and Qwen3-VL models locally and apply PEFT LoRA adapters for enhanced image captioning. Supports 4-bit and 8-bit quantization (BitsAndBytes), FP8 pre-quantized models, Flash Attention 2, SageAttention, and torch.compile. Includes a LoRA strength slider and configurable captioning prompts.",
-            "tags": ["captioning", "LLM", "VLM", "LoRA", "Qwen"]
+            "tags": [
+                "captioning",
+                "LLM",
+                "VLM",
+                "LoRA",
+                "Qwen"
+            ]
         },
         {
             "author": "SeanBRVFX",
@@ -44276,7 +44589,14 @@
             ],
             "install_type": "git-clone",
             "description": "Smart real-time token counter for CLIP-L, T5-XXL (Flux), Qwen + seed-controlled prompt mixer from custom CSV wildcards. Supports field overrides, flat/paragraph modes, thread-safe caching.",
-            "tags": ["prompt", "token", "csv", "wildcard", "utils", "text"]
+            "tags": [
+                "prompt",
+                "token",
+                "csv",
+                "wildcard",
+                "utils",
+                "text"
+            ]
         },
         {
             "author": "FugitiveExpert01",
@@ -44997,7 +45317,7 @@
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
             "files": [
-            	"https://github.com/senjinthedragon/comfyui-gender-tag-filter"
+                "https://github.com/senjinthedragon/comfyui-gender-tag-filter"
             ],
             "install_type": "git-clone",
             "category": "utils/tags",
@@ -45335,7 +45655,7 @@
             "author": "HalfikCode",
             "title": "Prompt DB",
             "reference": "https://github.com/HalfikCode/ComfyUI-Prompt-DB",
-            "files":[
+            "files": [
                 "https://github.com/HalfikCode/ComfyUI-Prompt-DB"
             ],
             "install_type": "git-clone",
@@ -45401,7 +45721,10 @@
             ],
             "install_type": "git-clone",
             "description": "Intel Arc-first ComfyUI monitor with real-time GPU/CPU/RAM stats and an exclusive workflow execution success rate predictor. NVIDIA (CUDA) fully supported.",
-            "pip": ["psutil", "pynvml"]
+            "pip": [
+                "psutil",
+                "pynvml"
+            ]
         },
         {
             "author": "darksidewalker",
@@ -45835,7 +46158,7 @@
             "author": "artyclaw",
             "title": "ArtyClaw Comfy Nodes",
             "reference": "https://github.com/artyclaw/artyclaw-comfy",
-            "files":[
+            "files": [
                 "https://github.com/artyclaw/artyclaw-comfy"
             ],
             "install_type": "git-clone",
@@ -46047,19 +46370,6 @@
             "install_type": "git-clone",
             "description": "Personal ComfyUI custom nodes."
         },
-
-
-
-
-
-
-
-
-
-
-
-
-
         {
             "author": "Ser-Hilary",
             "title": "SDXL_sizing",
@@ -46437,6 +46747,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "VixDreamer",
+            "title": "Kontext ControlNet Fix",
+            "id": "kontext-controlnet-fix",
+            "reference": "https://github.com/VixDreamer/kontext-controlnet-fix",
+            "files": [
+                "https://github.com/VixDreamer/kontext-controlnet-fix"
+            ],
+            "install_type": "git-clone",
+            "description": "Runtime patch that fixes the shape-mismatch crash when combining Flux Kontext ReferenceLatent with any ControlNet node. No core files modified. Idempotent — skips if upstream fix (PR #9180) is already present."
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds **kontext-controlnet-fix** by VixDreamer
- Runtime patch that fixes the `RuntimeError` shape-mismatch crash when combining **Flux Kontext** (`ReferenceLatent`) with any **ControlNet** node
- No core ComfyUI files modified; patch applied at startup via monkey-patch
- **Idempotent** — skips patching if upstream fix (PR #9180) is already present

## Node Info

| Field | Value |
|-------|-------|
| Author | VixDreamer |
| Title | Kontext ControlNet Fix |
| Install type | git-clone |
| Repository | https://github.com/VixDreamer/kontext-controlnet-fix |
| Tags | flux, kontext, controlnet, fix, patch |

## Checklist
- [x] Entry added to `custom-node-list.json`
- [x] `install_type: git-clone`
- [x] Repository is public and accessible
- [x] No new UI nodes (pure runtime patch — `"nodes": []`)
- [x] MIT license