### PR TITLE
Update ComfyUI Krea Reference description: Concept Slider nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54044,7 +54044,7 @@
                 "https://github.com/kgilper/krea-reference"
             ],
             "install_type": "git-clone",
-            "description": "Give each reference image a job before it reaches Krea 2. Guide cards assign per-image roles (keep the same subject, suggest the visual style, copy lighting or pose, big shapes only, avoid copying text/logos) and the stack encoder builds Krea conditioning with per-card strength, per-layer gains, and guarded prompt handling."
+            "description": "Give each reference image a job, and every attribute a dial. Guide cards assign per-image roles (keep the same subject, suggest the visual style, copy lighting or pose, big shapes only, avoid copying text/logos) with per-card strength, timing, and user-defined recipes - and Concept Slider cards turn any attribute you can name (brightness, age, fog density) into a training-free -6..+6 dial derived from Krea 2 text encoding."
         },
         {
             "author": "DutchyDutch",


### PR DESCRIPTION
Description-only update to the existing `ComfyUI Krea Reference` entry (applied directly by @ltdrdata when #3045 was closed - thanks!).

Version 0.4.0 of the pack (`comfyui-krea-reference` on the registry, published today) adds a second product line: Concept Slider nodes - training-free attribute dials (-6..+6) derived from Krea 2 text encoding at encode time. The updated description covers both the guide cards and the sliders so the listing matches what the pack now does.

No other fields changed.