### PR TITLE
Add Comfy EverAnimate to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -52986,6 +52986,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "younestft",
+            "title": "Comfy EverAnimate",
+            "reference": "https://github.com/younestft/Comfy_EverAnimate",
+            "files": [
+                "https://github.com/younestft/Comfy_EverAnimate"
+            ],
+            "install_type": "git-clone",
+            "description": "Native ComfyUI nodes for EverAnimate-style chunked WanAnimate workflows, including master/chunk settings, chunk calculation, image carry-over, and boundary color correction."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds Comfy EverAnimate to `custom-node-list.json` so it can be installed through ComfyUI Manager.

Repository: https://github.com/younestft/Comfy_EverAnimate

## Node pack

Native ComfyUI nodes for EverAnimate-style chunked WanAnimate workflows, including master/chunk settings, chunk calculation, image carry-over, and boundary color correction.