### PR TITLE
Add ComfyUI LoRA Lab

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -8,7 +8,7 @@
                 "https://github.com/m3i3k3e/ComfyUI-LoRA-Lab"
             ],
             "install_type": "git-clone",
-            "description": "LoRA / prompt comparison-grid toolkit: count-adjustable prompt list (per-prompt positive+negative), strength-list axis, two-toggle Multi-LoRA/Multi-Prompt switch, self-captioning banner, and workflow-embedded WEBP saver, bundled with a GPL-3 fork of jags111's efficiency-nodes for the XY-plot grid engine. Note: bundles efficiency nodes; do not install alongside stock efficiency-nodes-comfyui (shared node names collide)."
+            "description": "LoRA / prompt comparison-grid toolkit: count-adjustable prompt list (per-prompt positive+negative), strength-list axis, two-toggle Multi-LoRA/Multi-Prompt switch, self-captioning banner, and workflow-embedded WEBP saver, bundled with a GPL-3 fork of jags111's efficiency-nodes for the XY-plot grid engine."
         },
         {
             "author": "Carasibana",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "Mythspire",
+            "title": "ComfyUI LoRA Lab",
+            "reference": "https://github.com/m3i3k3e/ComfyUI-LoRA-Lab",
+            "files": [
+                "https://github.com/m3i3k3e/ComfyUI-LoRA-Lab"
+            ],
+            "install_type": "git-clone",
+            "description": "LoRA / prompt comparison-grid toolkit: count-adjustable prompt list (per-prompt positive+negative), strength-list axis, two-toggle Multi-LoRA/Multi-Prompt switch, self-captioning banner, and workflow-embedded WEBP saver, bundled with a GPL-3 fork of jags111's efficiency-nodes for the XY-plot grid engine. Note: bundles efficiency nodes; do not install alongside stock efficiency-nodes-comfyui (shared node names collide)."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds **ComfyUI LoRA Lab** (https://github.com/m3i3k3e/ComfyUI-LoRA-Lab) to the custom node list.

A LoRA / prompt comparison-grid toolkit (GPL-3): a count-adjustable prompt list with per-prompt positive+negative, a strength-list axis, a two-toggle Multi-LoRA/Multi-Prompt switch, a self-captioning banner, and a workflow-embedded WEBP saver. It bundles a GPL-3 fork of jags111's efficiency-nodes for the XY-plot grid engine (full credit in the repo's FORK_NOTICE.md).

Note: because it bundles the efficiency engine, it shares some node class names with stock `efficiency-nodes-comfyui` and should not be installed alongside it (documented in the README).

Verified loading cleanly in a live ComfyUI: all 45 nodes served by /object_info with no import errors.