### PR TITLE
Add Empty Latent Image Plus

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54216,6 +54216,16 @@
             ],
             "install_type": "git-clone",
             "description": "int8 dp4a (sm_70/Volta) acceleration for diffusion DiTs in ComfyUI, over the fni8 kernels"
+        },
+        {
+            "author": "ukr8b3g-cmyk",
+            "title": "Empty Latent Image Plus",
+            "reference": "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus"
+            ],
+            "install_type": "git-clone",
+            "description": "A compact Empty Latent Image replacement that also outputs WIDTH and HEIGHT values for ComfyUI workflows."
         }
     ]
 }


### PR DESCRIPTION
Adds Empty Latent Image Plus to the ComfyUI Manager custom node list.

Repository: https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus

Description:
A compact Empty Latent Image replacement that also outputs WIDTH and HEIGHT values for ComfyUI workflows.

Validation:
- Added as a git-clone custom node entry
- Confirmed custom-node-list.json parses as JSON
- Kept this PR scoped to Empty Latent Image Plus only