### PR TITLE
Add AntiMatter Nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -9,7 +9,7 @@
                 "https://github.com/AntiMatterComfy/antimatter-nodes"
             ],
             "install_type": "git-clone",
-            "description": "AntiMatter custom nodes for ComfyUI. Includes Anti_aspect_ratio_master for SDXL aspect ratio and resolution latent creation."
+            "description": "AntiMatter custom nodes for ComfyUI. Includes Anti_aspect_ratio_master for Flux, Z-Image, and ERNIE-oriented aspect ratio and resolution latent creation."
         },
         {
             "author": "Carasibana",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "AntiMatterComfy",
+            "title": "AntiMatter Nodes",
+            "id": "antimatter-nodes",
+            "reference": "https://github.com/AntiMatterComfy/antimatter-nodes",
+            "files": [
+                "https://github.com/AntiMatterComfy/antimatter-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "AntiMatter custom nodes for ComfyUI. Includes Anti_aspect_ratio_master for SDXL aspect ratio and resolution latent creation."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds AntiMatter Nodes to the custom node list.\n\nRepository: https://github.com/AntiMatterComfy/antimatter-nodes\nNodes:\n- Anti_aspect_ratio_master\n- Batch Loader from folder\n\nCategory: AntiMatter/Image\nFocus: Flux, Z-Image, and ERNIE-oriented aspect ratio presets plus local folder batch image loading.\n\nValidation: ran check.bat successfully.