### PR TITLE
Update Realtime LoRA Toolkit description

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -40795,7 +40795,7 @@
                 "https://github.com/ShootTheSound/comfyUI-Realtime-Lora"
             ],
             "install_type": "git-clone",
-            "description": "Train and Block Edit and Save LoRAs directly inside ComfyUI. Supports SDXL (via sd-scripts), FLUX, Z-Image Turbo, and Wan 2.2 (via Musubi Tuner and AI-Toolkit)."
+            "description": "Train, analyze, selectively load, and extract/merge LoRAs inside ComfyUI. Supports Z-Image, Qwen Image, Qwen Image Edit, SDXL, FLUX, FLUX Klein, Wan 2.2, and SD 1.5. Includes LoRA layer analyzers, selective block loaders, model layer editors, and text-encoder debiasing/inspection tools."
         },
         {
             "author": "shootthesound",


### PR DESCRIPTION
Updates the description for the existing `comfyui-realtime-lora` entry to reflect the current node set. The Clippy Reloaded, Image of the Day, and Model Diff to LoRA utility nodes are now published as standalone nodes, so the description now focuses on the training / analysis / editing toolkit.