### PR TITLE
Fix deprecated legacy API imports with modern API shims

### DIFF
--- a/js/comfyui-gui-builder.js
+++ b/js/comfyui-gui-builder.js
@@ -1,4 +1,9 @@
-import { $el } from "../../scripts/ui.js";
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el;
+if (window?.comfyAPI?.ui) {
+    ({ $el } = window.comfyAPI.ui);
+} else {
+    ({ $el } = await import("../../scripts/ui.js"));
 
 function normalizeContent(content) {
 	const tmp = document.createElement('div');

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1,6 +1,5 @@
 import { api } from "../../scripts/api.js";
 import { app } from "../../scripts/app.js";
-import { $el, ComfyDialog } from "../../scripts/ui.js";
 import {
 	SUPPORTED_OUTPUT_NODE_TYPES,
 	ShareDialog,
@@ -21,6 +20,27 @@ import { CustomNodesManager } from "./custom-nodes-manager.js";
 import { ModelManager } from "./model-manager.js";
 import { SnapshotManager } from "./snapshot.js";
 import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js, button.js + buttonGroup.js warnings) ===
+let $el, ComfyDialog, ComfyButton, ComfyButtonGroup;
+
+if (window?.comfyAPI?.ui) {
+	({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+	({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
+
+if (window?.comfyAPI?.button) {
+	ComfyButton = window.comfyAPI.button.ComfyButton;
+} else {
+	ComfyButton = (await import("../../scripts/ui/components/button.js")).ComfyButton;
+}
+
+if (window?.comfyAPI?.buttonGroup?.ComfyButtonGroup) {
+	ComfyButtonGroup = window.comfyAPI.buttonGroup.ComfyButtonGroup;
+} else {
+	ComfyButtonGroup = (await import("../../scripts/ui/components/buttonGroup.js")).ComfyButtonGroup;
+}
 
 let manager_version = await getVersion();
 
@@ -1567,8 +1587,9 @@ app.registerExtension({
 		try {
 			// new style Manager buttons
 			// unload models button into new style Manager button
-			let cmGroup = new (await import("../../scripts/ui/components/buttonGroup.js")).ComfyButtonGroup(
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+			// Use hoisted ComfyButton + ComfyButtonGroup from shim at top of file
+			let cmGroup = new ComfyButtonGroup(
+				new ComfyButton({
 					icon: "puzzle",
 					action: () => {
 						if(!manager_instance)
@@ -1579,7 +1600,7 @@ app.registerExtension({
 					content: "Manager",
 					classList: "comfyui-button comfyui-menu-mobile-collapse primary"
 				}).element,
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+				new ComfyButton({
 					icon: "star",
 					action: () => {
 						if(!manager_instance)
@@ -1592,21 +1613,21 @@ app.registerExtension({
 					},
 					tooltip: "Show favorite custom node list"
 				}).element,
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+				new ComfyButton({
 					icon: "vacuum-outline",
 					action: () => {
 						free_models();
 					},
 					tooltip: "Unload Models"
 				}).element,
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+				new ComfyButton({
 					icon: "vacuum",
 					action: () => {
 						free_models(true);
 					},
 					tooltip: "Free model and node cache"
 				}).element,
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+				new ComfyButton({
 					icon: "share",
 					action: () => {
 						if (share_option === 'openart') {

--- a/js/comfyui-share-common.js
+++ b/js/comfyui-share-common.js
@@ -1,10 +1,17 @@
 import { api } from "../../scripts/api.js";
 import { app } from "../../scripts/app.js";
-import { $el, ComfyDialog } from "../../scripts/ui.js";
 import { CopusShareDialog } from "./comfyui-share-copus.js";
 import { OpenArtShareDialog } from "./comfyui-share-openart.js";
 import { YouMLShareDialog } from "./comfyui-share-youml.js";
 import { customAlert } from "./common.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
 
 export const SUPPORTED_OUTPUT_NODE_TYPES = [
 	"PreviewImage",

--- a/js/comfyui-share-copus.js
+++ b/js/comfyui-share-copus.js
@@ -1,6 +1,13 @@
 import { app } from "../../scripts/app.js";
-import { $el, ComfyDialog } from "../../scripts/ui.js";
 import { customAlert } from "./common.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
 
 const env = "prod";
 

--- a/js/comfyui-share-openart.js
+++ b/js/comfyui-share-openart.js
@@ -1,7 +1,14 @@
 import {app} from "../../scripts/app.js";
 import {api} from "../../scripts/api.js";
-import {ComfyDialog, $el} from "../../scripts/ui.js";
 import { customAlert } from "./common.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
 
 const LOCAL_STORAGE_KEY = "openart_comfy_workflow_key";
 const DEFAULT_HOMEPAGE_URL = "https://openart.ai/workflows/dev?developer=true";

--- a/js/comfyui-share-youml.js
+++ b/js/comfyui-share-youml.js
@@ -1,7 +1,14 @@
 import {app} from "../../scripts/app.js";
 import {api} from "../../scripts/api.js";
-import {ComfyDialog, $el} from "../../scripts/ui.js";
 import { customAlert } from "./common.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
 
 const BASE_URL = "https://youml.com";
 //const BASE_URL = "http://localhost:3000";

--- a/js/common.js
+++ b/js/common.js
@@ -1,7 +1,14 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
-import { $el, ComfyDialog } from "../../scripts/ui.js";
 import { getBestPosition, getPositionStyle, getRect } from './popover-helper.js';
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el, ComfyDialog;
+if (window?.comfyAPI?.ui) {
+    ({ $el, ComfyDialog } = window.comfyAPI.ui);
+} else {
+    ({ $el, ComfyDialog } = await import("../../scripts/ui.js"));
+}
 
 
 function internalCustomConfirm(message, confirmMessage, cancelMessage) {

--- a/js/components-manager.js
+++ b/js/components-manager.js
@@ -1,8 +1,22 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js"
 import { sleep, show_message, customConfirm, customAlert } from "./common.js";
-import { GroupNodeConfig, GroupNodeHandler } from "../../extensions/core/groupNode.js";
-import { ComfyDialog, $el } from "../../scripts/ui.js";
+
+// === SHIM FOR NEW COMFYUI (removes groupNode.js warning) ===
+let GroupNodeConfig, GroupNodeHandler;
+if (window?.comfyAPI?.groupNode) {
+    ({ GroupNodeConfig, GroupNodeHandler } = window.comfyAPI.groupNode);
+} else {
+    ({ GroupNodeConfig, GroupNodeHandler } = await import("../../extensions/core/groupNode.js"));
+}
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let ComfyDialog, $el;
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+}
 
 const SEPARATOR = ">"
 

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1,5 +1,4 @@
 import { app } from "../../scripts/app.js";
-import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { api } from "../../scripts/api.js";
 import { buildGuiFrameCustomHeader,  createSettingsCombo } from "./comfyui-gui-builder.js";
 
@@ -13,6 +12,14 @@ import {
 
 // https://cenfun.github.io/turbogrid/api.html
 import TG from "./turbogrid.esm.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let ComfyDialog, $el;
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+}
 
 loadCss("./custom-nodes-manager.css");
 

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -1,5 +1,4 @@
 import { app } from "../../scripts/app.js";
-import { $el } from "../../scripts/ui.js";
 import {
 	manager_instance, rebootAPI,
 	fetchData, md5, icons, show_message, customAlert, infoToast, showTerminal,
@@ -10,6 +9,14 @@ import { api } from "../../scripts/api.js";
 // https://cenfun.github.io/turbogrid/api.html
 import TG from "./turbogrid.esm.js";
 import { buildGuiFrameCustomHeader,  createSettingsCombo } from "./comfyui-gui-builder.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let $el;
+if (window?.comfyAPI?.ui) {
+    ({ $el } = window.comfyAPI.ui);
+} else {
+    ({ $el } = await import("../../scripts/ui.js"));
+}
 
 loadCss("./model-manager.css");
 

--- a/js/snapshot.js
+++ b/js/snapshot.js
@@ -1,8 +1,15 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js"
-import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { manager_instance, rebootAPI, show_message, handle403Response, loadCss } from  "./common.js";
 import { buildGuiFrame } from "./comfyui-gui-builder.js";
+
+// === SHIM FOR NEW COMFYUI (removes ui.js warning) ===
+let ComfyDialog, $el;
+if (window?.comfyAPI?.ui) {
+    ({ ComfyDialog, $el } = window.comfyAPI.ui);
+} else {
+    ({ ComfyDialog, $el } = await import("../../scripts/ui.js"));
+}
 
 loadCss("./snapshot.css");
 


### PR DESCRIPTION
ComfyUI has deprecated direct imports of several legacy API paths and logs
DEPRECATION WARNING in the browser console when these are imported directly
by extensions.

This replaces static imports with shims that check for the new
window.comfyAPI API first, falling back to the legacy path for backward
compatibility with older ComfyUI versions.

Files changed:
- comfyui-manager.js: ui.js, button.js + buttonGroup.js shims. Also
  replaces repeated inline await import() calls with top-level hoisted
  variables for ComfyButton and ComfyButtonGroup.
- components-manager.js: groupNode.js + ui.js shims
- comfyui-gui-builder.js: ui.js shim
- comfyui-share-common.js: ui.js shim
- comfyui-share-copus.js: ui.js shim
- comfyui-share-openart.js: ui.js shim
- comfyui-share-youml.js: ui.js shim
- common.js: ui.js shim
- custom-nodes-manager.js: ui.js shim
- model-manager.js: ui.js shim
- snapshot.js: ui.js shim

All static imports have been moved above shim blocks to maintain valid
JavaScript module syntax.

Addresses multiple open issues reporting DEPRECATION WARNING in the browser console.