### PR TITLE
[codex] Update AntiMatter nodes in Manager registry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -49385,7 +49385,7 @@
                 "https://github.com/AntiMatterComfy/antimatter-nodes"
             ],
             "install_type": "git-clone",
-            "description": "AntiMatter custom nodes for ComfyUI. Includes Anti_aspect_ratio_master for Flux, Z-Image, and ERNIE-oriented latent creation plus Batch Loader from folder for local image batch loading."
+            "description": "AntiMatter custom nodes for ComfyUI. Includes aspect ratio tools, image/video folder batch loading and saving, prompt line/JSON scene loaders, LM Studio local API prompt agents, and a text file appender with scene-aware replacement."
         },
         {
             "author": "dewittethomas",

--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -3087,8 +3087,15 @@
             "Anti_aspect_ratio_master",
             "Antimatter_TextFileAppender",
             "Batch_Loader_From_Folder",
+            "Antimetter_Video_Batch_Loader",
+            "AntiMatter_Save_Video_in_Folder",
+            "AntiMatter_TextFilter",
+            "AntiMatter_Video_Save_Popular",
             "LinePrompt_MasterLoad",
-            "LinePrompt_MasterLoad_JSON"
+            "LinePrompt_MasterLoad_JSON",
+            "LinePrompt_MasterLoad_JSON_Image",
+            "LMStudioMultiInputSettingsAgent",
+            "LMStudioThreeImageAgent"
         ],
         {
             "title_aux": "AntiMatter Nodes"

--- a/node_db/new/extension-node-map.json
+++ b/node_db/new/extension-node-map.json
@@ -3087,8 +3087,15 @@
             "Anti_aspect_ratio_master",
             "Antimatter_TextFileAppender",
             "Batch_Loader_From_Folder",
+            "Antimetter_Video_Batch_Loader",
+            "AntiMatter_Save_Video_in_Folder",
+            "AntiMatter_TextFilter",
+            "AntiMatter_Video_Save_Popular",
             "LinePrompt_MasterLoad",
-            "LinePrompt_MasterLoad_JSON"
+            "LinePrompt_MasterLoad_JSON",
+            "LinePrompt_MasterLoad_JSON_Image",
+            "LMStudioMultiInputSettingsAgent",
+            "LMStudioThreeImageAgent"
         ],
         {
             "title_aux": "AntiMatter Nodes"


### PR DESCRIPTION
﻿## Summary

Updates the AntiMatter Nodes registry entry and node map so ComfyUI-Manager can resolve the current AntiMatter node classes, including `AntiMatter_Save_Video_in_Folder` and its popular-first alias.

## Details

- Expands the AntiMatter Nodes description in `custom-node-list.json`.
- Adds video save, video batch loader, text filter, JSON image loader, and LM Studio agent class names to `extension-node-map.json`.
- Mirrors the node map update in `node_db/new/extension-node-map.json`.

## Validation

- Ran `python -m json.tool` on the touched JSON files.
