### PR TITLE
Add bbc-s custom nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -21,6 +21,36 @@
             "description": "A visual state machine for consistent character generation. It intelligently maintains character identity, outfits, and locations across multiple generations using LLM-driven state management."
         },
         {
+            "author": "bbc-s",
+            "title": "ZIT-Ideogram",
+            "reference": "https://github.com/bbc-s/ZIT-Ideogram",
+            "files": [
+                "https://github.com/bbc-s/ZIT-Ideogram"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI visual regional prompt builder for Z-Image-Turbo, based on the KJNodes Ideogram box editor."
+        },
+        {
+            "author": "bbc-s",
+            "title": "metadata-saver-viewer",
+            "reference": "https://github.com/bbc-s/metadata-saver-viewer",
+            "files": [
+                "https://github.com/bbc-s/metadata-saver-viewer"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for saving one compact metadata JSON per generated image and viewing embedded image metadata."
+        },
+        {
+            "author": "bbc-s",
+            "title": "float-increment-per-latent",
+            "reference": "https://github.com/bbc-s/float-increment-per-latent",
+            "files": [
+                "https://github.com/bbc-s/float-increment-per-latent"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node for sweeping LoRA model strength per latent sample in a single batch."
+        },
+        {
             "author": "Dr.Lt.Data",
             "title": "ComfyUI-Manager",
             "id": "manager",


### PR DESCRIPTION
Adds three bbc-s ComfyUI custom node repositories to custom-node-list.json:

- ZIT-Ideogram
- metadata-saver-viewer
- float-increment-per-latent

Each entry uses git-clone install_type and points to the published GitHub repository.