### PR TITLE
Add ComfyUI-Image-Safety-Gate

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "monkeykim111",
+            "title": "ComfyUI-Image-Safety-Gate",
+            "reference": "https://github.com/monkeykim111/ComfyUI-Image-Safety-Gate",
+            "files": [
+                "https://github.com/monkeykim111/ComfyUI-Image-Safety-Gate"
+            ],
+            "install_type": "git-clone",
+            "description": "Illustration-friendly NSFW + gore gate combining SmilingWolf WD tagger v3, CompVis CLIP safety checker, and OwenElliott image-safety-classifier-s NSFL signal with boolean OR. Drop-in compatible with the existing CLIP-based safety-checker node (matches the (IMAGE, nsfw) output signature)."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds entry for [ComfyUI-Image-Safety-Gate](https://github.com/monkeykim111/ComfyUI-Image-Safety-Gate) to `custom-node-list.json`.

## What the node does

Single node that returns `(IMAGE, BOOLEAN)` — passes the image through unchanged and emits an `nsfw` flag. The flag is the boolean OR of three signals tuned for illustration / anime workflows:

1. **SmilingWolf WD tagger v3** (ONNX) — `questionable + explicit` rating sum vs threshold. Five variants selectable from a widget (`vit`, `convnext`, `swinv2`, `vit-large`, `eva02-large`).
2. **CompVis stable-diffusion-safety-checker** (CLIP) — same model the existing `monkeykim111/ComfyUI-safety-checker` node uses, with matching sensitivity behaviour.
3. **OwenElliott image-safety-classifier-s** — NSFL dimension only (gore / violence), since the NSFW dimension over-triggers on illustrations.

Drop-in compatible with `monkeykim111/ComfyUI-safety-checker`: same `(IMAGE, nsfw)` output signature, so it can replace the existing node without changing the rest of the workflow.

## Entry

```json
{
    "author": "monkeykim111",
    "title": "ComfyUI-Image-Safety-Gate",
    "reference": "https://github.com/monkeykim111/ComfyUI-Image-Safety-Gate",
    "files": [
        "https://github.com/monkeykim111/ComfyUI-Image-Safety-Gate"
    ],
    "install_type": "git-clone",
    "description": "Illustration-friendly NSFW + gore gate combining SmilingWolf WD tagger v3, CompVis CLIP safety checker, and OwenElliott image-safety-classifier-s NSFL signal with boolean OR. Drop-in compatible with the existing CLIP-based safety-checker node (matches the (IMAGE, nsfw) output signature)."
}
```