### PR TITLE
Add ComfyUI-Pixal3D to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47652,6 +47652,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "dreamrec",
+            "title": "ComfyUI-Pixal3D",
+            "id": "comfyui-pixal3d",
+            "reference": "https://github.com/dreamrec/ComfyUI-Pixal3D",
+            "files": [
+                "https://github.com/dreamrec/ComfyUI-Pixal3D"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI wrapper for [a/Pixal3D](https://github.com/TencentARC/Pixal3D) — Tencent's SIGGRAPH 2026 single-image to PBR-textured-3D pipeline. Windows + NVIDIA RTX 30/40/50 (≥ 16 GB VRAM). One image → textured PBR mesh in ~3-5 min. Built on top of [a/ComfyUI-Trellis2](https://github.com/visualbruno/ComfyUI-Trellis2). Note: Pixal3D itself is academic / non-commercial only and NOT for EU use — see NOTICE.md."
         }
     ]
 }

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -65306,5 +65306,15 @@
         {
             "title_aux": "SDXLResolutionPresets"
         }
+    ],
+    "https://github.com/dreamrec/ComfyUI-Pixal3D": [
+        [
+            "Pixal3DLoadPipeline",
+            "Pixal3DImageToMesh",
+            "Pixal3DFreePipeline"
+        ],
+        {
+            "title_aux": "ComfyUI-Pixal3D"
+        }
     ]
 }


### PR DESCRIPTION
Adds [ComfyUI-Pixal3D](https://github.com/dreamrec/ComfyUI-Pixal3D) — a ComfyUI wrapper for [Tencent Pixal3D](https://github.com/TencentARC/Pixal3D) (SIGGRAPH 2026), the single-image to PBR-textured-3D pipeline. Built on top of [ComfyUI-Trellis2](https://github.com/visualbruno/ComfyUI-Trellis2), reusing its pixi-managed CUDA worker env.

**Highlights**
- One image → textured PBR GLB mesh in ~3-5 min on an RTX 5090.
- Windows 10/11 x64, Python 3.12, PyTorch 2.8 + CUDA 12.8.
- NVIDIA RTX 30 / 40 / 50 with ≥ 16 GB VRAM (24 GB+ recommended for `1024_cascade` defaults).

**Nodes registered** (`extension-node-map.json`)
- `Pixal3DLoadPipeline` — load the Pixal3D model into the Trellis2 worker.
- `Pixal3DImageToMesh` — single image → textured PBR mesh.
- `Pixal3DFreePipeline` — free the loaded pipeline to release VRAM.

**License note**
The wrapper itself is MIT, but Pixal3D upstream is licensed for **academic / non-commercial use only and explicitly NOT for use within the EU**. This is documented in the project's [NOTICE.md](https://github.com/dreamrec/ComfyUI-Pixal3D/blob/main/NOTICE.md).

**Validation**
- \`python3 json-checker.py custom-node-list.json\` → ✅ Validation passed
- \`python3 json-checker.py extension-node-map.json\` → ✅ Validation passed
- Surgical diff: 21 insertion lines, 0 deletions, no other lines touched.