### PR TITLE
Add SpriteSheetExtractor node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53410,6 +53410,20 @@
             ],
             "install_type": "unzip",
             "description": "This is a node to convert an image into a CMYK Halftone dot image."
+        },
+         {
+            "author": "ugotworms",
+            "title": "Sprite Sheet Extractor Nodes for ComfyUI",
+            "id": "sprite-sheet-extractor",
+            "reference": "https://github.com/ugotworms/comfyui_sprite_sheet_extractor",
+            "files": [
+                "https://github.com/ugotworms/comfyui_sprite_sheet_extractor"
+            ],
+            "install_type": "git-clone",
+            "description": "Extract sprite sheets from WAN video output. Samples evenly-spaced frames, removes background via YCbCr chroma keying, applies palette lock for temporal colour drift correction, and saves a horizontal RGBA sprite sheet. Includes animated preview node.",
+            "category": "Image Processing",
+            "tags": ["sprite", "animation", "video", "wan", "background-removal", "chroma-key"],
+            "version": "1.0.0"
         }
     ]
 }


### PR DESCRIPTION
## Add SpriteSheetExtractor custom node

Adds two nodes for extracting sprite sheets from WAN (or any batch) video output:

- **SpriteSheetExtractor** — Samples evenly-spaced frames, removes background via per-frame YCbCr chroma keying with flood-fill, applies palette lock for colour drift correction, and saves a horizontal RGBA sprite sheet PNG. Includes an interactive "Tweak Tolerance" panel for live adjustment without re-running generation.
- **SpriteSheetPreview** — Displays the sprite sheet as a looping pixel-art animation with checkerboard background for transparent areas.

**Details:**
- `install_type`: `git-clone`
- No extra pip dependencies (uses PyTorch, numpy, Pillow — all ComfyUI built-ins)
- NODE_CLASS_MAPPINGS: `SpriteSheetExtractor`, `SpriteSheetPreview`
- Category: `image/animation`

**Repo:** https://github.com/ugotworms/comfyui_sprite_sheet_extractor