### PR TITLE
Add Danbooru Tag JP Assist

### DIFF
--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "ukr8b3g-cmyk",
+            "title": "Danbooru Tag JP Assist",
+            "reference": "https://github.com/ukr8b3g-cmyk/Danbooru-Tag-JP-Assist",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/Danbooru-Tag-JP-Assist"
+            ],
+            "install_type": "git-clone",
+            "description": "Japanese-assisted tag autocomplete for ComfyUI text areas. Supports Danbooru tags, bundled natural language tags, local CSV tag files, Japanese aliases, popup settings, and optional Danbooru CSV update from Hugging Face."
+        },
+        {
             "author": "DutchyDutch",
             "title": "ComfyUI Local Wildcards",
             "reference": "https://github.com/DutchyDutch/ComfyUI_Local_Wildcards",


### PR DESCRIPTION
Adds Danbooru Tag JP Assist to the new custom node list.

Repository: https://github.com/ukr8b3g-cmyk/Danbooru-Tag-JP-Assist

Features:
- Japanese-assisted tag autocomplete for ComfyUI text areas
- Danbooru tag CSV support with optional Hugging Face update
- Bundled natural language tags and Japanese translation files
- Local CSV tag and translation file selection