### PR TITLE
Add Krea2-BBOX-Prompter custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53404,6 +53404,16 @@
             "description": "Quality-preserving per-layer conditioning control for Krea 2 - ComfyUI custom node (enhanced fork of nova452/ComfyUI-ConditioningKrea2Rebalance)."
         },
         {
+            "author": "ukr8b3g-cmyk",
+            "title": "Krea2-BBOX-Prompter",
+            "reference": "https://github.com/ukr8b3g-cmyk/Krea2-BBOX-Prompter",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/Krea2-BBOX-Prompter"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node package for Krea2 prompt effects with an interactive BBOX canvas, preset cards, local thumbnails, and workflow examples."
+        },
+        {
             "author": "aiknowledge2go",
             "title": "ComfyUI-AI2Go-Utils",
             "reference": "https://github.com/Little-God1983/ComfyUI-AI2Go-Utils",


### PR DESCRIPTION
Adds Krea2-BBOX-Prompter to custom-node-list.json for ComfyUI-Manager installation.

Repository: https://github.com/ukr8b3g-cmyk/Krea2-BBOX-Prompter

This package provides Krea2 prompt effect helpers with an interactive BBOX canvas, preset cards, local thumbnails, and workflow examples.