### PR TITLE
Add ComfyUI-SCAIL-Pose2 custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37654,6 +37654,17 @@
             "description": "Your own personal AIGC Factory. Any picture. Any reel. The Comfy way. ©️"
         },
         {
+            "author": "rookiestar28",
+            "title": "ComfyUI-SCAIL-Pose2",
+            "id": "comfyui-scail-pose2",
+            "reference": "https://github.com/rookiestar28/ComfyUI-SCAIL-Pose2",
+            "files": [
+                "https://github.com/rookiestar28/ComfyUI-SCAIL-Pose2"
+            ],
+            "install_type": "git-clone",
+            "description": "SCAIL and SCAIL-2 pose/mask preprocessing for ComfyUI, including DWPose-compatible pose data, NLF pose renders, condition metadata, and WanVideoWrapper adapter payloads."
+        },
+        {
             "author": "MoonMoon82",
             "title": "ClipVision_Tools",
             "reference": "https://github.com/MoonMoon82/ClipVision_Tools",


### PR DESCRIPTION
## Summary

Adds ComfyUI-SCAIL-Pose2 to `custom-node-list.json` as a git-clone installable custom node.

The entry follows the existing rookiestar28 records and points to:

- https://github.com/rookiestar28/ComfyUI-SCAIL-Pose2

## Scope

ComfyUI-SCAIL-Pose2 provides SCAIL and SCAIL-2 pose/mask preprocessing nodes for ComfyUI, including DWPose-compatible pose data, NLF pose renders, condition metadata, and WanVideoWrapper adapter payloads.

## Validation

- `python json-checker.py custom-node-list.json`
- `git diff --check -- custom-node-list.json`