### PR TITLE
Add MachinePainting Nodes to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46618,6 +46618,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "machinepainting",
+            "title": "MachinePainting Nodes",
+            "id": "comfyui-machinepainting-nodes",
+            "reference": "https://github.com/machinepainting/ComfyUI-MachinePaintingNodes",
+            "files": [
+                "https://github.com/machinepainting/ComfyUI-MachinePaintingNodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Professional photo editing tools for ComfyUI. Photoshop-style curves, levels, and color adjustments, AI-powered masking / background removal, LUT color grading, advanced channel masking, color management, frequency separation, blur and noise/grain filters, inpaint mask tools, and workflow utility nodes."
         }
     ]
 }


### PR DESCRIPTION
Adds the **MachinePainting Nodes** custom node pack to `custom-node-list.json`.

## About the pack
Image-processing utilities for ComfyUI: Photoshop-style curves, levels, and color adjustments, AI-powered masking / background removal, LUT color grading, advanced channel masking, color management, frequency separation, blur and noise/grain filters, inpaint mask tools, and workflow utility nodes (40 nodes total).

- **Repository:** https://github.com/machinepainting/ComfyUI-MachinePaintingNodes
- **Comfy Registry:** [comfyui-machinepainting-nodes](https://registry.comfy.org/nodes/comfyui-machinepainting-nodes) — currently published at v2.1.4 with 757+ downloads
- **Install type:** `git-clone`
- **Author:** machinepainting

## Diff
+11 lines, 0 removed — single entry appended to the list, no formatting churn elsewhere.