### PR TITLE
Add ComfyUI Krea Reference

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "kgilper",
+            "title": "ComfyUI Krea Reference",
+            "id": "comfyui-krea-reference",
+            "reference": "https://github.com/kgilper/krea-reference",
+            "files": [
+                "https://github.com/kgilper/krea-reference"
+            ],
+            "install_type": "git-clone",
+            "description": "Give each reference image a job before it reaches Krea 2. Guide cards assign per-image roles (keep the same subject, suggest the visual style, copy lighting or pose, big shapes only, avoid copying text/logos) and the stack encoder builds Krea conditioning with per-card strength, per-layer gains, and guarded prompt handling."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adding my node pack for Krea 2 reference conditioning.

**Repo:** https://github.com/kgilper/krea-reference

The idea is simple: give each reference image a job before it reaches Krea 2. A guide card assigns each image a plain-language role (keep the same subject, suggest the visual style, copy lighting or pose, big shapes only, avoid copying text/logos), and a stack encoder combines up to 12 cards plus the written prompt into standard conditioning with per-card strength, per-layer gains, and guarded prompt handling.

A few notes for review:

- Pure Python plus a small web extension. No model weights, and no pip dependencies beyond a standard ComfyUI install.
- Registers two nodes under advanced/conditioning: `KGKrea2ImageGuideCardV9` and `KGTextEncodeKreaImageReferencesV9`.
- Ships example workflows, ComfyUI-free contract tests, and full documentation including a technical paper on how the conditioning math works.
- The entry id matches the `[tool.comfy]` name in the repo's pyproject.toml (`comfyui-krea-reference`), so a future registry listing maps cleanly.
- JSON validated with a strict parser after the edit (list parses clean, entry count 5181 to 5182).

Thanks for maintaining this. Let me know if anything about the entry needs adjusting.

Kevin