### PR TITLE
Add ComfyUI-HiCache and ComfyUI-TRELLIS2-HiCache

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -53973,6 +53973,26 @@
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node suite for profiling, visualizing and steering attention heads in LTX-Video 2.3 (distill & dev)."
+        },
+        {
+            "author": "archerkattri",
+            "title": "ComfyUI-HiCache",
+            "reference": "https://github.com/Archerkattri/ComfyUI-HiCache",
+            "files": [
+                "https://github.com/Archerkattri/ComfyUI-HiCache"
+            ],
+            "install_type": "git-clone",
+            "description": "Training-free Hunyuan3D shape-generation acceleration: skip DiT steps and forecast the flow-matching velocity instead (HiCache Hermite / HiCache++ DMD, via hicache-pp). Pairs with kijai/ComfyUI-Hunyuan3DWrapper."
+        },
+        {
+            "author": "archerkattri",
+            "title": "ComfyUI-TRELLIS2-HiCache",
+            "reference": "https://github.com/Archerkattri/ComfyUI-TRELLIS2-HiCache",
+            "files": [
+                "https://github.com/Archerkattri/ComfyUI-TRELLIS2-HiCache"
+            ],
+            "install_type": "git-clone",
+            "description": "Training-free TRELLIS.2 image-to-3D acceleration: forecast the flow-matching velocity on skipped DiT steps (HiCache Hermite / HiCache++ DMD, via hicache-pp) across the sparse-structure and shape-SLaT stages (texture optional). ~2x faster, near-lossless. Pairs with visualbruno/ComfyUI-Trellis2."
         }
     ]
 }


### PR DESCRIPTION
Adds two of my custom nodes (both already published on registry.comfy.org, listed here for the legacy channel; ComfyUI-TRELLIS-HiCache is already in the list):

- **ComfyUI-HiCache** — training-free Hunyuan3D shape-generation acceleration (skip DiT steps, forecast the flow-matching velocity; HiCache Hermite / HiCache++ DMD via hicache-pp). Pairs with kijai/ComfyUI-Hunyuan3DWrapper.
- **ComfyUI-TRELLIS2-HiCache** — the same training-free acceleration for TRELLIS.2 image-to-3D (~2x, near-lossless). Pairs with visualbruno/ComfyUI-Trellis2.

Checked the JSON loads cleanly (python json.load, 5182 nodes) and followed the existing entry format.