### PR TITLE
Register ComfyUI MediaHub

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "vantang",
+            "title": "ComfyUI MediaHub",
+            "id": "mediahub-cloud",
+            "reference": "https://github.com/vantang/ComfyUI-MediaHub",
+            "files": [
+                "https://github.com/vantang/ComfyUI-MediaHub"
+            ],
+            "install_type": "git-clone",
+            "description": "Connect cloud image and video generation APIs to composable ComfyUI workflows."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
## Summary

Register [ComfyUI MediaHub](https://github.com/vantang/ComfyUI-MediaHub) in the ComfyUI-Manager custom node list.

ComfyUI MediaHub connects cloud image and video generation APIs to composable ComfyUI workflows. It is also published in Comfy Registry as [`mediahub-cloud`](https://registry.comfy.org/nodes/mediahub-cloud).

## Validation

- Parsed `custom-node-list.json` with `python3 -m json.tool`
- Ran `git diff --check`
- Confirmed the repository and Registry node are publicly accessible