### PR TITLE
Add Bone-Studio Workflow Manager

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53130,6 +53130,16 @@
             "description": "Download models from HuggingFace (no API key) and manage your local ComfyUI models (list, move, delete) from a built-in panel."
         },
         {
+            "author": "bonestudio",
+            "title": "Bone-Studio Workflow Manager",
+            "reference": "https://github.com/juangea/bs-comfyui-workflow-manager",
+            "files": [
+                "https://github.com/juangea/bs-comfyui-workflow-manager"
+            ],
+            "install_type": "git-clone",
+            "description": "Organize your ComfyUI workflows for production: a folder manager plus a project layer (exportable internal DB), bulk export and optional Git versioning, from a built-in panel."
+        },
+        {
             "author": "TODO",
             "title": "ComfyUI-SCAIL2-LongVideoContext",
             "reference": "https://github.com/1GirlUniversity/ComfyUI-SCAIL2-LongVideoContext",


### PR DESCRIPTION
Adds **Bone-Studio Workflow Manager** to `custom-node-list.json`.

It's a published Comfy Registry node by the same author/publisher (`bonestudio`) as the existing **Bone-Studio Model Manager**, which is already in the list. This entry mirrors that one (single `git-clone` entry).

- **Repository:** https://github.com/juangea/bs-comfyui-workflow-manager
- **Registry:** https://registry.comfy.org/nodes/bs-comfyui-workflow-manager
- **License:** GPL-3.0-only · Python stdlib only (no extra deps)

**What it does:** organizes ComfyUI workflows for production from a built-in panel — a folder manager plus a project layer (exportable internal DB), bulk export to .zip, and optional per-project Git versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)