### PR TITLE
Add ComfyUI-NukeLink

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54176,6 +54176,17 @@
             ],
             "install_type": "git-clone",
             "description": "Native ComfyUI nodes for EverAnimate-style chunked WanAnimate workflows, including master/chunk settings, chunk calculation, image carry-over, and boundary color correction."
+        },
+        {
+            "author": "drberkowitz",
+            "title": "ComfyUI-NukeLink",
+            "id": "comfyui-nukelink",
+            "reference": "https://github.com/drberkowitz/ComfyUI-NukeLink",
+            "files": [
+                "https://github.com/drberkowitz/ComfyUI-NukeLink"
+            ],
+            "install_type": "git-clone",
+            "description": "A bridge between Nuke and ComfyUI on the same machine. Send Read nodes from Nuke directly to the ComfyUI canvas with knob values intact, and return rendered outputs back to Nuke as Read nodes."
         }
     ]
 }


### PR DESCRIPTION
## Summary
Adds ComfyUI-NukeLink to the ComfyUI Manager custom node list.  ComfyUI-NukeLink bridges Foundry's Nuke and ComfyUI on the same machine.

## Extension Information
- **Name:** ComfyUI NukeLink
- **Author:** drberkowitz
- **Repository:** https://github.com/drberkowitz/ComfyUI-NukeLink
- **Install type:** git-clone
- **Nodes:** NukeLink - Read, NukeLink - Write, NukeLink - Path Builder

## Features
* Send one or more Nuke Read nodes to ComfyUI with knob values intact: file path, colorspace, frame range, and missing frames mode
* Automatic Path Builder node placement, pre-populated with output location, and shot name
* Shot name and output location derived from pipeline environment variables or script filename
* Send ComfyUI outputs back to Nuke as Read nodes via right-click menu on any NukeLink - Write node
* Sequence and still image preview with right-click menu playback controls on Read and Write nodes
* Missing frames handling: black, hold, nearest, and error modes
* Colorspace support: raw, sRGB, linear, and ACEScg
* Multiple simultaneous Nuke instances
* Standard, portable, and desktop ComfyUI installs supported