### PR TITLE
Add SF ComfyUI Nodes by Stillfront

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -3973,6 +3973,16 @@
             "description": "This extension contains a set of custom nodes for ComfyUI that allow you to use Core ML models in your ComfyUI workflows. The models can be obtained here, or you can convert your own models using coremltools. The main motivation behind using Core ML models in ComfyUI is to allow you to utilize the ANE (Apple Neural Engine) on Apple Silicon (M1/M2) machines to improve performance."
         },
         {
+            "author": "Stillfront",
+            "title": "SF ComfyUI Nodes",
+            "reference": "https://github.com/Stillfront/comfyui-sf-nodes",
+            "files": [
+                "https://github.com/Stillfront/comfyui-sf-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for ComfyUI including LLM Chat (Claude, Gemini, GPT), WaveSpeed AI image and video generation, VertexAI integration, and workflow utilities."
+        },
+        {
             "author": "taabata",
             "title": "Syrian Falcon Nodes",
             "id": "syrian",


### PR DESCRIPTION
## Add SF ComfyUI Nodes

**Repository:** https://github.com/Stillfront/comfyui-sf-nodes

**Author:** Stillfront

**Description:** Custom nodes for ComfyUI including:
- LLM Chat with support for Claude, Gemini, and OpenAI GPT models (with image input and token reporting)
- WaveSpeed AI image and video generation (40+ nodes: VEO, Sora, Qwen, Flux, ByteDance Seedream, Kling, VIDU, WAN, and more)
- VertexAI integration (Imagen3, VEO via Google Cloud)
- Utility nodes: resolution presets, dynamic prompt lists, text analyzer

All nodes are prefixed with "SF" for easy searching in ComfyUI.