### PR TITLE
Add Mask Editor One

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -92,6 +92,17 @@
             "description": "A massive node pack consisting of over 200 nodes, including image processing, masking, text handling, and arithmetic operations.\nNOTE: A replacement node pack provided for existing users following the retirement of the original author of the widely used WAS Node Suite."
         },
         {
+            "author": "ketle-man",
+            "title": "Mask Editor One",
+            "id": "comfyui-mask-editor-one",
+            "reference": "https://github.com/ketle-man/comfyui-mask-editor-one",
+            "files": [
+                "https://github.com/ketle-man/comfyui-mask-editor-one"
+            ],
+            "install_type": "git-clone",
+            "description": "A layer-based modal mask editor for ComfyUI with Photoshop-like controls. Features paint, color selection, alpha extraction, vector (Catmull-Rom spline), shape, and text tools, SAM3 AI segmentation, BiRefNet background removal, layer management with Undo/Redo (30 levels), ABR brush import, brush library, and multilingual UI (en/ja/zh)."
+        },
+        {
             "author": "Test.Data",
             "title": "TEST NODEPACK: DON'T INSTALL THIS #1",
             "reference": "https://github.com/ltdrdata/nodepack-test1-do-not-install",


### PR DESCRIPTION
## New custom node: Mask Editor One

- **Repository**: https://github.com/ketle-man/comfyui-mask-editor-one
- **Author**: ketle-man
- **License**: MIT

### Description

A layer-based modal mask editor for ComfyUI with Photoshop-like controls.

### Features

- Paint, color selection, alpha extraction, vector (Catmull-Rom spline), shape, and text tools
- SAM3 / SAM 3.1 AI segmentation (text prompt)
- BiRefNet background removal (via ComfyUI's native `comfy.bg_removal_model`)
- Layer management with Undo/Redo (30 levels per layer)
- ABR brush import (v1/v2/v6/v10), brush library with folder tree UI
- Multilingual UI: English / Japanese / Chinese
- Outputs: `IMAGE`, `MASK`, `inverted_mask`, `mask_image`

### Checklist

- [x] The repository is public
- [x] `__init__.py` exports `NODE_CLASS_MAPPINGS`
- [x] MIT License included
- [x] README available in English