### PR TITLE
Add ComfyUI-GMImageSaver to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52986,6 +52986,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ruminar",
+            "title": "ComfyUI-GMImageSaver",
+            "id": "gmimagesaver",
+            "reference": "https://github.com/ruminar/ComfyUI-GMImageSaver",
+            "files": [
+                "https://github.com/ruminar/ComfyUI-GMImageSaver"
+            ],
+            "install_type": "git-clone",
+            "description": "GraphicsMagick-based direct JPEG saver node for ComfyUI. Saves IMAGE tensors directly as JPEG without intermediate PNG files. JPEG-only, previewless, label-aware, and useful for organized batch/inventory workflows. NOTE: GraphicsMagick must be installed separately and available via GM_PATH or PATH."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds ComfyUI-GMImageSaver to `custom-node-list.json`.

ComfyUI-GMImageSaver provides a GraphicsMagick-based direct JPEG saver node for ComfyUI.

## Notes

- Saves ComfyUI IMAGE tensors directly as JPEG
- Does not create intermediate PNG files
- JPEG-only and previewless by design
- Supports label-aware filename / directory organization
- Works well with checkpoint inventory workflows such as ComfyUI-CheckpointHandpickerSuite while remaining loosely coupled
- GraphicsMagick must be installed separately and available via `GM_PATH` or `PATH`