### PR TITLE
Add ResolutionMaster preemption for Comfyui-Resolution-Master

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -33152,6 +33152,9 @@
                 "https://github.com/Azornes/Comfyui-Resolution-Master"
             ],
             "install_type": "git-clone",
+            "preemptions": [
+                "ResolutionMaster"
+            ],
             "description": " Precise resolution and aspect ratio control for ComfyUI"
         },
         {


### PR DESCRIPTION
## Summary

This PR adds ResolutionMaster as a preemption for Azornes/Comfyui-Resolution-Master in custom-node-list.json.

## Context

Comfyui-Resolution-Master is the original provider of the ResolutionMaster ComfyUI node used by existing workflows.

Another node pack now also registers a node with the same technical node id/class type: ResolutionMaster. This creates an ambiguous mapping in ComfyUI-Manager. When users load workflows with missing nodes and use the missing-node installer, Manager can suggest or install the conflicting package, which may cause workflows expecting Comfyui-Resolution-Master to load the wrong implementation.

## Change

This PR marks Azornes/Comfyui-Resolution-Master as the preferred provider for the ResolutionMaster node id:

`json
"preemptions": [
  "ResolutionMaster"
]
`

This does not remove or block the other node pack. It only helps ComfyUI-Manager resolve the ResolutionMaster node id to the original package when installing missing nodes.

## Related repositories

Original node:
https://github.com/Azornes/Comfyui-Resolution-Master

Conflicting node pack:
https://github.com/axces2000/comfyui-axces2000