### PR TITLE
Add Comfyui-Pick_Any to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -31282,6 +31282,16 @@
             "description": "A custom node for ComfyUI that performs speaker diarization to isolate individual speaker audio tracks from a single audio source."
         },
         {
+            "author": "pmarmotte2",
+            "title": "Comfyui-Pick_Any",
+            "reference": "https://github.com/pmarmotte2/Comfyui_Pick_Any",
+            "files": [
+                "https://github.com/pmarmotte2/Comfyui_Pick_Any"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced chooser nodes for ComfyUI that let workflows pause for image, audio, or text selection, with optional automatic picking and series helper nodes."
+        },
+        {
             "author": "IIEleven11",
             "title": "ComfyUI-FairyTaler",
             "reference": "https://github.com/IIEleven11/ComfyUI-FairyTaler",


### PR DESCRIPTION
## Summary

Adds Comfyui-Pick_Any to `custom-node-list.json` so it can be installed through ComfyUI-Manager.

## Details

- Registers `https://github.com/pmarmotte2/Comfyui_Pick_Any`
- Uses `git-clone` install type
- Describes the image, audio, and text chooser workflow support

## Validation

- Ran `python -m json.tool custom-node-list.json` successfully.