### PR TITLE
Add Advanced Pose Studio to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -31282,6 +31282,16 @@
             "description": "A custom node for ComfyUI that performs speaker diarization to isolate individual speaker audio tracks from a single audio source."
         },
         {
+            "author": "pmarmotte2",
+            "title": "Comfyui_Advanced_Pose_Studio",
+            "reference": "https://github.com/pmarmotte2/Comfyui_Advanced_Pose_Studio",
+            "files": [
+                "https://github.com/pmarmotte2/Comfyui_Advanced_Pose_Studio"
+            ],
+            "install_type": "git-clone",
+            "description": "Advanced Pose Studio is a standalone ComfyUI custom node for staging MakeHuman-based character meshes, editing poses, and exporting viewport-aligned pose renders."
+        },
+        {
             "author": "IIEleven11",
             "title": "ComfyUI-FairyTaler",
             "reference": "https://github.com/IIEleven11/ComfyUI-FairyTaler",


### PR DESCRIPTION
## Summary

Adds Comfyui_Advanced_Pose_Studio to `custom-node-list.json` so it can be installed through ComfyUI-Manager.

## Details

- Registers `https://github.com/pmarmotte2/Comfyui_Advanced_Pose_Studio`
- Uses `git-clone` install type
- Describes the MakeHuman mesh staging, pose editing, and viewport-aligned render workflow support

## Validation

- Ran `python -m json.tool custom-node-list.json` successfully.