### PR TITLE
Add ComfyUI-GU_Nodepack

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52986,6 +52986,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "Alexander Guryev",
+            "title": "ComfyUI-GU_Nodepack",
+            "id": "comfyui-gu-nodepack",
+            "reference": "https://github.com/alexguryev/ComfyUI-GU_Nodepack",
+            "files": [
+                "https://github.com/alexguryev/ComfyUI-GU_Nodepack"
+            ],
+            "install_type": "git-clone",
+            "description": "Several utility nodes for ComfyUI: LoRA management, image annotation, project organization, sampling utilities, system integration."
         }
     ]
 }


### PR DESCRIPTION
Register [ComfyUI-GU_Nodepack](https://github.com/alexguryev/ComfyUI-GU_Nodepack) in `custom-node-list.json`.

> Re-submission of #2815, closed for security review. Security rationale is documented
> in the README (added in
> [d91cc62](https://github.com/alexguryev/ComfyUI-GU_Nodepack/commit/d91cc62))
> and summarized below.

## About the pack

27+ utility nodes for ComfyUI covering:

- LoRA management (stack, randomizer, motion LoRA, trigger-words filter)
- Image annotation (label overlay with configurable font/position)
- Project organization (project paths, naming conventions, file helpers)
- Sampling utilities (indexed sampler/scheduler pickers, resolution presets, sides pack/unpack)
- System integration (timer, save-image-info, get-node-active, switch-any-by-index)

## Security rationale

The previous PR was closed because automated scanning flagged `aiohttp.web` import in
`prestartup_script.py`. Here is the full rationale (also in README → Security Notes):

**`prestartup_script.py` imports `aiohttp.web`** — used solely to monkey-patch
`WebSocketResponse.prepare` to hook the moment a browser tab connects to ComfyUI.
The hook refreshes the LoRA file list and resets the seed-file flag.
**No custom HTTP routes or endpoints are registered.**

The patch is applied defensively: checks the method signature before installing,
wraps the original in try/except, falls back gracefully if the aiohttp API changes.

Other patterns confirmed absent:
- No `subprocess` or `exec()` calls
- No `pickle` usage
- JS `fetch()` calls only load the nodepack's own static `.txt` config files — standard ComfyUI extension pattern

## Metadata

- Repository: https://github.com/alexguryev/ComfyUI-GU_Nodepack
- License: MIT
- Python: >=3.10
- Version: v2.6.0 (tagged)
- `pyproject.toml` with `[tool.comfy]`, registered on registry.comfy.org (publisher `alexguryev`)

## Verification

- JSON validated with `python -m json.tool` after edit.
- No existing entries reordered.