### PR TITLE
Fix aria2 path handling for local (non-Docker) installations

### DIFF
--- a/glob/manager_downloader.py
+++ b/glob/manager_downloader.py
@@ -80,10 +80,10 @@ def aria2_download_url(model_url: str, model_dir: str, filename: str):
     import tqdm
     import time
 
-    if model_dir.startswith(core.comfy_path):
-        model_dir = model_dir[len(core.comfy_path) :]
-
-    download_dir = model_dir if model_dir.startswith('/') else os.path.join('/models', model_dir)
+    if os.path.isabs(model_dir):
+        download_dir = model_dir
+    else:
+        download_dir = os.path.join('/models', model_dir)
 
     download = aria2_find_task(download_dir, filename)
     if download is None:

--- a/glob/manager_downloader.py
+++ b/glob/manager_downloader.py
@@ -80,7 +80,15 @@ def aria2_download_url(model_url: str, model_dir: str, filename: str):
     import tqdm
     import time
 
-    if os.path.isabs(model_dir):
+    # In Docker, aria2 runs in a separate container and can only access
+    # container-relative mount paths (e.g. /models, /custom_nodes), not host
+    # absolute paths. Outside Docker, use the full absolute path directly.
+    in_docker = os.path.exists('/.dockerenv') or os.environ.get('COMFYUI_ARIA2_CONTAINER_PATHS', '').lower() == 'true'
+
+    if in_docker and model_dir.startswith(core.comfy_path):
+        rel = model_dir[len(core.comfy_path):]
+        download_dir = rel if rel.startswith('/') else '/' + rel
+    elif os.path.isabs(model_dir):
         download_dir = model_dir
     else:
         download_dir = os.path.join('/models', model_dir)


### PR DESCRIPTION
The previous logic stripped the ComfyUI base path prefix and sent a root-relative path (e.g. /custom_nodes) to aria2 via RPC, causing a permission error when aria2 tried to create that directory at the filesystem root.

Use the full absolute path when model_dir is absolute; fall back to /models/"directory" only for relative paths (Docker-style setups).

Aria2 RPC was receiving /custom_nodes instead of the full path, causing permission denied on non-Docker (local venv's) installs.