### PR TITLE
Add ComfyUI Workflow Group Navigator

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "gregowahoo",
+            "title": "ComfyUI Workflow Group Navigator",
+            "reference": "https://github.com/gregowahoo/comfyui-navigator",
+            "files": [
+                "https://github.com/gregowahoo/comfyui-navigator"
+            ],
+            "install_type": "git-clone",
+            "description": "Floating panel that lists every group in your ComfyUI workflow — jump to any group, toggle on/off via rgthree Fast Groups Muter, reorder via drag-and-drop, configurable keyboard shortcuts. Designed for large multi-stage workflows."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds a new entry to `custom-node-list.json` for **comfyui-navigator**.

### Project
- Repo: https://github.com/gregowahoo/comfyui-navigator
- License: MIT
- Type: JS-only extension (no Python deps, no custom nodes — populates `WEB_DIRECTORY` only)

### What it does
A floating panel that lists every group in the current ComfyUI workflow and lets you:
- Click a row to pan + zoom to that group
- Click the toggle pill to enable/disable the group (drives an existing rgthree Fast Groups Muter)
- Drag rows to reorder them (order persists)
- Jump to rows via number-key shortcuts (multi-digit supported)
- Customize colors and key bindings via a settings panel

Built for workflows with many logical sub-stages where scrolling to a Fast Groups Muter every time is its own friction.

### Notes
- Requires [rgthree-comfy](https://github.com/rgthree/rgthree-comfy) and at least one Fast Groups Muter on the graph for full functionality (toggles render as a dashed placeholder otherwise; jump/reorder still work).
- Auto-activates when the open workflow has 2+ groups.

Thanks for maintaining the Manager.