### PR TITLE
Add ComfyUI Agent Panel (comfyui-mcp-panel)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "artokun",
+            "title": "ComfyUI Agent Panel",
+            "reference": "https://github.com/artokun/comfyui-mcp-panel",
+            "files": [
+                "https://github.com/artokun/comfyui-mcp-panel"
+            ],
+            "install_type": "git-clone",
+            "description": "Agent sidebar panel for ComfyUI — chat with an autonomous agent (Claude, Codex/GPT, Gemini, or local Ollama) that builds, runs, and debugs workflows on your live canvas. UI-only pack (also on the Comfy Registry as comfyui-agent-panel); pairs with the comfyui-mcp orchestrator: npx -y comfyui-mcp@latest --panel-orchestrator"
+        },
+        {
             "author": "designloves2",
             "title": "ComfyUI-TJ_NODE_STUDIO_ONE",
             "id": "ComfyUI-TJ_NODE_STUDIO_ONE",


### PR DESCRIPTION
This adds ComfyUI Agent Panel, an agent sidebar panel for ComfyUI: a UI-only custom node pack (WEB_DIRECTORY-served frontend, no Python nodes) that lets you chat with an autonomous agent (Claude, Codex/GPT, Gemini, or local Ollama) that builds, runs, and debugs workflows on the live canvas.

The pack is already published on the Comfy Registry as comfyui-agent-panel (v0.5.0) and users are installing it through Manager today. This PR adds it to the legacy custom-node-list.json for discoverability.

Repo: https://github.com/artokun/comfyui-mcp-panel