### PR TITLE
Add EA_LMStudio: LM Studio integration by EnragedAntelope

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -39146,6 +39146,20 @@
             "description": "ComfyUI custom node pack for loading SDNQ quantized models"
         },
         {
+            "author": "EnragedAntelope",
+            "title": "EA_LMStudio",
+            "id": "ea-lmstudio",
+            "reference": "https://github.com/EnragedAntelope/EA_LMStudio",
+            "files": [
+                "https://github.com/EnragedAntelope/EA_LMStudio"
+            ],
+            "install_type": "git-clone",
+            "pip": [
+                "lmstudio>=1.0.0"
+            ],
+            "description": "LM Studio ComfyUI integration with easy model selection and many optimizations! Features auto model discovery, vision/VLM support, reasoning extraction for DeepSeek R1/Qwen3/QwQ models, and detailed stats with VRAM management."
+        },
+        {
             "author": "tester4488",
             "title": "mc_qwen",
             "reference": "https://github.com/tester4488/mc_qwen",


### PR DESCRIPTION
## Summary

Adds `EA_LMStudio` to `custom-node-list.json`.

- **Repo:** https://github.com/EnragedAntelope/EA_LMStudio
- **Author:** EnragedAntelope
- **What it does:** ComfyUI custom node for LM Studio integration — auto model discovery, vision/VLM support, reasoning extraction for DeepSeek R1 / Qwen3 / QwQ models, and VRAM management.

## Why this PR

The node is already published to the Comfy Registry (install path works fine), but the `github-stats.json` scraper only tracks repos listed in `custom-node-list.json`. Without this entry, the star count and "last updated" fields render blank on the Manager card. Adding the entry here enables the scraper to populate those fields on its next run.

## Checklist

- [x] JSON validated with `python -c "import json; json.load(open('custom-node-list.json', encoding='utf-8'))"`
- [x] Entry inserted adjacent to other EnragedAntelope entries
- [x] `install_type: git-clone`, `pip: ["lmstudio>=1.0.0"]` (the non-standard SDK dependency)
- [x] `reference` URL matches exact GitHub repo URL (case-sensitive)