### PR TITLE
add Anima PiD and EasyControl node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47601,6 +47601,26 @@
             "description": "Spectrum: training-free diffusion sampling acceleration via Chebyshev polynomial feature forecasting. Drop-in KSampler replacement that skips transformer blocks on predicted steps for ~2-3x speedup."
         },
         {
+            "author": "sorryhyun",
+            "title": "Anima PiD",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Anima-PiD",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Anima-PiD"
+            ],
+            "install_type": "git-clone",
+            "description": "NVIDIA PiD (Pixel Diffusion Decoder) as a drop-in replacement for VAE Decode on Anima / Qwen-Image latents."
+        },
+        {
+            "author": "sorryhyun",
+            "title": "Easycontrol KSampler Compatible",
+            "reference": "https://github.com/sorryhyun/ComfyUI-EasyControl-KSamplerCompat",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-EasyControl-KSamplerCompat"
+            ],
+            "install_type": "git-clone",
+            "description": "KSampler-compatible Anima EasyControl image conditioning for ComfyUI."
+        },
+        {
             "author": "spacewarpstudio",
             "title": "ComfyUI Override Switch",
             "reference": "https://github.com/SpaceWarpStudio/ComfyUI-OverrideSwitch",


### PR DESCRIPTION
1. Anima PiD node: NVIDIA PiD (Pixel Diffusion Decoder) as a drop-in replacement for VAE Decode on Anima / Qwen-Image latents.

2. Easycontrol KSampler Compatible: KSampler-compatible Anima EasyControl image conditioning for ComfyUI