### PR TITLE
Add PSD Figure Creator node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52986,6 +52986,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ketle-man",
+            "title": "PSD Figure Creator",
+            "id": "psd-figure-creator",
+            "reference": "https://github.com/ketle-man/PSD-Figure-Creator",
+            "files": [
+                "https://github.com/ketle-man/PSD-Figure-Creator"
+            ],
+            "install_type": "git-clone",
+            "description": "Load PSD files, rig layers with interactive R / MR / SW control points, and composite as IMAGE + MASK. Supports setup/pose modes, model/pose library, background options, and i18n (ja/en/zh)."
         }
     ]
 }


### PR DESCRIPTION
## New Custom Node

**Title:** PSD Figure Creator  
**Author:** ketle-man  
**Repository:** https://github.com/ketle-man/PSD-Figure-Creator  

## Description

A ComfyUI custom node for loading PSD files, rigging layers with interactive control points, and compositing the result as `IMAGE` + `MASK` outputs.

**Key features:**
- R / MR / SW control points placed directly on the canvas
- Setup mode (configure rigs) / Pose mode (animate)
- Model & pose library (save/load `.psd-model.json`)
- Background options: checker / solid color / local image / upstream IMAGE node
- Capture → Queue Prompt bake
- i18n: auto-detected from `navigator.language` (Japanese / English / Simplified Chinese)

## Checklist

- [x] `install_type` is `git-clone`
- [x] `files` contains the GitHub repository URL
- [x] Repository is public
- [x] Node is working (tested on ComfyUI latest)