### PR TITLE
Add ComfyUI-save-webp-meta-node to custom node list

### DIFF
--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -1589,15 +1589,25 @@
             "install_type": "git-clone",
             "description": "A ComfyUI custom node that blends a natural image with a stripe pattern image using pixel-wise multiplication, producing a geometric composite output."
         },
-        {
-            "author": "allegiancerecords0-afk",
-            "title": "Comfyui-LatentOR",
-            "reference": "https://github.com/allegiancerecords0-afk/Comfyui-LatentOR",
-            "files": [
-                "https://github.com/allegiancerecords0-afk/Comfyui-LatentOR"
-            ],
-            "install_type": "git-clone",
-            "description": "Latent detection logic node"
-        }
-    ]
+           {
+      "author": "allegiancerecords0-afk",
+      "title": "Comfyui-LatentOR",
+      "reference": "https://github.com/allegiancerecords0-afk/Comfyui-LatentOR",
+      "files": [
+        "https://github.com/allegiancerecords0-afk/Comfyui-LatentOR"
+      ],
+      "install_type": "git-clone",
+      "description": "Latent detection logic node"
+    },
+    {
+      "author": "ukr8b3g-cmyk",
+      "title": "ComfyUI-save-webp-meta-node",
+      "reference": "https://github.com/ukr8b3g-cmyk/ComfyUI-save-webp-meta-node",
+      "files": [
+        "https://github.com/ukr8b3g-cmyk/ComfyUI-save-webp-meta-node"
+      ],
+      "install_type": "git-clone",
+      "description": "Custom ComfyUI node for saving WebP images with metadata."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Add `ComfyUI-save-webp-meta-node` to the ComfyUI Manager custom node list.

Repository:
https://github.com/ukr8b3g-cmyk/ComfyUI-save-webp-meta-node

## What this node does
This custom node adds support for saving WebP images with metadata in ComfyUI.

## Validation
- Repository is public
- Added as a git-clone custom node entry