### PR TITLE
Update Deno Custom Nodes LTX AV sampler mapping

### DIFF
--- a/extension-node-map.json
+++ b/extension-node-map.json
@@ -7474,7 +7474,7 @@
             "DenoLTXMultiLoraLoader",
             "DenoLTXPromptGuide",
             "DenoLTXSequencer",
-            "DenoLTXStepFusedTiledSampler",
+            "DenoLTXAVStepFusedTiledSampler",
             "DenoLTXTiledSpatialUpscaler",
             "DenoLocalLLMRefiner",
             "DenoMultiImageLoader",


### PR DESCRIPTION
## Summary

- Replace the retired `DenoLTXStepFusedTiledSampler` mapping with `DenoLTXAVStepFusedTiledSampler` for Deno Custom Nodes.
- Keep `DenoLTXTiledSpatialUpscaler` unchanged.

## Context

Deno Custom Nodes v0.7.64 keeps the LTX tiled spatial upscaler and publishes the AV-aware tiled sampler as the public sampler node. The old video-only sampler is no longer registered publicly.
