### PR TITLE
Remove legacy MSXYZ node listing

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -46232,17 +46232,6 @@
             "description": "Building upon the excellent foundation of ComfyUI_TensorRT, this version focuses on full support for the Anima architecture and advanced TensorRT acceleration. It aims to push NVIDIA RTX™ GPU performance to its limits for the next generation of Stable Diffusion workflows."
         },
         {
-            "author": "MSXYZ",
-            "title": "ComfyUI-MSXYZ",
-            "id": "comfyui-msxyz",
-            "reference": "https://github.com/MSXYZ-GenAI/comfyui-msxyz",
-            "files": [
-                "https://github.com/MSXYZ-GenAI/comfyui-msxyz"
-            ],
-            "install_type": "git-clone",
-            "description": "Video Adaptive Anti-Aliasing post-processing node for ComfyUI to eliminate jagged edges in AI-generated videos and images."
-        },
-        {
             "author": "longyijdos",
             "title": "ComfyUI-LLM-Prompt-Tagger",
             "id": "llm-prompt-tagger",


### PR DESCRIPTION
This PR removes the old MSXYZ node listing.

The project has been rebranded to SOLRICKS and the updated listing is already available as comfyui-solricks.

New repository:
https://github.com/SOLRICKS/comfyui-solricks

Thank you.