### PR TITLE
Add ComfyUI-Angelo (click-to-refine sampler)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -38372,7 +38372,7 @@
                 "https://github.com/ShootTheSound/comfyUI-Realtime-Lora"
             ],
             "install_type": "git-clone",
-            "description": "Train LoRAs directly inside ComfyUI. Supports SDXL (via sd-scripts), FLUX, Z-Image Turbo, and Wan 2.2 (via AI-Toolkit)."
+            "description": "Train and Block Edit and Save LoRAs directly inside ComfyUI. Supports SDXL (via sd-scripts), FLUX, Z-Image Turbo, and Wan 2.2 (via Musubi Tuner and AI-Toolkit)."
         },
         {
             "author": "shootthesound",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -40177,6 +40177,16 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "shootthesound",
+            "title": "ComfyUI-Angelo",
+            "reference": "https://github.com/shootthesound/ComfyUI-Angelo",
+            "files": [
+                "https://github.com/shootthesound/ComfyUI-Angelo"
+            ],
+            "install_type": "git-clone",
+            "description": "Click-to-refine sampler. Generate, then click or paint regions to refine them in place. First-class support for FLUX 2 Klein 9B and Qwen-Image-Edit (Smart Inpaint / Smart Guided Inpaint / Xtra-Fine), works with any sampler-compatible model for Refine + Area Prompt. Optional SAM 3 Detect for text-prompted segmentation, and a companion Overrides node for custom samplers (power-sigma, Flux 2 scheduler, NAG)."
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyUI-Angelo to the custom node list.

Angelo is a click-to-refine sampler — generate an image, then click or paint on regions you want improved. Each click refines just that area while the rest stays bit-exact. One node replaces the standard KSampler + post-processing chain. First-class edit support for FLUX 2 Klein 9B and Qwen-Image-Edit; works with any sampler-compatible model for the Refine + Area Prompt paths.

Key features:
- Refine mode: click or paint a region for partial-denoise touch-ups
- Xtra-Fine: ADetailer-style crop + upscale + refine + composite
- Smart Inpaint (drag rectangle, add new content via edit model)
- Smart Guided Inpaint (location-by-words via dropdown — no painting)
- Area Prompt (refine a region with a different prompt)
- Detect mode (optional SAM 3 — text-prompted segmentation)
- Re-roll / Persistent Mask / Undo / Redo
- Optional companion node "Angelo — Overrides" for full custom sampler control (power-sigma, Flux 2 scheduler, NAG-Extended, custom guiders)

Repo: https://github.com/shootthesound/ComfyUI-Angelo
Current release: v1.6.4
License: MIT