### PR TITLE
[codex] Register Anima-Tools custom node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54005,6 +54005,17 @@
             "description": "Gemma 4 reference-image prompt nodes for ComfyUI"
         },
         {
+            "author": "nnegret",
+            "title": "Anima-Tools",
+            "id": "comfyui-anima-tools",
+            "reference": "https://github.com/nregret/Comfyui-Anima-Tools",
+            "files": [
+                "https://github.com/nregret/Comfyui-Anima-Tools"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for anime prompt selection, random prompt generation, background and character tag composition, and Anima LoRA search, download, and loading."
+        },
+        {
             "author": "ashen3",
             "title": "Two-Stage Sampler and Krea 2 Resolution Picker",
             "reference": "https://github.com/Auryg/Krea-2-Two-Stage-Sampler",


### PR DESCRIPTION
## Summary

Adds Anima-Tools to `custom-node-list.json` so ComfyUI-Manager can recognize the GitHub repository through the legacy custom node database.

## Why

Anima-Tools is already published on Comfy Registry as `comfyui-anima-tools`, but the Manager table can show `N/A` for stars and last update when a node is only present through the Registry path. Adding the GitHub repository to the legacy list lets the existing Manager stats pipeline associate the node with `https://github.com/nregret/Comfyui-Anima-Tools`.

## Checks

- `python -m json.tool custom-node-list.json`
- `PYTHONIOENCODING=utf-8 python json-checker.py custom-node-list.json`
- `git diff --check -- custom-node-list.json`
