### PR TITLE
Add Seedance 2.0 BytePlus custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -48331,6 +48331,17 @@
             "description": "Run ByteDance Seedance 2.0 video generation in ComfyUI via Sjinn.ai API. Supports up to 6 image, 3 video and 2 audio references. Outputs native VIDEO plus first frame, last frame and frame batch."
         },
         {
+            "author": "nnnnkatsu",
+            "title": "Seedance 2.0 BytePlus",
+            "id": "seedance2-comfyui-byteplus",
+            "reference": "https://github.com/nnnnkatsu/seedance2-comfyui-byteplus",
+            "files": [
+                "https://github.com/nnnnkatsu/seedance2-comfyui-byteplus"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for BytePlus ModelArk Seedance 2.0 direct API generation. Supports text/image/omni/reference video workflows, AWS S3 private reference video upload and browsing, batch result selection, generation history, and saved-video workflow metadata."
+        },
+        {
             "author": "knottttt",
             "title": "ComfyUI TinyPNG",
             "id": "comfyui-tinypng",


### PR DESCRIPTION
Adds the Seedance 2.0 BytePlus ComfyUI custom node to custom-node-list.json.

Repository: https://github.com/nnnnkatsu/seedance2-comfyui-byteplus

This node pack provides BytePlus ModelArk Seedance 2.0 direct API generation nodes, AWS S3 private reference video upload/browse helpers, batch result selection, generation history browsing, and saved-video workflow metadata support.

Validation run locally:
- PYTHONIOENCODING=utf-8 python json-checker.py custom-node-list.json