### PR TITLE
Add ComfyUI Local Wildcards custom node

### DIFF
--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -760,6 +760,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for LongCat Video Avatar 1.5 audio-driven human video generation."
+        },
+        {
+              "author": "DutchyDutch",
+              "title": "ComfyUI Local Wildcards",
+              "reference": "https://github.com/DutchyDutch/ComfyUI_Local_Wildcards",
+              "files": [
+                "https://github.com/DutchyDutch/ComfyUI_Local_Wildcards"
+              ],
+              "install_type": "git-clone",
+              "description": "A ComfyUI local wildcard text expansion node with support for .txt, .json, .yaml, and .yml wildcard files, plus Dynamic Prompts-style syntax."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds ComfyUI Local Wildcards to the ComfyUI Manager node database.

## Node information

- Name: ComfyUI Local Wildcards
- Author: DutchyDutch
- Repository: https://github.com/DutchyDutch/ComfyUI_Local_Wildcards
- Install type: git-clone

## Description

ComfyUI Local Wildcards is a local wildcard text expansion node for ComfyUI.

It supports:

- `__wildcard__` syntax
- Local wildcard files using `.txt`, `.json`, `.yaml`, and `.yml`
- Folder-based wildcard names such as `__folder/name__`
- Dynamic Prompts-style choices such as `{red|blue|green}`
- Multi-select syntax such as `{1-3$$ and $$Round}`
- Explicit wildcard multi-select syntax such as `{1-3$$ and $$__Round__}`
- Weighted options such as `{common::0.9|rare::0.1}`

## Related issue

Related issue: #3026