### PR TITLE
Add ComfyUI Image Picker and ComfyUI Live Preview to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52845,7 +52845,7 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
-        }
+        },
         {
             "author": "TechnoWarrior2",
             "title": "ComfyUI Image Picker",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52846,5 +52846,25 @@
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
         }
+        {
+            "author": "TechnoWarrior2",
+            "title": "ComfyUI Image Picker",
+            "reference": "https://github.com/TechnoWarrior2/comfyui-image-picker",
+            "files": [
+                "https://github.com/TechnoWarrior2/comfyui-image-picker"
+            ],
+            "install_type": "git-clone",
+            "description": "Pauses your workflow and opens a popup window to manually pick which generated images pass through to the rest of the graph."
+        },
+        {
+            "author": "TechnoWarrior2",
+            "title": "ComfyUI Live Preview",
+            "reference": "https://github.com/TechnoWarrior2/comfyui-live-preview",
+            "files": [
+                "https://github.com/TechnoWarrior2/comfyui-live-preview"
+            ],
+            "install_type": "git-clone",
+            "description": "Displays a large draggable floating window with live denoising step previews as your image generates, similar to A1111 and Forge."
+        }
     ]
 }


### PR DESCRIPTION
Adds two new custom nodes to the registry:

- **ComfyUI Image Picker** — pauses a workflow and opens a popup window to manually select which generated images pass through to the rest of the graph. Supports single/multi select, fullscreen lightbox, countdown timer, and rerun button.

- **ComfyUI Live Preview** — displays a large draggable floating overlay window showing live denoising step previews as the image generates, similar to A1111 and Forge.