### PR TITLE
Add PlagueKind Nodes to ComfyUI-Manager registry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47652,6 +47652,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "PlagueKind",
+            "title": "PlagueKind-Nodes",
+            "reference": "https://github.com/PlagueKind/ComfyUI-PlagueKind-Nodes",
+            "files": [
+                "https://github.com/PlagueKind/ComfyUI-PlagueKind-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom ComfyUI nodes providing unified image and mask resizing with multiple scaling modes, aspect-ratio preservation, center crop alignment, and stable tensor-based mask transformations."
         }
     ]
 }


### PR DESCRIPTION
Adds PlagueKind node pack to ComfyUI-Manager registry.

This node pack provides unified image and mask resizing with:
- multiple scaling modes
- aspect-ratio preservation
- center crop alignment
- stable tensor-based mask transformations

Repository:
https://github.com/PlagueKind/ComfyUI-PlagueKind-Nodes

Tested locally and installs correctly.

License with MIT.

