### PR TITLE
Add ComfyUI-Magos-Nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -272,6 +272,17 @@
             "install_type": "git-clone",
             "description": "Proper implementation of ImageMagick - the famous software suite for editing and manipulating digital images to ComfyUI using [a/wandpy](https://github.com/emcconville/wand).\nNOTE: You need to install ImageMagick, manually."
         },
+            {
+        "author": "Magos Digital Studio",
+        "title": "ComfyUI-Magos-Nodes",
+        "reference": "https://github.com/MagosDigitalStudio/ComfyUI-Magos-Nodes",
+        "files": [
+            "https://github.com/MagosDigitalStudio/ComfyUI-Magos-Nodes"
+        ],
+        "install_type": "git-clone",
+        "description": "DWPose & NLF skeleton editor, retargeter, and renderer for ComfyUI. Extract body/hand/face keypoints (+ optional NLF 3D) from video, edit them frame-by-frame in a full-screen timeline + dope sheet + graph + 3D orbit editor with animated camera, retarget DWPose proportions per-cluster, and render clean pose images. Outputs standard ComfyUI types — drives WanAnimate, ControlNet, SCAIL, LTX-Video, UniAnimate, and any other pose-driven pipeline."
+    },
+
         {
             "author": "time-river",
             "title": "CLIPSeg",


### PR DESCRIPTION
    {
        "author": "Magos Digital Studio",
        "title": "ComfyUI-Magos-Nodes",
        "reference": "https://github.com/MagosDigitalStudio/ComfyUI-Magos-Nodes",
        "files": [
            "https://github.com/MagosDigitalStudio/ComfyUI-Magos-Nodes"
        ],
        "install_type": "git-clone",
        "description": "DWPose & NLF skeleton editor, retargeter, and renderer for ComfyUI. Extract body/hand/face keypoints (+ optional NLF 3D) from video, edit them frame-by-frame in a full-screen timeline + dope sheet + graph + 3D orbit editor with animated camera, retarget DWPose proportions per-cluster, and render clean pose images. Outputs standard ComfyUI types — drives WanAnimate, ControlNet, SCAIL, LTX-Video, UniAnimate, and any other pose-driven pipeline."
    },
