### PR TITLE
Add ComfyUI Save WebP Meta Node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53381,6 +53381,16 @@
             ],
             "install_type": "git-clone",
             "description": "Save WebP images with A1111-compatible generation parameters and ComfyUI prompt/workflow metadata."
+        },
+        {
+            "author": "ukr8b3g-cmyk",
+            "title": "Empty Latent Image Plus",
+            "reference": "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus"
+            ],
+            "install_type": "git-clone",
+            "description": "A compact Empty Latent Image replacement that also outputs WIDTH and HEIGHT values for ComfyUI workflows."
         }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53370,6 +53370,17 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+        {
+            "author": "ukr8b3g-cmyk",
+            "title": "ComfyUI Save WebP Meta Node",
+            "id": "save-webp-meta",
+            "reference": "https://github.com/ukr8b3g-cmyk/ComfyUI-save-webp-meta-node",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/ComfyUI-save-webp-meta-node"
+            ],
+            "install_type": "git-clone",
+            "description": "Save WebP images with A1111-compatible generation parameters and ComfyUI prompt/workflow metadata."
         }
     ]
 }


### PR DESCRIPTION
Additional update:

Adds Empty Latent Image Plus to custom-node-list.json.

Repository:
https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus

Description:
A compact Empty Latent Image replacement that also outputs WIDTH and HEIGHT values for ComfyUI workflows.