### PR TITLE
Add Sequential Image Loader

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "shootthesound",
+            "title": "ComfyUI-SequentialImageLoader",
+            "reference": "https://github.com/shootthesound/ComfyUI-SequentialImageLoader",
+            "files": [
+                "https://github.com/shootthesound/ComfyUI-SequentialImageLoader"
+            ],
+            "install_type": "git-clone",
+            "description": "Load a folder of images one at a time, in order — a fresh image on every Queue. Natural sort, filetype picker, reverse, subfolders, hold/pause, scrub bar, folder browser, and current/next previews."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds **Sequential Image Loader** to the custom node list.

- Repo: https://github.com/shootthesound/ComfyUI-SequentialImageLoader
- Comfy Registry: https://registry.comfy.org/nodes/sequential-image-loader
- Author: shootthesound

A paced, single-image folder sequencer — loads a folder of images one at a time, in order, advancing one image per Queue press. Useful for batch-processing frames or photos through any ComfyUI workflow without rewiring between runs.