### PR TITLE
Fix NKD Preview Tools entry: repo renamed + dedupe

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45999,13 +45999,13 @@
         },
         {
             "author": "nekodificador",
-            "title": "NKD Popup Preview",
-            "reference": "https://github.com/Nekodificador/ComfyUI-NKD-Popup-Preview",
+            "title": "NKD Preview Tools",
+            "reference": "https://github.com/Nekodificador/ComfyUI-NKD-Preview-Tools",
             "files": [
-                "https://github.com/Nekodificador/ComfyUI-NKD-Popup-Preview"
+                "https://github.com/Nekodificador/ComfyUI-NKD-Preview-Tools"
             ],
             "install_type": "git-clone",
-            "description": "A floating preview window node for ComfyUI. Ideal for multi-monitor setups."
+            "description": "Preview and masking tools for ComfyUI: floating popup preview window (multi-monitor, live TAESD preview) and a procedural mask painter that bridges any IMAGE source into the native mask editor."
         },
         {
             "author": "BacoHubo",
@@ -47610,16 +47610,6 @@
             ],
             "install_type": "git-clone",
             "description": "A lightweight health check plugin for ComfyUI that monitors custom node import status and provides colorful summary reports"
-        },
-        {
-            "author": "nekodificador",
-            "title": "NKD Popup Preview",
-            "reference": "https://github.com/Nekodificador/ComfyUI-NKD-Popup-Preview",
-            "files": [
-                "https://github.com/Nekodificador/ComfyUI-NKD-Popup-Preview"
-            ],
-            "install_type": "git-clone",
-            "description": "A floating preview window node for ComfyUI. Ideal for multi-monitor setups."
         },
         {
             "author": "nekodificador",


### PR DESCRIPTION
## What

The custom node repo `github.com/Nekodificador/ComfyUI-NKD-Popup-Preview` was **renamed** to `ComfyUI-NKD-Preview-Tools` (GitHub keeps the old→new redirect). `custom-node-list.json` still referenced the old name and contained a **duplicate** entry.

Effect: older ComfyUI-Manager installs (git-clone channel) tracked the orphaned old name and stopped detecting updates, while the scanner kept attributing the node classes (`NKDPopupPreviewNode`, `NKDMaskPainter`, `NKDReferenceImage`) to the old URL in `extension-node-map.json`.

## Changes

- Point `reference` / `files` to the current repo URL.
- Update title (`NKD Popup Preview` → `NKD Preview Tools`) and description to match the published package.
- Remove the duplicate entry.

`extension-node-map.json` is scanner-generated, so it will pick up the new URL automatically on the next scan once this reference is corrected.

The node is also published on the Comfy Registry as `comfyui-nkd-preview-tools`.