### PR TITLE
Add ComfyUI-TJ_NODE_STUDIO_ONE to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "designloves2",
+            "title": "ComfyUI-TJ_NODE_STUDIO_ONE",
+            "id": "ComfyUI-TJ_NODE_STUDIO_ONE",
+            "reference": "https://github.com/designloves2/ComfyUI-TJ_NODE_STUDIO_ONE",
+            "files": [
+                "https://github.com/designloves2/ComfyUI-TJ_NODE_STUDIO_ONE"
+            ],
+            "install_type": "git-clone",
+            "description": "One-node studio UI package for Z-Image Turbo, Flux.2 Klein, Qwen Image Edit 2511, and Krea 2 workflows, including T2I, I2I, inpaint, outpaint, edit, faceswap, angle, and upscale modes."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Hi, I would like to add my new custom node package ComfyUI-TJ_NODE_STUDIO_ONE to the ComfyUI Manager custom node list.

Repository:
https://github.com/designloves2/ComfyUI-TJ_NODE_STUDIO_ONE

This package provides one-node studio UIs for Z-Image Turbo, Flux.2 Klein, Qwen Image Edit 2511, and Krea 2 workflows, including T2I, I2I, inpaint, outpaint, edit, faceswap, angle, and upscale modes.

Only `custom-node-list.json` is changed in this PR.

Thank you!