### PR TITLE
Add TINT4 — INT4 Weight-Only Quantization via torchao

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54236,6 +54236,18 @@
             ],
             "install_type": "git-clone",
             "description": "Block Swap (RAM Offload) node for native ComfyUI MODEL - run DiT models larger than VRAM by streaming transformer blocks from system RAM."
+        },
+        {
+            "author": "JWLHS",
+            "title": "TINT4 — INT4 Weight-Only Quantization via torchao",
+            "id": "tint4_xpu",
+            "reference": "https://github.com/JWLHS/ComfyUI-TINT4-XPU",
+            "files": [
+                "https://github.com/JWLHS/ComfyUI-TINT4-XPU"
+            ],
+            "install_type": "git-clone",
+            "description": "INT4 weight-only quantization (W4A16) for diffusion models via torchao. Activations remain FP16 — zero quantization quality loss. Full LoRA support: standard + LoKr format compatible, multi-LoRA stack (≤5), IS_CHANGED fingerprint skip (0s repeat generation), SHA256 JSON disk cache (<1s hit), GPU pre-hook bake-in. Supports Intel Arc XPU, NVIDIA CUDA, AMD ROCm. Verified on Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu. Includes model analysis CLI. Requires: pip install torchao>=0.17.0"
         }
     ]
 }
+

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1115,6 +1115,16 @@
             "description": "Comics/Manga like panel layouts."
         },
         {
+            "author": "bmad4ever",
+            "title": "comfyui_quasi_secure_load_image_url",
+            "reference": "https://github.com/bmad4ever/comfyui_quasi_secure_load_image_url",
+            "files": [
+                "https://github.com/bmad4ever/comfyui_quasi_secure_load_image_url"
+            ],
+            "install_type": "git-clone",
+            "description": "Fetch PNG, JPEG, WebP and SVG images via URL. Has SSRF protection, size limits, SVG sanitisation; however, no formal security audit has been performed."
+        },
+        {
             "author": "FizzleDorf",
             "title": "FizzNodes",
             "id": "fizz",
@@ -5444,6 +5454,16 @@
             "description": "Enhanced the comfyui savevideo node to support previewing and saving videos containing alpha channels."
         },
         {
+            "author": "yolain",
+            "title": "ComfyUI-Easy-Sam3",
+            "reference": "https://github.com/yolain/ComfyUI-Easy-Sam3",
+            "files": [
+                "https://github.com/yolain/ComfyUI-Easy-Sam3"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node package for segment anything 3"
+        },
+        {
             "author": "bruefire",
             "title": "ComfyUI Sequential Image Loader",
             "id": "comfyui-sq-imageloader",
@@ -6049,6 +6069,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI Taylor attention custom node"
+        },
+        {
+            "author": "ttulttul",
+            "title": "Modal Sync",
+            "reference": "https://github.com/ttulttul/ComfyUI-Modal",
+            "files": [
+                "https://github.com/ttulttul/ComfyUI-Modal"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node extension for routing marked nodes to Modal-backed execution."
         },
         {
             "author": "jitcoder",
@@ -10042,6 +10072,16 @@
             "description": "ComfyUI Custom Nodes including FrameRangedFaceLoader for consistent face editing and framing"
         },
         {
+            "author": "alisson-anjos",
+            "title": "ComfyUI-LocateAnything",
+            "reference": "https://github.com/alisson-anjos/ComfyUI-LocateAnything",
+            "files": [
+                "https://github.com/alisson-anjos/ComfyUI-LocateAnything"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for NVIDIA LocateAnything-3B visual grounding, detection, text localization, GUI grounding, and pointing."
+        },
+        {
             "author": "chaosaiart",
             "title": "Chaosaiart-Nodes",
             "id": "chaosaiart",
@@ -11927,6 +11967,36 @@
             ],
             "install_type": "git-clone",
             "description": "Compare one to nine images when use ComfyUI"
+        },
+        {
+            "author": "smthemex",
+            "title": "ComfyUI_UniBlockSwap",
+            "reference": "https://github.com/smthemex/ComfyUI_UniBlockSwap",
+            "files": [
+                "https://github.com/smthemex/ComfyUI_UniBlockSwap"
+            ],
+            "install_type": "git-clone",
+            "description": "A universal swap node that supports ComfyUI native workflow, allowing 4_6G users to experience Klein9B or other large models"
+        },
+        {
+            "author": "smthemex",
+            "title": "ComfyUI_Dif_GGUF",
+            "reference": "https://github.com/smthemex/ComfyUI_Dif_GGUF",
+            "files": [
+                "https://github.com/smthemex/ComfyUI_Dif_GGUF"
+            ],
+            "install_type": "git-clone",
+            "description": "Easy quant comfyUI origin model to gguf , and esay use it, save more disk..."
+        },
+        {
+            "author": "smthemex",
+            "title": "ComfyUI_TwinFlow",
+            "reference": "https://github.com/smthemex/ComfyUI_TwinFlow",
+            "files": [
+                "https://github.com/smthemex/ComfyUI_TwinFlow"
+            ],
+            "install_type": "git-clone",
+            "description": "twinflow:Realizing One-step Generation on Large Models with Self-adversarial Flows,you can use it in comfyUI"
         },
         {
             "author": "choey",
@@ -17143,6 +17213,16 @@
             "description": "A simple minimap in the bottom-right of the window showing the full workflow, left click to navigate"
         },
         {
+            "author": "OliverCrosby",
+            "title": "Universal Seamless Tiles",
+            "reference": "https://github.com/OliverCrosby/ComfyUI-Universal-Seamless-Tiles",
+            "files": [
+                "https://github.com/OliverCrosby/ComfyUI-Universal-Seamless-Tiles"
+            ],
+            "install_type": "git-clone",
+            "description": "Model-agnostic seamless / tileable image generation for ComfyUI — works on transformer/DiT models (Flux, Wan/Anima) as well as convolutional models (SD1.5, SDXL)."
+        },
+        {
             "author": "Sieyalixnet",
             "title": "ComfyUI_Textarea_Loaders",
             "reference": "https://github.com/Sieyalixnet/ComfyUI_Textarea_Loaders",
@@ -18520,6 +18600,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI wrapper of IP-Composer"
+        },
+        {
+            "author": "godmt",
+            "title": "OpenAI Compatible LLM",
+            "reference": "https://github.com/godmt/comfyui-openai-llm",
+            "files": [
+                "https://github.com/godmt/comfyui-openai-llm"
+            ],
+            "install_type": "git-clone",
+            "description": "Lightweight OpenAI-compatible LLM nodes for ComfyUI, with LM Studio, Ollama, Responses API, image input, MCP tools, and local MCP runners."
         },
         {
             "author": "pedrogengo",
@@ -21981,6 +22071,16 @@
             "description": "ComfyUI custom node — load AUDIO from a public URL. Bypasses torchcodec entirely. Multi-backend: torchaudio / soundfile / ffmpeg."
         },
         {
+            "author": "PauldeLavallaz",
+            "title": "comfyui-ltx-node",
+            "reference": "https://github.com/PauldeLavallaz/comfyui-ltx-node",
+            "files": [
+                "https://github.com/PauldeLavallaz/comfyui-ltx-node"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for LTX-2 video generation API"
+        },
+        {
             "author": "huanngzh",
             "title": "ComfyUI-MVAdapter",
             "reference": "https://github.com/huanngzh/ComfyUI-MVAdapter",
@@ -23487,6 +23587,16 @@
             "description": "Latent Color Space (LCS) manipulation for ComfyUI — brightness, tone, sharpness, and diversity tools."
         },
         {
+            "author": "facok",
+            "title": "comfyui-x2hdr",
+            "reference": "https://github.com/facok/comfyui-x2hdr",
+            "files": [
+                "https://github.com/facok/comfyui-x2hdr"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for PU21/LogC HDR decode, EXR export, tone-map previews, color grading, and metrics."
+        },
+        {
             "author": "FinetunersAI",
             "title": "ComfyUI_Finetuners_Suite",
             "reference": "https://github.com/FinetunersAI/ComfyUI_Finetuners_Suite",
@@ -24216,6 +24326,16 @@
             ],
             "install_type": "git-clone",
             "description": "Outpaint flat video into fulldome / planetarium shows: domemaster rendering with tilted-venue presets for ComfyUI, on top of the Burgstall Labs 360 outpaint pipeline."
+        },
+        {
+            "author": "burgstall-labs",
+            "title": "ComfyUI-Gradual-IC-LoRA",
+            "reference": "https://github.com/Burgstall-labs/ComfyUI-Gradual-IC-LoRA",
+            "files": [
+                "https://github.com/Burgstall-labs/ComfyUI-Gradual-IC-LoRA"
+            ],
+            "install_type": "git-clone",
+            "description": "Gradual IC-LoRA time-curve nodes for LTX-2.3 (ComfyUI). Modulate IC-LoRA strength over the output clip via a user-drawn curve, applied as a per-token runtime adapter."
         },
         {
             "author": "Kidev",
@@ -28087,6 +28207,26 @@
             "description": "ComfyUI plugin for Sa2VA segmentation with independent model loaders, ComfyUI memory management, and VITMatte edge refinement. (Description by CC)"
         },
         {
+            "author": "yogurt7771",
+            "title": "ComfyUI-YogurtNodes-InstructSAM",
+            "reference": "https://github.com/yogurt7771/ComfyUI-YogurtNodes-InstructSAM",
+            "files": [
+                "https://github.com/yogurt7771/ComfyUI-YogurtNodes-InstructSAM"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for InstructSAM."
+        },
+        {
+            "author": "yogurt7771",
+            "title": "ComfyUI-YogurtNodes-LingBotVideo",
+            "reference": "https://github.com/yogurt7771/ComfyUI-YogurtNodes-LingBotVideo",
+            "files": [
+                "https://github.com/yogurt7771/ComfyUI-YogurtNodes-LingBotVideo"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for local LingBot Video inference."
+        },
+        {
             "author": "comfy-deploy",
             "title": "ComfyUI LLM Toolkit",
             "reference": "https://github.com/comfy-deploy/comfyui-llm-toolkit",
@@ -28814,6 +28954,16 @@
             "description": "Experimental Normalized Attention Guidance node for Anima Preview 3 in ComfyUI."
         },
         {
+            "author": "hybskgks28275",
+            "title": "ComfyUI-LoRA-Merge-EXPERIMENTAL",
+            "reference": "https://github.com/hybskgks28275/ComfyUI-LoRA-Merge-EXPERIMENTAL",
+            "files": [
+                "https://github.com/hybskgks28275/ComfyUI-LoRA-Merge-EXPERIMENTAL"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for ComfyUI that support NP-LoRA and SSR-Merge based LoRA merging, providing loaders for subject-style LoRA fusion, calibration, and merged LoRA application. (Description by CC)"
+        },
+        {
             "author": "mohsensd1373",
             "title": "comfyui_wordpress",
             "reference": "https://github.com/mohsensd1373/comfyui_wordpress",
@@ -29292,6 +29442,16 @@
             ],
             "install_type": "git-clone",
             "description": "I wanted a way to batch add effects to images inside Comfyui so I made these nodes. Some of the effects should be ordered specifically so they stack and are effecting the image emulating camera effectsI made some workflows to show you the correct order."
+        },
+        {
+            "author": "TrophiHunter",
+            "title": "ComfyUI-MLUT",
+            "reference": "https://github.com/TrophiHunter/ComfyUI-MLUT",
+            "files": [
+                "https://github.com/TrophiHunter/ComfyUI-MLUT"
+            ],
+            "install_type": "git-clone",
+            "description": "Apply color **LUTs** and **swatches/palettes** to images in ComfyUI from one self-contained collection."
         },
         {
             "author": "magic-eraser-org",
@@ -30561,26 +30721,6 @@
             "description": "Achieve seamless inpainting results without needing a specialized inpainting model."
         },
         {
-            "author": "hvppycoding",
-            "title": "RandomSamplerSchedulerSteps for ComfyUI",
-            "reference": "https://github.com/hvppycoding/comfyui-random-sampler-scheduler-steps",
-            "files": [
-                "https://github.com/hvppycoding/comfyui-random-sampler-scheduler-steps"
-            ],
-            "install_type": "git-clone",
-            "description": "A ComfyUI custom node that randomly selects a (Sampler, Scheduler, Steps) combination from user-defined presets."
-        },
-        {
-            "author": "hvppycoding",
-            "title": "json prompt renderer",
-            "reference": "https://github.com/hvppycoding/comfyui-json-prompt-renderer",
-            "files": [
-                "https://github.com/hvppycoding/comfyui-json-prompt-renderer"
-            ],
-            "install_type": "git-clone",
-            "description": "NODES: Extract JSON, 'Prompt: Render Template from JSON'"
-        },
-        {
             "author": "o-l-l-i",
             "title": "Olm Resolution Picker for ComfyUI",
             "reference": "https://github.com/o-l-l-i/ComfyUI-Olm-Resolution-Picker",
@@ -31039,7 +31179,7 @@
                 "https://github.com/INuBq8/ComfyUI-MultiMaskOps"
             ],
             "install_type": "git-clone",
-            "description": "A collection of ComfyUI nodes for working with multiple masks at once — sorting them by position, picking one out, removing duplicates, and expanding/feathering them without letting neighbours overlap."
+            "description": "A ComfyUI node pack for working with multiple masks at once — spatial sorting, index picking, duplicate removal, and overlap-free expansion/feathering. Native-matched dilation and blur."
         },
         {
             "author": "Erehr",
@@ -33144,6 +33284,16 @@
             "description": "Sends images with metadata (PNGInfo) obtained from the input values of each node to Eagle. You can customize the tags to be registered in Eagle."
         },
         {
+            "author": "watarika",
+            "title": "ComfyUI Model Batch Downloader",
+            "reference": "https://github.com/watarika/ComfyUI-Model-Batch-Downloader",
+            "files": [
+                "https://github.com/watarika/ComfyUI-Model-Batch-Downloader"
+            ],
+            "install_type": "git-clone",
+            "description": "Download and load multiple ComfyUI model files from Hugging Face, Civitai, and HTTP URLs."
+        },
+        {
             "author": "Azornes",
             "title": "Comfyui-LayerForge",
             "id": "layerforge",
@@ -33915,27 +34065,6 @@
             ],
             "install_type": "git-clone",
             "description": "Pixel art Enhancement Node for ComfyUI"
-        },
-        {
-            "author": "Rzgar Espo",
-            "title": "ComfyUI Qwen Image Size Picker",
-            "id": "QwenImg-latent",
-            "reference": "https://github.com/rzgarespo/ComfyUI-qwen-image-size-picker",
-            "files": [
-                "https://github.com/rzgarespo/ComfyUI-qwen-image-size-picker"
-            ],
-            "install_type": "git-clone",
-            "description": "An empty latent size picker with support for Qwen Image, SDXL, and Flux models."
-        },
-        {
-            "author": "rzgarespo",
-            "title": "ComfyUI-diffusiondb",
-            "reference": "https://github.com/rzgarespo/ComfyUI-diffusiondb",
-            "files": [
-                "https://github.com/rzgarespo/ComfyUI-diffusiondb"
-            ],
-            "install_type": "git-clone",
-            "description": "This code gives you the quick access to 14 million text-to-image prompts from the DiffusionDB dataset."
         },
         {
             "author": "luke-mino-altherr",
@@ -34821,6 +34950,26 @@
             "description": "A custom node for ComfyUI that allows you to cache an image and its mask to avoid recalculating upstream steps in your workflow."
         },
         {
+            "author": "orion4d",
+            "title": "Orion4D_FXMax",
+            "reference": "https://github.com/orion4d/Orion4D_FXMax",
+            "files": [
+                "https://github.com/orion4d/Orion4D_FXMax"
+            ],
+            "install_type": "git-clone",
+            "description": "A professional post-production, color grading, and sharpness suite for ComfyUI, featuring a custom built-in web application for real-time adjustments."
+        },
+        {
+            "author": "orion4d",
+            "title": "Orion4D_layer_manager",
+            "reference": "https://github.com/orion4d/Orion4D_layer_manager",
+            "files": [
+                "https://github.com/orion4d/Orion4D_layer_manager"
+            ],
+            "install_type": "git-clone",
+            "description": "A custom layer editor for ComfyUI with three utilities (drop shadow editor, crop editor, and gradient editor)."
+        },
+        {
             "author": "Fabio Sarracino",
             "title": "VibeVoice ComfyUI",
             "id": "vibevoice-comfyui",
@@ -34948,6 +35097,56 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI custom nodes for Higgs Audio v3 TTS with native inference, voice cloning, multi-speaker dialogue, longform chunking, and AIMDO DynamicVRAM support"
+        },
+        {
+            "author": "saganaki22",
+            "title": "WavTTS",
+            "reference": "https://github.com/Saganaki22/WavTTS-ComfyUI",
+            "files": [
+                "https://github.com/Saganaki22/WavTTS-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for WavTTS zero-shot text-to-speech with real ComfyUI memory tracking"
+        },
+        {
+            "author": "saganaki22",
+            "title": "MOSS-TTS",
+            "reference": "https://github.com/Saganaki22/Moss_TTS-ComfyUI",
+            "files": [
+                "https://github.com/Saganaki22/Moss_TTS-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for OpenMOSS MOSS-TTS Local Transformer v1.5 with model catalog downloads, Whisper prefix transcription, continuation, voice cloning, and AIMDO memory tracking"
+        },
+        {
+            "author": "saganaki22",
+            "title": "Dots TTS",
+            "reference": "https://github.com/Saganaki22/Dots-TTS-ComfyUI",
+            "files": [
+                "https://github.com/Saganaki22/Dots-TTS-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for rednote-hilab dots.tts with model loading, generation, voice cloning, Whisper transcription, progress tracking, and AIMDO memory visualization"
+        },
+        {
+            "author": "saganaki22",
+            "title": "Ideogram 4 Prompter",
+            "reference": "https://github.com/Saganaki22/ideogram4_prompter-ComfyUI",
+            "files": [
+                "https://github.com/Saganaki22/ideogram4_prompter-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Ideogram 4 Magic Prompt and Ideogram 4 resolution selection"
+        },
+        {
+            "author": "saganaki22",
+            "title": "ZONOS2 TTS",
+            "reference": "https://github.com/Saganaki22/Zonos2_TTS-ComfyUI",
+            "files": [
+                "https://github.com/Saganaki22/Zonos2_TTS-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "Native ComfyUI nodes for Zyphra ZONOS2 text-to-speech and voice cloning with AIMDO memory tracking"
         },
         {
             "author": "sfinktah",
@@ -36179,16 +36378,6 @@
             ],
             "install_type": "git-clone",
             "description": "Improved qwen image editing accuracy"
-        },
-        {
-            "author": "Ian2073",
-            "title": "ComfyUI-MyLLMNode",
-            "reference": "https://github.com/Ian2073/ComfyUI-MyLLMnode",
-            "files": [
-                "https://github.com/Ian2073/ComfyUI-MyLLMnode"
-            ],
-            "install_type": "git-clone",
-            "description": "Custom ComfyUI node for running LLMs via HuggingFace pipeline. Supports both local paths and HuggingFace model names."
         },
         {
             "author": "semonxue",
@@ -39218,6 +39407,16 @@
             "description": "ComfyUI nodes for Groq API - chat, vision, audio, tool use, and batch processing"
         },
         {
+            "author": "val",
+            "title": "Splat Loader",
+            "reference": "https://github.com/brayevalerien/comfyui-splat-loader",
+            "files": [
+                "https://github.com/brayevalerien/comfyui-splat-loader"
+            ],
+            "install_type": "git-clone",
+            "description": "In-node Gaussian splat viewport (Spark) for ComfyUI with WYSIWYG image capture."
+        },
+        {
             "author": "x0x0b",
             "title": "Prompt History Gallery",
             "reference": "https://github.com/x0x0b/ComfyUI-PromptHistoryGallery",
@@ -39714,6 +39913,16 @@
             ],
             "install_type": "git-clone",
             "description": "A long-form video generation suite that chains keyframe images into coherent videos with automatic segment transitions and cross-dissolves. (Description by CC)"
+        },
+        {
+            "author": "princepainter",
+            "title": "ComfyUI-PainterNodes",
+            "reference": "https://github.com/princepainter/ComfyUI-PainterNodes",
+            "files": [
+                "https://github.com/princepainter/ComfyUI-PainterNodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Video generation nodes for LTX, Wan2.2, Bernini, qwen image edit,flux image edit, and utility nodes."
         },
         {
             "author": "rafacost",
@@ -40440,6 +40649,16 @@
             ],
             "install_type": "git-clone",
             "description": "NK2E — experimental, unofficial in-context image editing for Krea 2 (community project; not affiliated with Krea)."
+        },
+        {
+            "author": "nynxz",
+            "title": "Nynxz",
+            "reference": "https://github.com/Nynxz/ComfyUI-NynxzExperimental",
+            "files": [
+                "https://github.com/Nynxz/ComfyUI-NynxzExperimental"
+            ],
+            "install_type": "git-clone",
+            "description": "A collection of experimental custom nodes for ComfyUI made by Nynxz."
         },
         {
             "author": "huygiatrng",
@@ -43152,6 +43371,36 @@
             "description": "Vision-aware text conditioning for the Krea2 / K2 model. Feeds reference images through the Qwen3-VL-4B vision path with the Krea2 descriptor template; optional per-image mask crops to the masked region. No VAE (Krea2 has no reference-latent pathway). Auto-growing image+mask slots."
         },
         {
+            "author": "ethanfel",
+            "title": "Node Usage Stats",
+            "reference": "https://github.com/ethanfel/Comfyui-Nodes-Stats",
+            "files": [
+                "https://github.com/ethanfel/Comfyui-Nodes-Stats"
+            ],
+            "install_type": "git-clone",
+            "description": "Track usage statistics for all ComfyUI nodes and packages"
+        },
+        {
+            "author": "ethanfel",
+            "title": "UTFCN — Use The Core Nodes",
+            "reference": "https://github.com/ethanfel/ComfyUI-UTFCN",
+            "files": [
+                "https://github.com/ethanfel/ComfyUI-UTFCN"
+            ],
+            "install_type": "git-clone",
+            "description": "Use The F***ing Core Nodes — suggests core (or otherwise-available) equivalents for custom nodes, and replaces them across a workflow after a preview."
+        },
+        {
+            "author": "ethanfel",
+            "title": "comfyui-nodes-agents",
+            "reference": "https://github.com/ethanfel/ComfyUI-Agent-Bridge",
+            "files": [
+                "https://github.com/ethanfel/ComfyUI-Agent-Bridge"
+            ],
+            "install_type": "git-clone",
+            "description": "In-graph ComfyUI nodes + MCP bridge for external coding agents (Claude Code / Codex)"
+        },
+        {
             "author": "shin131002",
             "title": "RandomLoRALoader",
             "reference": "https://github.com/shin131002/RandomLoRALoader",
@@ -45080,6 +45329,16 @@
             "description": "Gemini-powered image generation for ComfyUI supporting text-to-image, image-to-image, and batch processing with flexible API configuration. (Description by CC)"
         },
         {
+            "author": "peter119lee",
+            "title": "Anima Artist Mixer Forge",
+            "reference": "https://github.com/peter119lee/Anima-Artist-Mixer-Forge",
+            "files": [
+                "https://github.com/peter119lee/Anima-Artist-Mixer-Forge"
+            ],
+            "install_type": "git-clone",
+            "description": "Forge fork of Anima-Artist-Mixer: a ComfyUI node pack for multi-artist mixing on the Anima model by hooking into its cross-attention layers."
+        },
+        {
             "author": "petmycat",
             "title": "ComfyUI-gen2",
             "reference": "https://github.com/petmycat/ComfyUI-gen2",
@@ -46380,6 +46639,16 @@
             "description": "Task-aware Wan 2.2 sampling plans and sampler-specific breakout nodes for ComfyUI."
         },
         {
+            "author": "boobkake22",
+            "title": "Quick Watermark",
+            "reference": "https://github.com/boobkake22/ComfyUI-QuickWatermark",
+            "files": [
+                "https://github.com/boobkake22/ComfyUI-QuickWatermark"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node for applying PNG watermarks to still images and IMAGE batches."
+        },
+        {
             "author": "wobba",
             "title": "ComfyUI-ChatterBox-Turbo",
             "reference": "https://github.com/wobba/ComfyUI-ChatterBox-Turbo",
@@ -47289,6 +47558,17 @@
             "description": "A layer-based modal mask editor for ComfyUI with Photoshop-like controls. Features paint, color selection, alpha extraction, vector (Catmull-Rom spline), shape, and text tools, SAM3 AI segmentation, BiRefNet background removal, layer management with Undo/Redo (30 levels), ABR brush import, brush library, and multilingual UI (en/ja/zh)."
         },
         {
+            "author": "ketle-man",
+            "title": "ComfyUI Comic Creator",
+            "id": "comfyui-comic-creator",
+            "reference": "https://github.com/ketle-man/comfyui-comic-creator",
+            "files": [
+                "https://github.com/ketle-man/comfyui-comic-creator"
+            ],
+            "install_type": "git-clone",
+            "description": "A manga page creation SPA running on top of ComfyUI. Manage pages by 'works' (page groups), create pages from templates, and place images, speech balloons, text, shapes, and 3D poses into panels. Includes a layer-based image editor (layers, masks, adjustment layers), font manager with reusable style/preset system, AI image generation (Nanobanana/Gemini), script/storyboard management, and export to JPEG/PNG/WebP/PDF/EPUB. Multi-language UI (ja/en/zh)."
+        },
+        {
             "author": "senjinthedragon",
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",
@@ -47912,6 +48192,36 @@
             ],
             "install_type": "git-clone",
             "description": "Anima Block Compile for ComfyUI: a one-purpose node that runs torch.compile on the Anima DiT per transformer block (diffusion_model.blocks.{i}) instead of the whole model. Faster compile, fewer graph breaks. A thin, Anima-named wrapper over ComfyUI core's set_torch_compile_wrapper."
+        },
+        {
+            "author": "sorryhyun",
+            "title": "Distilled ResShift SR",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Distilled-ResShift",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Distilled-ResShift"
+            ],
+            "install_type": "git-clone",
+            "description": "Distilled 1-step ResShift super-resolution (×4 or ×2) as a pixel-space IMAGE to IMAGE node. A ResShift student distilled from a 15-step teacher upsamples any RGB image in one stochastic step (scale dropdown). Self-contained vendored ResShift net (no xformers needed on any GPU); student + vq-f4 VQGAN auto-download on first use."
+        },
+        {
+            "author": "sorryhyun",
+            "title": "Anima Adapter Loader",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Anima_lora-Adapter",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Anima_lora-Adapter"
+            ],
+            "install_type": "git-clone",
+            "description": "Anima loader nodes for ComfyUI. AnimaAdapterLoader auto-detects LoRA, HydraLoRA multi-head with live σ-conditional and FeRA-style FEI-conditional routing, ChimeraHydra dual-pool routing (per-Linear content router + network-level FreqRouter on FEI+σ), and LoReFT residual-stream edits. AnimaFeraLoader handles FeRA (Yin et al., arXiv:2511.17979) — both the author-faithful networks.methods.fera format and the plan2 stacked_experts_global_fei format with global router on the latent's spectral energy + independent stacked experts per Linear. AnimaSoftTokensLoader handles SoftREPA-parameterization soft tokens (Lee et al., arXiv:2503.08250) — per-layer × per-timestep-bucket learned tokens spliced into the crossattn embedding inside the first n_layers DiT blocks. Three single-purpose nodes; chain via the MODEL socket."
+        },
+        {
+            "author": "sorryhyun",
+            "title": "Anima DAVE (Diversity)",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Anima-DAVE",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Anima-DAVE"
+            ],
+            "install_type": "git-clone",
+            "description": "DAVE (DC Attenuation for diVersity Enhancement) as a drop-in MODEL patch for Anima / Cosmos-predict2 DiT: recover same-prompt sample diversity by attenuating the DC component of early-mid blocks over the first tau fraction of steps. Self-contained — bundles the shipped block-pool mask, pulls no training-repo code."
         },
         {
             "author": "spacewarpstudio",
@@ -48677,6 +48987,26 @@
             "description": "Experimental tools and motion controls for LTX-Video in ComfyUI"
         },
         {
+            "author": "machinedelusions",
+            "title": "ComfyUI-FL-VLM",
+            "reference": "https://github.com/filliptm/ComfyUI-FL-VLM",
+            "files": [
+                "https://github.com/filliptm/ComfyUI-FL-VLM"
+            ],
+            "install_type": "git-clone",
+            "description": "Fill Labs VLM nodes for ComfyUI, starting with Qwen3-VL image and image-batch inference."
+        },
+        {
+            "author": "machinedelusions",
+            "title": "FL HeartMuLa",
+            "reference": "https://github.com/filliptm/ComfyUI_FL-HeartMuLa",
+            "files": [
+                "https://github.com/filliptm/ComfyUI_FL-HeartMuLa"
+            ],
+            "install_type": "git-clone",
+            "description": "FL HeartMuLa - Multilingual AI music generation nodes for ComfyUI. Generate full songs with lyrics using the HeartMuLa model family. Supports English, Chinese, Japanese, Korean, and Spanish with song structure control via section markers and style tags."
+        },
+        {
             "author": "intelliprompt",
             "title": "comfy-intelliprompt",
             "reference": "https://github.com/galpt/comfy-intelliPrompt",
@@ -49215,6 +49545,16 @@
             "description": "Automatically upload ComfyUI output files to Google Drive with optional encryption. Supports OAuth and service accounts, real-time monitoring, cloud setups (RunPod), and includes cross-platform decryption scripts."
         },
         {
+            "author": "machinepainting",
+            "title": "DropSend Node",
+            "reference": "https://github.com/machinepainting/ComfyUI_DropSendNode",
+            "files": [
+                "https://github.com/machinepainting/ComfyUI_DropSendNode"
+            ],
+            "install_type": "git-clone",
+            "description": "Automatically upload ComfyUI output files to Dropbox with optional encryption. Supports real-time monitoring, cloud setups (RunPod), and includes cross-platform decryption scripts."
+        },
+        {
             "author": "karcsiha",
             "title": "comfyUi-deflicker",
             "reference": "https://github.com/karcsiha/comfyUi-deflicker",
@@ -49579,6 +49919,16 @@
             "description": "Real-time ComfyUI Hardware Monitor with native AMD ROCm and All GPU/APU NVIDIA support and Universal Prompt Translator node for multilingual AI workflows, AMD ROCm utilities, optimization, and workflow enhance"
         },
         {
+            "author": "Anonymzx",
+            "title": "ComfyUI-Supertonic3TTS",
+            "reference": "https://github.com/Anonymzx/ComfyUI-Supertonic3TTS",
+            "files": [
+                "https://github.com/Anonymzx/ComfyUI-Supertonic3TTS"
+            ],
+            "install_type": "git-clone",
+            "description": "custom nodes integrating Supertone's Supertonic-3 — a lightning-fast, on-device, multilingual Text-to-Speech system running natively via ONNX Runtime."
+        },
+        {
             "author": "Magos Digital Studio",
             "title": "ComfyUI-Magos-Nodes",
             "reference": "https://github.com/MagosDigitalStudio/ComfyUI-Magos-Nodes",
@@ -49658,6 +50008,16 @@
             ],
             "install_type": "git-clone",
             "description": "Anima-friendly first-pass resolution picker for ComfyUI. Outputs resolution, width, and height integers for image generation workflows."
+        },
+        {
+            "author": "cyberdelia",
+            "title": "NegPiP Prompt (Multi-Model)",
+            "reference": "https://github.com/cyberdeliaAI/comfyui-negpip-zimage",
+            "files": [
+                "https://github.com/cyberdeliaAI/comfyui-negpip-zimage"
+            ],
+            "install_type": "git-clone",
+            "description": "One-node NegPiP prompting for Z-Image, SD1, SDXL, and Anima in ComfyUI."
         },
         {
             "author": "KATO Kanryu",
@@ -51642,6 +52002,26 @@
             "description": "ComfyUI nodes for video -> audio -> JSON transcript pipeline. Designed to pair with ComfyUI-MiMoASR for the ASR step."
         },
         {
+            "author": "aadebuger",
+            "title": "comfyui-hymt2",
+            "reference": "https://github.com/aadebuger/ComfyUI-HyMT2",
+            "files": [
+                "https://github.com/aadebuger/ComfyUI-HyMT2"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Tencent's Hy-MT2 translation model family (1.8B / 7B / 30B-A3B)."
+        },
+        {
+            "author": "aadebuger",
+            "title": "comfyui-lensturbo",
+            "reference": "https://github.com/aadebuger/ComfyUI-LensTurbo",
+            "files": [
+                "https://github.com/aadebuger/ComfyUI-LensTurbo"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for Microsoft Lens / Lens-Turbo (3.8B T2I)"
+        },
+        {
             "author": "adampolczynski",
             "title": "◧ AP ClipSEG Mask Light",
             "reference": "https://github.com/adampolczynski/ComfyUI_AP_ClipSEG_Light",
@@ -52922,16 +53302,6 @@
             "description": "ComfyUI custom nodes for one-sample-per-run iteration across image, video, and text sources."
         },
         {
-            "author": "zhangrui",
-            "title": "ComfyUI-QuickUseTools",
-            "reference": "https://github.com/cingee2016/ComfyUI-QuickUseTools",
-            "files": [
-                "https://github.com/cingee2016/ComfyUI-QuickUseTools"
-            ],
-            "install_type": "git-clone",
-            "description": "A collection of quick-use custom nodes for ComfyUI - image processing and workflow tools"
-        },
-        {
             "author": "millerlight",
             "title": "Key-Value KV-Tools for ComfyUI",
             "reference": "https://github.com/millerlight/ComfyUI-KVTools",
@@ -52962,6 +53332,16 @@
             "description": "A small ComfyUI custom node for shortening long silent sections in AUDIO inputs."
         },
         {
+            "author": "Yang Li",
+            "title": "comfyui-mimo-asr",
+            "reference": "https://github.com/gaoqi125/comfyui-mimo-asr",
+            "files": [
+                "https://github.com/gaoqi125/comfyui-mimo-asr"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node adapter for Xiaomi MiMo-V2.5-ASR."
+        },
+        {
             "author": "1756141021",
             "title": "comfyui-character-picker",
             "reference": "https://github.com/1756141021/comfyui-character-picker",
@@ -52990,6 +53370,36 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI-native Bernini in-context conditioning for Wan 2.2 with external LLM prompt-enhancement helpers."
+        },
+        {
+            "author": "gluttony10",
+            "title": "ComfyUI-RH-Bernini-Full",
+            "reference": "https://github.com/RH-RunningHub/ComfyUI-RH-Bernini-Full",
+            "files": [
+                "https://github.com/RH-RunningHub/ComfyUI-RH-Bernini-Full"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-RH wrapper for full Bernini Diffusers inference"
+        },
+        {
+            "author": "gluttony10",
+            "title": "ComfyUI_RH_VoxCPM",
+            "reference": "https://github.com/RH-RunningHub/ComfyUI_RH_VoxCPM",
+            "files": [
+                "https://github.com/RH-RunningHub/ComfyUI_RH_VoxCPM"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for VoxCPM text-to-speech, voice cloning, multi-speaker generation, and LoRA training."
+        },
+        {
+            "author": "gluttony10",
+            "title": "ComfyUI_RH_SmartPhotoCrafter",
+            "reference": "https://github.com/RH-RunningHub/ComfyUI_RH_SmartPhotoCrafter",
+            "files": [
+                "https://github.com/RH-RunningHub/ComfyUI_RH_SmartPhotoCrafter"
+            ],
+            "install_type": "git-clone",
+            "description": "RunningHub ComfyUI nodes for SmartPhotoCrafter automatic photographic image editing."
         },
         {
             "author": "MoRanYue",
@@ -53171,16 +53581,6 @@
             ],
             "install_type": "git-clone",
             "description": "A small collection of ComfyUI audio nodes, starting with peak and RMS normalization."
-        },
-        {
-            "author": "feice-huang",
-            "title": "joyai_image_comfyui_gguf",
-            "reference": "https://github.com/feice-huang/joyai_image_comfyui_gguf",
-            "files": [
-                "https://github.com/feice-huang/joyai_image_comfyui_gguf"
-            ],
-            "install_type": "git-clone",
-            "description": "Unofficial GGUF companion package for JoyAI-Image-Edit, adding GGUF loader nodes as drop-in replacements for bf16 transformer and text encoder loaders."
         },
         {
             "author": "jieg9341-lab",
@@ -53455,6 +53855,16 @@
             ],
             "install_type": "git-clone",
             "description": "Save WebP images with A1111-compatible generation parameters and ComfyUI prompt/workflow metadata."
+        },
+        {
+            "author": "ukr8b3g-cmyk",
+            "title": "Empty Latent Image Plus",
+            "reference": "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus",
+            "files": [
+                "https://github.com/ukr8b3g-cmyk/Empty-Latent-Image-Plus"
+            ],
+            "install_type": "git-clone",
+            "description": "A compact Empty Latent Image replacement that also outputs WIDTH and HEIGHT values for ComfyUI workflows."
         },
         {
             "author": "surrealbydesign",
@@ -54017,6 +54427,16 @@
             "description": "ComfyUI expansion of the 🍅Tomato Crypt"
         },
         {
+            "author": "lhy666",
+            "title": "ComfyUI-PowerPanel",
+            "reference": "https://github.com/lihaoyun6/ComfyUI-PowerPanel",
+            "files": [
+                "https://github.com/lihaoyun6/ComfyUI-PowerPanel"
+            ],
+            "install_type": "git-clone",
+            "description": "Add unified control panels to your workflows and convert them to WebApp without using Node 2.0"
+        },
+        {
             "author": "g-raw",
             "title": "ComfyUI-LTX-Attention-Toolkit",
             "reference": "https://github.com/g-raw/ComfyUI-LTX-Attention-Toolkit",
@@ -54118,6 +54538,17 @@
             "description": "One-node studio UI package for Z-Image Turbo, Flux.2 Klein, Qwen Image Edit 2511, and Krea 2 workflows, including T2I, I2I, inpaint, outpaint, edit, faceswap, angle, and upscale modes."
         },
         {
+            "author": "designloves2",
+            "title": "ITDA",
+            "id": "itda",
+            "reference": "https://github.com/designloves2/itda",
+            "files": [
+                "https://github.com/designloves2/itda"
+            ],
+            "install_type": "git-clone",
+            "description": "Frame-accurate layered video editor inside ComfyUI for stitching AI-generated clips into one continuous piece. Auto Stitch recommends the best cut point between two clips using frame and motion matching; also scene/beat detection, version stacks, wipe compare, pre-render, and MP4/MOV/WebM export."
+        },
+        {
             "author": "depth-layer-rasterizer",
             "title": "Depth Layer Rasterizer",
             "reference": "https://github.com/maDcaDDie2000/comfyui_depth_layer_rasterizer",
@@ -54208,16 +54639,6 @@
             "description": "Training-free Krea2 style reference nodes for ComfyUI, with LoRA-like single-image transfer, experimental two-reference blending, low content leakage, and preserved image quality."
         },
         {
-            "author": "fni8",
-            "title": "ComfyUI-fni8 (int8 dp4a / Volta)",
-            "reference": "https://github.com/jajmangold/ComfyUI-fni8",
-            "files": [
-                "https://github.com/jajmangold/ComfyUI-fni8"
-            ],
-            "install_type": "git-clone",
-            "description": "int8 dp4a (sm_70/Volta) acceleration for diffusion DiTs in ComfyUI, over the fni8 kernels"
-        },
-        {
             "author": "navalyalgam97",
             "title": "XFlow Resolution",
             "reference": "https://github.com/navalyalgam97/comfyui-xflow-resolution",
@@ -54238,6 +54659,1432 @@
             "description": "Block Swap (RAM Offload) node for native ComfyUI MODEL - run DiT models larger than VRAM by streaming transformer blocks from system RAM."
         },
         {
+            "author": "vitacon",
+            "title": "Retro Pixel-Matrix Dither 👾",
+            "reference": "https://github.com/vitacon/ComfyUI-Retro-Pixel-Matrix-Dither",
+            "files": [
+                "https://github.com/vitacon/ComfyUI-Retro-Pixel-Matrix-Dither"
+            ],
+            "install_type": "git-clone",
+            "description": "An advanced multi-ratio Bayer matrix dithering node for ComfyUI with edge protection."
+        },
+        {
+            "author": "m0rtus59",
+            "title": "ComfyUI-ComfySidebar",
+            "reference": "https://github.com/m0rtus59/ComfyUI-ComfySidebar",
+            "files": [
+                "https://github.com/m0rtus59/ComfyUI-ComfySidebar"
+            ],
+            "install_type": "git-clone",
+            "description": "Restoring the ComfyUI frontend pre-vue update queue functionality, drag&drop support, quicksave, and more in a clean design that respects your screen area."
+        },
+        {
+            "author": "WaitWut",
+            "title": "Ultimate Lora Loader",
+            "reference": "https://github.com/WaitWut/comfyui-ultimate-lora-loader",
+            "files": [
+                "https://github.com/WaitWut/comfyui-ultimate-lora-loader"
+            ],
+            "install_type": "git-clone",
+            "description": "A Power-Lora-Loader-style dynamic LoRA stack node with a real on-disk folder browser, drag-to-reorder, optional CLIP, and per-lora split model/clip strengths."
+        },
+        {
+            "author": "albert999-pixel",
+            "title": "comfyui-beeble-switchx",
+            "reference": "https://github.com/albert999-pixel/comfyui-beeble-switchx",
+            "files": [
+                "https://github.com/albert999-pixel/comfyui-beeble-switchx"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom ComfyUI nodes for Beeble SwitchX image and video workflows."
+        },
+        {
+            "author": "KoishiAI",
+            "title": "LD ComfyUI Prompt Nodes",
+            "reference": "https://github.com/KoishiAI/LD-ComfyUI-Prompt-Nodes",
+            "files": [
+                "https://github.com/KoishiAI/LD-ComfyUI-Prompt-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Contains SlopPrompt and BooruPromptGenerator nodes to automate prompt generation for anime models. SlopPrompt allows natural language prompt generation or advanced formats like json and various conversions between them, while BooruPromptGenerator will let you generate random prompts anchored around tags you specify with various sampling options."
+        },
+        {
+            "author": "nnegret",
+            "title": "Anima-Tools",
+            "id": "comfyui-anima-tools",
+            "reference": "https://github.com/nregret/Comfyui-Anima-Tools",
+            "files": [
+                "https://github.com/nregret/Comfyui-Anima-Tools"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for anime prompt selection, random prompt generation, background and character tag composition, and Anima LoRA search, download, and loading."
+        },
+        {
+            "author": "YOUR_COMFY_PUBLISHER_ID",
+            "title": "Undulating Glitch",
+            "reference": "https://github.com/jsterlingvids/ComfyUI-UndulatingGlitch",
+            "files": [
+                "https://github.com/jsterlingvids/ComfyUI-UndulatingGlitch"
+            ],
+            "install_type": "git-clone",
+            "description": "Four-way alignment, travelling wave, and block-glitch video compositor nodes for ComfyUI."
+        },
+        {
+            "author": "galigali",
+            "title": "ComfyUI-PNGInfo",
+            "reference": "https://github.com/galigali-san/ComfyUI-PNGInfo",
+            "files": [
+                "https://github.com/galigali-san/ComfyUI-PNGInfo"
+            ],
+            "install_type": "git-clone",
+            "description": "A1111-style PNG Info for ComfyUI: load an image, read its generation metadata as human-readable text (A1111 parameters and ComfyUI embedded workflows), and reuse positive/negative/seed/steps/cfg as typed outputs."
+        },
+        {
+            "author": "RmaNMetaverse",
+            "title": "First Frame & Last Frame Extractor",
+            "reference": "https://github.com/RmaNMetaverse/ComfyUI-FirstframeLastframeExtractor",
+            "files": [
+                "https://github.com/RmaNMetaverse/ComfyUI-FirstframeLastframeExtractor"
+            ],
+            "install_type": "git-clone",
+            "description": "Extract the first and last frame from any video file or image batch in ComfyUI."
+        },
+        {
+            "author": "90-RED",
+            "title": "ComfyUI-LinkRouter",
+            "reference": "https://github.com/90-RED/ComfyUI-LinkRouter",
+            "files": [
+                "https://github.com/90-RED/ComfyUI-LinkRouter"
+            ],
+            "install_type": "git-clone",
+            "description": "Object-avoiding orthogonal link routing for ComfyUI. Links automatically detour around nodes with smooth right-angle paths. Flow animation, hover highlight, floating control bar, and full settings panel. Pure frontend — zero impact on generation."
+        },
+        {
+            "author": "Yasei-no-otoko",
+            "title": "ComfyUI RDNA35 Attention",
+            "id": "rdna35-attention",
+            "reference": "https://github.com/Yasei-no-otoko/ComfyUI-RDNA35-Attention",
+            "files": [
+                "https://github.com/Yasei-no-otoko/ComfyUI-RDNA35-Attention"
+            ],
+            "install_type": "git-clone",
+            "description": "RDNA 3.5 attention research nodes for ComfyUI, including fixed-block, exact Triton, FlexAttention, and PISA paths with model-local fallback handling."
+        },
+        {
+            "author": "CocyNoric",
+            "title": "ComfyUI-Anima-TeaCache",
+            "reference": "https://github.com/CocyNoric/ComfyUI-Anima-TeaCache",
+            "files": [
+                "https://github.com/CocyNoric/ComfyUI-Anima-TeaCache"
+            ],
+            "install_type": "git-clone",
+            "description": "TeaCache acceleration for the native ComfyUI implementation of circlestone-labs/Anima."
+        },
+        {
+            "author": "TiwazM",
+            "title": "ComfyUI-Precision-Model-Save",
+            "reference": "https://github.com/TiwazM/ComfyUI-Precision-Model-Save",
+            "files": [
+                "https://github.com/TiwazM/ComfyUI-Precision-Model-Save"
+            ],
+            "install_type": "git-clone",
+            "description": "For users who merge models in ComfyUI and want the saved checkpoint to match the live merged model exactly. A small custom node for saving a live merged MODEL without using ComfyUI's normal ModelSave materialisation path."
+        },
+        {
+            "author": "luminatrix",
+            "title": "Lumina_NIVR2",
+            "reference": "https://github.com/Luminatrixx/NIVR2",
+            "files": [
+                "https://github.com/Luminatrixx/NIVR2"
+            ],
+            "install_type": "git-clone",
+            "description": "Native ComfyUI implementation of ByteDance SeedVR2 using ComfyUI's own model stack and core graph nodes."
+        },
+        {
+            "author": "CovertBannana",
+            "title": "ComfyUI-ImagePlus",
+            "reference": "https://github.com/CovertBannana/ComfyUI-ImagePlus",
+            "files": [
+                "https://github.com/CovertBannana/ComfyUI-ImagePlus"
+            ],
+            "install_type": "git-clone",
+            "description": "Unified nodes pack primarily for Image to Image generation with a toggleable Text to Image option for easy switch back. CivitAI and local image inspection."
+        },
+        {
+            "author": "Azornes",
+            "title": "ComfyUI Model Resolver",
+            "reference": "https://github.com/Azornes/Comfyui-Model-Resolver",
+            "files": [
+                "https://github.com/Azornes/Comfyui-Model-Resolver"
+            ],
+            "install_type": "git-clone",
+            "description": "Automatically resolves missing models in ComfyUI workflows using intelligent local fuzzy matching, online search, direct downloads, background download tracking, and in-place workflow updates."
+        },
+        {
+            "author": "gregowahoo",
+            "title": "ComfyUI Workflow Group Navigator",
+            "reference": "https://github.com/gregowahoo/comfyui-navigator",
+            "files": [
+                "https://github.com/gregowahoo/comfyui-navigator"
+            ],
+            "install_type": "git-clone",
+            "description": "Floating panel that lists every group in your ComfyUI workflow — jump to any group, toggle on/off via rgthree Fast Groups Muter, reorder via drag-and-drop, configurable keyboard shortcuts. Designed for large multi-stage workflows."
+        },
+        {
+            "author": "shootthesound",
+            "title": "ComfyUI-WorkflowDropZone",
+            "reference": "https://github.com/shootthesound/ComfyUI-WorkflowDropZone",
+            "files": [
+                "https://github.com/shootthesound/ComfyUI-WorkflowDropZone"
+            ],
+            "install_type": "git-clone",
+            "description": "A persistent drop zone for loading workflows from images or .json files — a reliable alternative to ComfyUI's built-in drag-and-drop, with crash-recovery snapshots, recents, favorites, paste and append."
+        },
+        {
+            "author": "VixDreamer",
+            "title": "Kontext ControlNet Fix",
+            "id": "kontext-controlnet-fix",
+            "reference": "https://github.com/VixDreamer/kontext-controlnet-fix",
+            "files": [
+                "https://github.com/VixDreamer/kontext-controlnet-fix"
+            ],
+            "install_type": "git-clone",
+            "description": "Runtime patch that fixes the shape-mismatch crash when combining Flux Kontext ReferenceLatent with any ControlNet node. No core files modified. Idempotent — skips if upstream fix (PR #9180) is already present."
+        },
+        {
+            "author": "wraith-executioner-year-2",
+            "title": "comfyui-misc",
+            "id": "wraith-executioner-year-2.comfyui-misc",
+            "reference": "https://github.com/wraith-executioner-year-2/comfyui-misc",
+            "files": [
+                "https://github.com/wraith-executioner-year-2/comfyui-misc"
+            ],
+            "install_type": "git-clone",
+            "description": "A small utility custom nodes."
+        },
+        {
+            "author": "rikunarita",
+            "title": "ComfyUI-ModelMergeCosmosPredict-2B-Slerp",
+            "reference": "https://github.com/rikunarita/ComfyUI-ModelMergeCosmosPredict-2B-Slerp",
+            "files": [
+                "https://github.com/rikunarita/ComfyUI-ModelMergeCosmosPredict-2B-Slerp"
+            ],
+            "install_type": "git-clone",
+            "description": "Slerp model merging node specifically for Cosmos Predict 2B. Supports layer-wise ratio adjustment."
+        },
+        {
+            "author": "Tsubasa109",
+            "title": "comfyui-manga-panel",
+            "reference": "https://github.com/Tsubasa109/comfyui_manga_panel",
+            "files": [
+                "https://github.com/Tsubasa109/comfyui_manga_panel"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for selecting, generating, and compositing rectangular manga panels"
+        },
+        {
+            "author": "konokoaz",
+            "title": "Krea 2 Reference",
+            "reference": "https://github.com/KonokoAz/ComfyUI-Krea2-Reference",
+            "files": [
+                "https://github.com/KonokoAz/ComfyUI-Krea2-Reference"
+            ],
+            "install_type": "git-clone",
+            "description": "Reference images for Krea 2 via native Qwen3-VL vision tokens: character and style transfer with the companion reference LoRA (layered loader included)."
+        },
+        {
+            "author": "Gerbesh",
+            "title": "PNG Info for ComfyUI",
+            "id": "png-info",
+            "reference": "https://github.com/Gerbesh/png-info-for-comfyui",
+            "files": [
+                "https://github.com/Gerbesh/png-info-for-comfyui"
+            ],
+            "install_type": "git-clone",
+            "description": "Reads A1111 and ComfyUI PNG metadata and applies editable generation settings to bound checkpoint, LoRA, CLIP text encode, and KSampler nodes."
+        },
+        {
+            "author": "AI Embedded Systems",
+            "title": "ComfyUI Local Run Receipts",
+            "id": "local-run-receipts",
+            "reference": "https://github.com/nawnie/ComfyUI-Local-Run-Receipts",
+            "files": [
+                "https://github.com/nawnie/ComfyUI-Local-Run-Receipts"
+            ],
+            "install_type": "git-clone",
+            "description": "Local-only output nodes that derive a stable run key, save image hashes, and write a receipt beside ComfyUI images. Repeated identical outputs are reported without overwriting the completed receipt."
+        },
+        {
+            "author": "atomic-trash",
+            "title": "Colorist Delivery Bay",
+            "reference": "https://github.com/Atomic-Trash/ComfyUI-DeliveryBay",
+            "files": [
+                "https://github.com/Atomic-Trash/ComfyUI-DeliveryBay"
+            ],
+            "install_type": "git-clone",
+            "description": "One master, every deliverable. Protected crops, optional conformed film finish, named delivery sets for ComfyUI."
+        },
+        {
+            "author": "atomic-trash",
+            "title": "Colorist Film Grain",
+            "reference": "https://github.com/Atomic-Trash/ComfyUI-ColoristFilmGrain",
+            "files": [
+                "https://github.com/Atomic-Trash/ComfyUI-ColoristFilmGrain"
+            ],
+            "install_type": "git-clone",
+            "description": "Colorist film tools for ComfyUI: 35mm-faithful film grain (per-channel, band-pass, midtone-weighted, added not overlaid, fresh or coherent) plus a companion warm-highlight halation node."
+        },
+        {
+            "author": "mushroomfleet",
+            "title": "ComfyUI-LASED-mask",
+            "reference": "https://github.com/MushroomFleet/ComfyUI-LASED-mask",
+            "files": [
+                "https://github.com/MushroomFleet/ComfyUI-LASED-mask"
+            ],
+            "install_type": "git-clone",
+            "description": "LASED (Learning Ant Swarm Edge Detection) nodes: a colour-region-aware, learnable edge/contour extractor with a sticky-latch masking mode. Swarm Edge, Multi-Seed, Food Map, Overlay, Animate and Point Picker nodes."
+        },
+        {
+            "author": "meet-ai",
+            "title": "Gemma 4 - Multimodal AI",
+            "reference": "https://github.com/mailzwj/ComfyUI-Gemma4",
+            "files": [
+                "https://github.com/mailzwj/ComfyUI-Gemma4"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Gemma 4 multimodal AI"
+        },
+        {
+            "author": "molbal94",
+            "title": "molbals-stats",
+            "reference": "https://github.com/molbal/ComfyUI-molbals-stats",
+            "files": [
+                "https://github.com/molbal/ComfyUI-molbals-stats"
+            ],
+            "install_type": "git-clone",
+            "description": "Prompt diagnostics output node for elapsed time plus sampled peak process RAM and device VRAM."
+        },
+        {
+            "author": "latentdesireai",
+            "title": "ComfyUI-Unblend",
+            "reference": "https://github.com/LatentDesireAI/ComfyUI-Unblend",
+            "files": [
+                "https://github.com/LatentDesireAI/ComfyUI-Unblend"
+            ],
+            "install_type": "git-clone",
+            "description": "Character separation for anime art in ComfyUI: detection, instance masks, exclusive regions, prompt routing and pose extraction — fixes character blending on multi-character images."
+        },
+        {
+            "author": "enrico",
+            "title": "MOSS-TTS 1.5",
+            "reference": "https://github.com/eehrich/ComfyUI-MOSS-TTS-1.5",
+            "files": [
+                "https://github.com/eehrich/ComfyUI-MOSS-TTS-1.5"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for OpenMOSS MOSS-TTS v1.5 — both the 1.7B Local-Transformer (48 kHz) and the 8B full model (24 kHz). Reference-free TTS, zero-shot voice cloning, audio continuation, hard duration control, 31 languages, stereo output."
+        },
+        {
+            "author": "kunail0804",
+            "title": "comfyui-scene-compiler",
+            "reference": "https://github.com/kunail0804/ComfyUI-Scene-Compiler",
+            "files": [
+                "https://github.com/kunail0804/ComfyUI-Scene-Compiler"
+            ],
+            "install_type": "git-clone",
+            "description": "Deterministic natural-language-to-prompt compiler for ComfyUI (Illustrious)."
+        },
+        {
+            "author": "yasei-no-otoko",
+            "title": "AMD Video Upscaler",
+            "reference": "https://github.com/Yasei-no-otoko/ComfyUI-AMD-Video-Upscaler",
+            "files": [
+                "https://github.com/Yasei-no-otoko/ComfyUI-AMD-Video-Upscaler"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for AMD AMF VideoSR/HQ video upscaling through FFmpeg sr_amf."
+        },
+        {
+            "author": "xinjian0101",
+            "title": "Continuity Director",
+            "reference": "https://github.com/xinjian0101/continuity-director",
+            "files": [
+                "https://github.com/xinjian0101/continuity-director"
+            ],
+            "install_type": "git-clone",
+            "description": "Twenty continuity, directing, quality, runtime, collaboration, export, and reliability nodes with a bilingual ComfyUI dashboard."
+        },
+        {
+            "author": "aaalice",
+            "title": "ComfyUI-Aaalice-Nodes",
+            "reference": "https://github.com/Aaalice233/ComfyUI-Aaalice-Nodes",
+            "files": [
+                "https://github.com/Aaalice233/ComfyUI-Aaalice-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Compact parameter controls and workflow utilities for ComfyUI"
+        },
+        {
+            "author": "iChrist",
+            "title": "LlamaCPP → Ideogram Prompt",
+            "reference": "https://github.com/iChristGit/comfyui-llamacpp-ideogram",
+            "files": [
+                "https://github.com/iChristGit/comfyui-llamacpp-ideogram"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node: local llama.cpp → structured Ideogram 4 JSON prompt with thinking/reasoning support"
+        },
+        {
+            "author": "mzkmkgm22-sudo",
+            "title": "ComfyUI-SaveImageDPI",
+            "reference": "https://github.com/mzkmkgm22-sudo/ComfyUI-SaveImageDPI",
+            "files": [
+                "https://github.com/mzkmkgm22-sudo/ComfyUI-SaveImageDPI"
+            ],
+            "install_type": "git-clone",
+            "description": "Save images as PNG/JPEG/TIFF/PSD with DPI metadata and filename tokens (%model%, %seed%)"
+        },
+        {
+            "author": "kazuya-bros",
+            "title": "Visual Prompt Library",
+            "reference": "https://github.com/kazuya-bros/ComfyUI-VisualPromptLibrary",
+            "files": [
+                "https://github.com/kazuya-bros/ComfyUI-VisualPromptLibrary"
+            ],
+            "install_type": "git-clone",
+            "description": "Thumbnail-based visual prompt part picker and library manager for ComfyUI."
+        },
+        {
+            "author": "MdONeilsl",
+            "title": "MdColorMod",
+            "reference": "https://github.com/MdONeilsl/ComfyUI-MdColorMod",
+            "files": [
+                "https://github.com/MdONeilsl/ComfyUI-MdColorMod"
+            ],
+            "install_type": "git-clone",
+            "description": "GIMP color mod nodes in comfyUI"
+        },
+        {
+            "author": "photalabs",
+            "title": "Phota API Nodes",
+            "reference": "https://github.com/photalabs/comfyui-phota",
+            "files": [
+                "https://github.com/photalabs/comfyui-phota"
+            ],
+            "install_type": "git-clone",
+            "description": "Phota API nodes for ComfyUI — identity-preserving image generation, editing, enhancement, and profile training (photalabs.com)."
+        },
+        {
+            "author": "dawncreatescode",
+            "title": "Smart Aspect Ratio",
+            "reference": "https://github.com/dawncreatescode/comfyui-ResolutionAndAspectRatio",
+            "files": [
+                "https://github.com/dawncreatescode/comfyui-ResolutionAndAspectRatio"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node that lets you set the aspect ratio with the prompt. Converts megapixels + aspect ratio into width/height, with prompt-based ratio detection and randomization."
+        },
+        {
+            "author": "wenli",
+            "title": "ComfyUI-BerniniR Wrapper",
+            "reference": "https://github.com/xiaolibai-sys/ComfyUI-BerniniRWrapper",
+            "files": [
+                "https://github.com/xiaolibai-sys/ComfyUI-BerniniRWrapper"
+            ],
+            "install_type": "git-clone",
+            "description": "Wan-Video based video generation custom node: seven-mode guidance (CFG/APG/RAAG/S2/Z2/STG_A/STG_R), context-window sampling, and segment prompt-travel."
+        },
+        {
+            "author": "daceheg",
+            "title": "ComfyUI Civitai MCP",
+            "reference": "https://github.com/daceheg/ComfyUI-civitai-mcp",
+            "files": [
+                "https://github.com/daceheg/ComfyUI-civitai-mcp"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for posting images, fetching model/image metadata, and interacting with Civitai daily challenges via the Civitai MCP server."
+        },
+        {
+            "author": "n0va39",
+            "title": "ComfyUI EasyUse Anima",
+            "reference": "https://github.com/n0va39/ComfyUI-EasyUseAnima",
+            "files": [
+                "https://github.com/n0va39/ComfyUI-EasyUseAnima"
+            ],
+            "install_type": "git-clone",
+            "description": "Prompt editing, ANIMA prompt correction, NAIA prompt integration, LoRA preset management, wildcard expansion, AiO generation, and ANIMA/Spectrum workflow helpers for ComfyUI."
+        },
+        {
+            "author": "tuid",
+            "title": "ComfyUI-BerniniR",
+            "reference": "https://github.com/neuregex/ComfyUI-BerniniR",
+            "files": [
+                "https://github.com/neuregex/ComfyUI-BerniniR"
+            ],
+            "install_type": "git-clone",
+            "description": "ByteDance Bernini-R (Wan2.2-T2V-A14B + source-id RoPE + APG multi-condition guidance) for ComfyUI: t2v/t2i, image & video editing, reference-to-video."
+        },
+        {
+            "author": "skb",
+            "title": "ComfyUI DuckHunt",
+            "reference": "https://github.com/SKBv0/ComfyUI-DuckHunt",
+            "files": [
+                "https://github.com/SKBv0/ComfyUI-DuckHunt"
+            ],
+            "install_type": "git-clone",
+            "description": "Classic Duck Hunt game integrated as a ComfyUI custom node with interactive gameplay."
+        },
+        {
+            "author": "skb",
+            "title": "ComfyUI BobRoss",
+            "reference": "https://github.com/SKBv0/ComfyUI_BobRoss",
+            "files": [
+                "https://github.com/SKBv0/ComfyUI_BobRoss"
+            ],
+            "install_type": "git-clone",
+            "description": "Transparent WebM overlay for live previews and sampler previews in ComfyUI."
+        },
+        {
+            "author": "artificialsweetener",
+            "title": "Substitute BackEnd",
+            "reference": "https://github.com/Artificial-Sweetener/Substitute-Backend",
+            "files": [
+                "https://github.com/Artificial-Sweetener/Substitute-Backend"
+            ],
+            "install_type": "git-clone",
+            "description": "Backend liaison services for SugarSubstitute and ComfyUI."
+        },
+        {
+            "author": "arcvelvet",
+            "title": "ARC Save (sign on arrival)",
+            "reference": "https://github.com/arcvelvetOS/comfyui-arc-save",
+            "files": [
+                "https://github.com/arcvelvetOS/comfyui-arc-save"
+            ],
+            "install_type": "git-clone",
+            "description": "Sign-on-arrival save nodes for ArcVelvetOS: ARC Save (image, stable) and ARC Save Audio (WAV, alpha). POSTs encoded media to the ArcVelvet arcIngest API; the C2PA-signed copy comes back and lands in your output directory. Server-side prompt moderation; plaintext prompts never enter the public manifest unless you opt in. Audio node is alpha — audio-content moderation (transcript scanning, voice-clone detection) not yet covered; see README before public use."
+        },
+        {
+            "author": "nikythebikky",
+            "title": "Temporal Face Detailer",
+            "reference": "https://github.com/nikythebikky/ComfyUI-Temporal-Face-Detailer",
+            "files": [
+                "https://github.com/nikythebikky/ComfyUI-Temporal-Face-Detailer"
+            ],
+            "install_type": "git-clone",
+            "description": "Video FaceDetailer for SDXL in ComfyUI: face tracking, per-track fixed-seed detailing and flow-guided temporal blending to fix faces in videos without flicker."
+        },
+        {
+            "author": "yunlong",
+            "title": "CivitaiManager",
+            "reference": "https://github.com/nregret/CivitaiManager",
+            "files": [
+                "https://github.com/nregret/CivitaiManager"
+            ],
+            "install_type": "git-clone",
+            "description": "Browse, download, and organize Civitai assets inside ComfyUI."
+        },
+        {
+            "author": "giusparsifal",
+            "title": "Upscaler Filename",
+            "reference": "https://github.com/giusparsifal/ComfyUI-Upscaler-Filename",
+            "files": [
+                "https://github.com/giusparsifal/ComfyUI-Upscaler-Filename"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node that names saved outputs after the selected upscale model."
+        },
+        {
+            "author": "pippingo002",
+            "title": "Queued Reboot",
+            "reference": "https://github.com/t22m003/ComfyUI-QueuedReboot",
+            "files": [
+                "https://github.com/t22m003/ComfyUI-QueuedReboot"
+            ],
+            "install_type": "git-clone",
+            "description": "Restart the ComfyUI server as a queued job (after the current queue finishes), with a top-bar button."
+        },
+        {
+            "author": "pharma-lobby",
+            "title": "Replicate Select",
+            "reference": "https://github.com/Pharma-Lobby/ComfyUI-Replicate-Select",
+            "files": [
+                "https://github.com/Pharma-Lobby/ComfyUI-Replicate-Select"
+            ],
+            "install_type": "git-clone",
+            "description": "Kuratierte Replicate-Modelle als ComfyUI-Nodes (Bild, Video, Upscale, TTS, Lipsync) + Custom-Node für beliebige Modell-IDs."
+        },
+        {
+            "author": "zed93",
+            "title": "Comfy Cabinet",
+            "reference": "https://github.com/Zed93/Comfy-Cabinet",
+            "files": [
+                "https://github.com/Zed93/Comfy-Cabinet"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI custom node pack to manage checkpoint presets (steps, CFG, samplers, schedulers, and prompt prefixes/suffixes)."
+        },
+        {
+            "author": "document97",
+            "title": "Comfy-INT4-HIPtest",
+            "reference": "https://github.com/document97/Comfy-INT4-HIPtest",
+            "files": [
+                "https://github.com/document97/Comfy-INT4-HIPtest"
+            ],
+            "install_type": "git-clone",
+            "description": "AMD/HIP native Triton W4A4 ConvRot nodes for ComfyUI."
+        },
+        {
+            "author": "maxdingsda",
+            "title": "ComfyUI-HumanComposer",
+            "reference": "https://github.com/max-dingsda/ComfyUI-HumanComposer",
+            "files": [
+                "https://github.com/max-dingsda/ComfyUI-HumanComposer"
+            ],
+            "install_type": "git-clone",
+            "description": "A ComfyUI node for creating human character prompts with guided fields for gender, age, ethnicity, body type, hair, clothing, accessories, pose, camera, lighting, and art style. (Description by CC)"
+        },
+        {
+            "author": "herczy",
+            "title": "ComfyUI-latent-eval",
+            "reference": "https://github.com/herczy/ComfyUI-latent-eval",
+            "files": [
+                "https://github.com/herczy/ComfyUI-latent-eval"
+            ],
+            "install_type": "git-clone",
+            "description": "ZEval is a Python library and ComfyUI custom node that allows you to perform mathematical operations and transformations on latent tensors using a domain-specific language (DSL)."
+        },
+        {
+            "author": "realtneu",
+            "title": "Speech-God",
+            "reference": "https://github.com/realTNEU/ComfyUI-SpeechGod",
+            "files": [
+                "https://github.com/realTNEU/ComfyUI-SpeechGod"
+            ],
+            "install_type": "git-clone",
+            "description": "Speech-God: expressive character-dialogue TTS suite for ComfyUI. F5-TTS / Fish Speech engines, voice cloning, emotion acting, multi-character scripts, character database, alternate takes, post-processing and export."
+        },
+        {
+            "author": "y277an",
+            "title": "ComfyUI-y277an-Gemini",
+            "reference": "https://github.com/y277an/ComfyUI-y277an-Gemini",
+            "files": [
+                "https://github.com/y277an/ComfyUI-y277an-Gemini"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for Google Gemini: image generation & editing (Nano Banana), Veo video, text/prompt generation, and TTS speech."
+        },
+        {
+            "author": "aiark032025",
+            "title": "Smart Load Image",
+            "reference": "https://github.com/aiark032025/comfyui_smart_load_image",
+            "files": [
+                "https://github.com/aiark032025/comfyui_smart_load_image"
+            ],
+            "install_type": "git-clone",
+            "description": "A single custom node, Load Image (Smart), that addresses several shortcomings of ComfyUI's built-in image loaders. It includes: Base folder selector – choose between output and input; subfolder selector – lists single-level subfolders of the selected base folder; videos filtered out – the image list only shows files whose mimetype is an image; selection survives reloads – unlike the built-in Load Image (Outputs) node, the saved selection is preserved when a workflow is reloaded or refreshed."
+        },
+        {
+            "author": "pavel-zinchenko",
+            "title": "ComfyUI 360° Viewer",
+            "reference": "https://github.com/pavel-zinchenko/comfyui-360-viewer",
+            "files": [
+                "https://github.com/pavel-zinchenko/comfyui-360-viewer"
+            ],
+            "install_type": "git-clone",
+            "description": "360° equirectangular image viewer node for ComfyUI"
+        },
+        {
+            "author": "xiaden",
+            "title": "imgutils",
+            "reference": "https://github.com/xiaden/comfyui-imgutils",
+            "files": [
+                "https://github.com/xiaden/comfyui-imgutils"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI V3 nodes wrapping deepghs/imgutils for anime image analysis and processing."
+        },
+        {
+            "author": "ai-fashion-studio",
+            "title": "AI Fashion Studio",
+            "reference": "https://github.com/KillPhantom/ai-fashion-studio",
+            "files": [
+                "https://github.com/KillPhantom/ai-fashion-studio"
+            ],
+            "install_type": "git-clone",
+            "description": "API-first fashion generation and evaluation nodes for ComfyUI."
+        },
+        {
+            "author": "senyilmaz",
+            "title": "Reframe 360",
+            "reference": "https://github.com/senyilmaz/ComfyUI-Reframe360",
+            "files": [
+                "https://github.com/senyilmaz/ComfyUI-Reframe360"
+            ],
+            "install_type": "git-clone",
+            "description": "Virtual camera inside a 360 image. Real focal lengths, sensor sizes, lens projections, interactive drag framing."
+        },
+        {
+            "author": "Pranjwal-Jha",
+            "title": "llama-api-comfy",
+            "reference": "https://github.com/Pranjwal-Jha/llamacpp-comfyui-autocaptioner",
+            "files": [
+                "https://github.com/Pranjwal-Jha/llamacpp-comfyui-autocaptioner"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for captioning images via a llama.cpp server with vision support"
+        },
+        {
+            "author": "b2renger",
+            "title": "Moebius Inpainting",
+            "reference": "https://github.com/b2renger/ComfyUI_moebius_inpainting",
+            "files": [
+                "https://github.com/b2renger/ComfyUI_moebius_inpainting"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for Moebius (hustvl) - 0.22B mask-driven inpainting / object removal, 10B-level quality, no text encoder, pure PyTorch (Blackwell/Ada ready)."
+        },
+        {
+            "author": "daminik124421",
+            "title": "ComfyUI Speech Bubble Detector",
+            "reference": "https://github.com/daminik124124-ops/ComfyUI-Speech-Bubble-Detector",
+            "files": [
+                "https://github.com/daminik124124-ops/ComfyUI-Speech-Bubble-Detector"
+            ],
+            "install_type": "git-clone",
+            "description": "Speech bubble detector for ComfyUI based on SAM3 Text Segmentation with crop-locked region detection for manga/manhwa cleanup workflows."
+        },
+        {
+            "author": "reality-comes",
+            "title": "Ideogram 4 Quad Storyboard",
+            "reference": "https://github.com/reality-comes/comfyui-ideogram4-quad-storyboard",
+            "files": [
+                "https://github.com/reality-comes/comfyui-ideogram4-quad-storyboard"
+            ],
+            "install_type": "git-clone",
+            "description": "Ideogram 4 quad nodes for ComfyUI: layout, prompt builder, keyframe, per-panel inpaint, and timed keyframe-release."
+        },
+        {
+            "author": "<claimed-publisher-id>",
+            "title": "LingBot-Video Dense 1.3B FP8",
+            "reference": "https://github.com/ALX-CODE/lingbot-video-1.3b-fp8",
+            "files": [
+                "https://github.com/ALX-CODE/lingbot-video-1.3b-fp8"
+            ],
+            "install_type": "git-clone",
+            "description": "Selective fused FP8 LingBot-Video Dense 1.3B runtime and workflows for ComfyUI"
+        },
+        {
+            "author": "aitocha",
+            "title": "AITocha Vision",
+            "reference": "https://github.com/AITocha/ComfyUI-AITocha-Vision",
+            "files": [
+                "https://github.com/AITocha/ComfyUI-AITocha-Vision"
+            ],
+            "install_type": "git-clone",
+            "description": "GPU-native, NSFW-friendly image captioner for ComfyUI. Drop-in replacement for the GGUF JoyCaption nodes — uses transformers + bitsandbytes 4-bit instead of llama-cpp-python."
+        },
+        {
+            "author": "nikodemon80",
+            "title": "Image Oasis",
+            "reference": "https://github.com/NikoDemon80/ComfyUI-Image-Oasis",
+            "files": [
+                "https://github.com/NikoDemon80/ComfyUI-Image-Oasis"
+            ],
+            "install_type": "git-clone",
+            "description": "All-in-one ComfyUI image generation node: switchable architecture (AuraFlow, Flux.1/2, Krea 2, Qwen-Image-Edit, SD1/SD1.5/SDXL, SD3/3.5), tri-source model loading, dual/triple CLIP, LoRA stack, prompt enhancer, refiner pass, optional upscale, A/B compare slider - in a single node."
+        },
+        {
+            "author": "CyberShadowX",
+            "title": "comfyui-smart-metadata-reader",
+            "reference": "https://github.com/CyberShadowX/ComfyUI-Smart-Metadata-Reader",
+            "files": [
+                "https://github.com/CyberShadowX/ComfyUI-Smart-Metadata-Reader"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI image loader node that reads AI image metadata and traces real prompt conditioning."
+        },
+        {
+            "author": "andy-ratsirarson",
+            "title": "ComfyUI_ExternalAPI",
+            "reference": "https://github.com/andy-ratsirarson/ComfyUI_ExternalAPI",
+            "files": [
+                "https://github.com/andy-ratsirarson/ComfyUI_ExternalAPI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node package for BYOK (bring-your-own-key) access to external generative APIs: Gemini, Veo, and more via LiteLLM."
+        },
+        {
+            "author": "Ave-Mollan",
+            "title": "civitai-sdk-api-nodes-for-comfyui",
+            "reference": "https://github.com/Ave-Mollan/CivitAI-SDK-API-nodes-for-ComfyUI",
+            "files": [
+                "https://github.com/Ave-Mollan/CivitAI-SDK-API-nodes-for-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for CivitAI cloud image generation via API"
+        },
+        {
+            "author": "stratopause-lsc",
+            "title": "ComfyUI-MacMemoryMonitor",
+            "reference": "https://github.com/stratopause-lsc/ComfyUI-MacMemoryMonitor",
+            "files": [
+                "https://github.com/stratopause-lsc/ComfyUI-MacMemoryMonitor"
+            ],
+            "install_type": "git-clone",
+            "description": "Real-time memory monitor for ComfyUI on Apple Silicon (MPS / unified memory) — unified RAM, MPS driver/active, MLX Metal, swap, and per-run peaks. The Mac analogue of ComfyUI-MemoryVisualization."
+        },
+        {
+            "author": "ComfyUI-EasyLLMPrompt Contributors",
+            "title": "comfyui-easy-llm-prompt",
+            "reference": "https://github.com/akumaburn/ComfyUI-EasyLLMPrompt",
+            "files": [
+                "https://github.com/akumaburn/ComfyUI-EasyLLMPrompt"
+            ],
+            "install_type": "git-clone",
+            "description": "Convert a structured scene description into an optimised SDXL prompt via LLM"
+        },
+        {
+            "author": "laurigates",
+            "title": "Model Gallery",
+            "reference": "https://github.com/laurigates/comfyui-model-gallery",
+            "files": [
+                "https://github.com/laurigates/comfyui-model-gallery"
+            ],
+            "install_type": "git-clone",
+            "description": "Touch-first card-grid picker with preview thumbnails for the folder-backed model combos (LoRA, checkpoint, VAE, ControlNet, UNet, CLIP, upscale)."
+        },
+        {
+            "author": "dingmuliang",
+            "title": "comfyui-mliang-lora-loader",
+            "reference": "https://github.com/dingmuliang/comfyui-mliang-lora-loader",
+            "files": [
+                "https://github.com/dingmuliang/comfyui-mliang-lora-loader"
+            ],
+            "install_type": "git-clone",
+            "description": "A professional ComfyUI custom node for browsing and loading LoRA files with folder tree navigation, multi-slot support, and instant preview."
+        },
+        {
+            "author": "helto",
+            "title": "Smart Prompt Manager",
+            "reference": "https://github.com/helto4real/comfyui-helto-smartprompt",
+            "files": [
+                "https://github.com/helto4real/comfyui-helto-smartprompt"
+            ],
+            "install_type": "git-clone",
+            "description": "Smart Prompt Manager custom node with managed Helto privacy."
+        },
+        {
+            "author": "helto",
+            "title": "AIO Image Generate",
+            "reference": "https://github.com/helto4real/comfyui-all-on-one-image-generation-node",
+            "files": [
+                "https://github.com/helto4real/comfyui-all-on-one-image-generation-node"
+            ],
+            "install_type": "git-clone",
+            "description": "Helto all-in-one ComfyUI image generation nodes with managed privacy."
+        },
+        {
+            "author": "numonic",
+            "title": "Numonic Workflow Recovery",
+            "reference": "https://github.com/numonic-labs/comfyui-workflow-recovery",
+            "files": [
+                "https://github.com/numonic-labs/comfyui-workflow-recovery"
+            ],
+            "install_type": "git-clone",
+            "description": "Drop in a generated image and recover its full ComfyUI workflow lineage — prompts, models, LoRAs, seed, sampler, and custom nodes. Local-first and privacy-preserving."
+        },
+        {
+            "author": "endman100",
+            "title": "comfyui-whisper-large-v3-repack",
+            "reference": "https://github.com/endman100/ComfyUI-WhisperLargeV3-Repack",
+            "files": [
+                "https://github.com/endman100/ComfyUI-WhisperLargeV3-Repack"
+            ],
+            "install_type": "git-clone",
+            "description": "Commercial-friendly Whisper Large V3 transcription nodes for ComfyUI."
+        },
+        {
+            "author": "endman100",
+            "title": "comfyui-higgs-audio-v3-tts",
+            "reference": "https://github.com/endman100/ComfyUI-HiggsAudioV3TTS",
+            "files": [
+                "https://github.com/endman100/ComfyUI-HiggsAudioV3TTS"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI local-loader custom node for bosonai/higgs-audio-v3-tts-4b"
+        },
+        {
+            "author": "clark",
+            "title": "ComfyUI-ClarkAirSana",
+            "reference": "https://github.com/clark-labs-inc/ComfyUI-ClarkAirSana",
+            "files": [
+                "https://github.com/clark-labs-inc/ComfyUI-ClarkAirSana"
+            ],
+            "install_type": "git-clone",
+            "description": "Run Clark Air Sana 1.6B (ternary ~1.58-bit, GemLite INT2 kernels) natively under ComfyUI's KSampler."
+        },
+        {
+            "author": "januspluto",
+            "title": "Krea2 Regional",
+            "reference": "https://github.com/januspluto/ComfyUI-Krea2-Regional",
+            "files": [
+                "https://github.com/januspluto/ComfyUI-Krea2-Regional"
+            ],
+            "install_type": "git-clone",
+            "description": "Regional prompting and per-region LoRA for Krea 2 in ComfyUI (single-pass)."
+        },
+        {
+            "author": "searchingman",
+            "title": "Klein Pruned Text Encoder Loader",
+            "reference": "https://github.com/kgonia/ComfyUI-KleinPrunedTE",
+            "files": [
+                "https://github.com/kgonia/ComfyUI-KleinPrunedTE"
+            ],
+            "install_type": "git-clone",
+            "description": "Loader node for the pruned FLUX.2-klein-9B text encoder (5.1B). Handles the mixed per-layer FFN/GQA shapes and remapped hidden-state taps that the stock CLIPLoader cannot express."
+        },
+        {
+            "author": "anima",
+            "title": "Anima LoRA Comparison",
+            "reference": "https://github.com/yunqiankuangyu/comfyui-anima-lora-comparison",
+            "files": [
+                "https://github.com/yunqiankuangyu/comfyui-anima-lora-comparison"
+            ],
+            "install_type": "git-clone",
+            "description": "Batch LoRA comparison sampler for Anima/Cosmos models in ComfyUI"
+        },
+        {
+            "author": "Hezldeen",
+            "title": "comfyui-hezl-ksamplerpreset",
+            "reference": "https://github.com/Hezldeen/ComfyUI_Hezl-KSamplerPreset",
+            "files": [
+                "https://github.com/Hezldeen/ComfyUI_Hezl-KSamplerPreset"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI KSampler with preset save/load/delete"
+        },
+        {
+            "author": "hardhant",
+            "title": "ComfyUI-AliAn-Ideogram-Magic-Prompt",
+            "reference": "https://github.com/hardhant/ComfyUI-AliAn-Ideogram-Magic-Prompt",
+            "files": [
+                "https://github.com/hardhant/ComfyUI-AliAn-Ideogram-Magic-Prompt"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node: rewrites a plain prompt into Ideogram 4's native structured JSON caption via the hosted magic-prompt API."
+        },
+        {
+            "author": "viralvfx",
+            "title": "ComfyUI-INT4-Fast",
+            "reference": "https://github.com/viralvfx/ComfyUI-INT4-Fast",
+            "files": [
+                "https://github.com/viralvfx/ComfyUI-INT4-Fast"
+            ],
+            "install_type": "git-clone",
+            "description": "This node speeds up Flux-based models in ComfyUI by using INT4 (W4A4) quantization on RTX 30 and 40 series cards, delivering faster inference and lower VRAM usage."
+        },
+        {
+            "author": "chrisjohnson",
+            "title": "NeuralBooru",
+            "reference": "https://github.com/ChrisJohnson89/ComfyUI-NeuralBooru",
+            "files": [
+                "https://github.com/ChrisJohnson89/ComfyUI-NeuralBooru"
+            ],
+            "install_type": "git-clone",
+            "description": "Turn natural language into validated Danbooru tags using a local LLM"
+        },
+        {
+            "author": "tothanate",
+            "title": "Higgs v3 TTS",
+            "reference": "https://github.com/tothanate/Higgs-V3-TTS-ComfyUI",
+            "files": [
+                "https://github.com/tothanate/Higgs-V3-TTS-ComfyUI"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Higgs Audio v3 TTS with native inference, voice cloning, multi-speaker dialogue, longform chunking, and AIMDO DynamicVRAM support"
+        },
+        {
+            "author": "cthomasdesign",
+            "title": "Krea2-MLX (Apple Silicon)",
+            "reference": "https://github.com/Cthomasdesign/ComfyUI-Krea2-MLX",
+            "files": [
+                "https://github.com/Cthomasdesign/ComfyUI-Krea2-MLX"
+            ],
+            "install_type": "git-clone",
+            "description": "Krea-2-Turbo text-to-image on Apple MLX (Apple Silicon), with stackable LoRAs. Runs the MLX pipeline in-process and returns ComfyUI IMAGE tensors."
+        },
+        {
+            "author": "dimmedcrow",
+            "title": "ComfyUI-ColorBias",
+            "reference": "https://github.com/dimmedcrow/ComfyUI-ColorBias",
+            "files": [
+                "https://github.com/dimmedcrow/ComfyUI-ColorBias"
+            ],
+            "install_type": "git-clone",
+            "description": "CONDITIONING Color Bias Node for ComfyUI"
+        },
+        {
+            "author": "darknoah",
+            "title": "X-Dub Lip Sync",
+            "reference": "https://github.com/DarkNoah/comfyui-x-dub",
+            "files": [
+                "https://github.com/DarkNoah/comfyui-x-dub"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Kling X-Dub single-person audio-driven lip sync."
+        },
+        {
+            "author": "bisam20",
+            "title": "Animated Mask Editor",
+            "reference": "https://github.com/BISAM20/ComfyUI-AnimatedMaskEditor",
+            "files": [
+                "https://github.com/BISAM20/ComfyUI-AnimatedMaskEditor"
+            ],
+            "install_type": "git-clone",
+            "description": "Interactive editor for drawing animated, keyframed masks on a video/image batch in ComfyUI — circle, rectangle and bézier shapes with automatic keyframing, feathering and invert."
+        },
+        {
+            "author": "cbpark84",
+            "title": "comfybridgeio",
+            "reference": "https://github.com/cbpark84/ComfyBridgeIO",
+            "files": [
+                "https://github.com/cbpark84/ComfyBridgeIO"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI dynamic I/O bridge for AI agents"
+        },
+        {
+            "author": "wennatre",
+            "title": "comfyui-openai-compatible-image",
+            "reference": "https://github.com/wennatre/ComfyUI-OpenAI-Compatible-Image",
+            "files": [
+                "https://github.com/wennatre/ComfyUI-OpenAI-Compatible-Image"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for OpenAI-compatible image generation and editing endpoints."
+        },
+        {
+            "author": "SF-Runnode",
+            "title": "RunNode Prompter",
+            "reference": "https://github.com/SF-Runnode/ComfyUI_rn_prompter",
+            "files": [
+                "https://github.com/SF-Runnode/ComfyUI_rn_prompter"
+            ],
+            "install_type": "git-clone",
+            "description": "RunNode prompter nodes for ComfyUI"
+        },
+        {
+            "author": "kevinzilin",
+            "title": "comfyui-krea2-visualref",
+            "reference": "https://github.com/kevinzilin/ComfyUI-Krea2-VisualRef",
+            "files": [
+                "https://github.com/kevinzilin/ComfyUI-Krea2-VisualRef"
+            ],
+            "install_type": "git-clone",
+            "description": "Experimental Krea2 visual-token reference conditioning nodes for ComfyUI."
+        },
+        {
+            "author": "kevinzilin",
+            "title": "ComfyUI_OpenAI_GPTImage2",
+            "reference": "https://github.com/kevinzilin/ComfyUI_OpenAI_GPTImage2",
+            "files": [
+                "https://github.com/kevinzilin/ComfyUI_OpenAI_GPTImage2"
+            ],
+            "install_type": "git-clone",
+            "description": "Official OpenAI GPT-Image-2 API nodes for ComfyUI: Text-to-Image & Image Editing with multi-image support"
+        },
+        {
+            "author": "schroldgames",
+            "title": "ComfyUI-llamacpp-Unloader",
+            "reference": "https://github.com/schroldgames/ComfyUI-llamacpp-Unloader",
+            "files": [
+                "https://github.com/schroldgames/ComfyUI-llamacpp-Unloader"
+            ],
+            "install_type": "git-clone",
+            "description": "Unload llama.cpp models from VRAM to free GPU memory in ComfyUI."
+        },
+        {
+            "author": "comfyui-findmodels",
+            "title": "ComfyUI Find Models",
+            "reference": "https://github.com/mclaughlinrosemary927/ComfyUI_FindModels",
+            "files": [
+                "https://github.com/mclaughlinrosemary927/ComfyUI_FindModels"
+            ],
+            "install_type": "git-clone",
+            "description": "Find and adapt missing models in the current ComfyUI workflow"
+        },
+        {
+            "author": "<your-publisher-id>",
+            "title": "Nanaix Image Nodes",
+            "reference": "https://github.com/nan-boop/NanAix_comfyui",
+            "files": [
+                "https://github.com/nan-boop/NanAix_comfyui"
+            ],
+            "install_type": "git-clone",
+            "description": "Nanaix image generation and editing nodes for ComfyUI"
+        },
+        {
+            "author": "oratorian",
+            "title": "Trinetra Image Host Uploader",
+            "reference": "https://github.com/Oratorian/comfyui-trinetra-imagehost",
+            "files": [
+                "https://github.com/Oratorian/comfyui-trinetra-imagehost"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node to upload images to the Trinetra image host, with rate-limit-aware backoff, an expiry picker, and a live folder dropdown."
+        },
+        {
+            "author": "covertbannana",
+            "title": "CivitAI ImagePlus",
+            "reference": "https://github.com/CovertBannana/ComfyUI_CivitAI_ImagePlus",
+            "files": [
+                "https://github.com/CovertBannana/ComfyUI_CivitAI_ImagePlus"
+            ],
+            "install_type": "git-clone",
+            "description": "Browse CivitAI images in ComfyUI, preview protected images, edit prompts, and pass selected images into img2img workflows."
+        },
+        {
+            "author": "megachill",
+            "title": "ComfyUI Chill Easy Image Save",
+            "reference": "https://github.com/Megachill/ComfyUI-ChillEasyImageSave",
+            "files": [
+                "https://github.com/Megachill/ComfyUI-ChillEasyImageSave"
+            ],
+            "install_type": "git-clone",
+            "description": "Enhanced image save node with PNG/JPEG/WebP/TIFF/BMP support, quality control, GPS EXIF metadata, and date macro expansion in filename prefix."
+        },
+        {
+            "author": "keitaizumi",
+            "title": "ComfyUI-KQube",
+            "reference": "https://github.com/IzumiKeita/ComfyUI_KQube",
+            "files": [
+                "https://github.com/IzumiKeita/ComfyUI_KQube"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom nodes for loading and applying KQUBE (.kqube) cubic projection layers onto diffusion models (SDXL)"
+        },
+        {
+            "author": "wuhu290",
+            "title": "Mask External Edit",
+            "reference": "https://github.com/wuhu290/ComfyUI-Mask-External-Edit",
+            "files": [
+                "https://github.com/wuhu290/ComfyUI-Mask-External-Edit"
+            ],
+            "install_type": "git-clone",
+            "description": "Masked local edit node for ComfyUI. Crop a user-painted region, send it to an external image editing API, and blend it back into the original image."
+        },
+        {
+            "author": "artfat-creator",
+            "title": "Face Style Preset (for FaceDetailer)",
+            "reference": "https://github.com/artfat-creator/ComfyUI-Face-Style-Preset-for-FaceDetailer-",
+            "files": [
+                "https://github.com/artfat-creator/ComfyUI-Face-Style-Preset-for-FaceDetailer-"
+            ],
+            "install_type": "git-clone",
+            "description": "All-in-one face styling node for ComfyUI: curated style presets with auto-fill prompts, FaceDetailer parameters, and a dynamic searchable LoRA stack. Outputs CONDITIONING + modified MODEL ready for FaceDetailer / KSampler."
+        },
+        {
+            "author": "fulletlab",
+            "title": "Anima Style Explorer",
+            "reference": "https://github.com/fulletLab/comfyui-anima-style-nodes",
+            "files": [
+                "https://github.com/fulletLab/comfyui-anima-style-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "A quality-of-life node for ComfyUI that lets you browse anime artists, Animadex styles, character tags, visual previews, prompt autocomplete, and configurable Auto Cycle prompt testing."
+        },
+        {
+            "author": "mikudes",
+            "title": "Conditional Nodes by Mikudes",
+            "reference": "https://github.com/levox00/Conditional-Nodes-Comfy-Ui",
+            "files": [
+                "https://github.com/levox00/Conditional-Nodes-Comfy-Ui"
+            ],
+            "install_type": "git-clone",
+            "description": "Logic, conditional and dynamic loader nodes for ComfyUI."
+        },
+        {
+            "author": "PUBLISHER_ID",
+            "title": "ComfyUI Stat-Imp Nodes",
+            "reference": "https://github.com/Statistical-Impossibility/comfyui-Stat-Imp-nodes",
+            "files": [
+                "https://github.com/Statistical-Impossibility/comfyui-Stat-Imp-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Clean pure-torch Deforum-style nodes for ComfyUI animation loops: an exact-Deforum depth-aware 3D camera warp (pixel-identical to transform_image_3d), LAB/EMA color-coherence nodes that stop feedback-loop color drift, a vanilla-semantics cadence node, and an optical-flow estimator."
+        },
+        {
+            "author": "exportanything",
+            "title": "DiffusionGemma Prompt Builder",
+            "reference": "https://github.com/exportAnything/ComfyUI-DiffusionGemmaPromptBuilder",
+            "files": [
+                "https://github.com/exportAnything/ComfyUI-DiffusionGemmaPromptBuilder"
+            ],
+            "install_type": "git-clone",
+            "description": "Five-node DiffusionGemma Director Assistant bridge for ComfyUI LTX workflows."
+        },
+        {
+            "author": "dominik124421",
+            "title": "ComfyUI SAM3 JSON Boxes API",
+            "reference": "https://github.com/daminik124124-ops/ComfyUI-SAM3-JSON-Boxes-API",
+            "files": [
+                "https://github.com/daminik124124-ops/ComfyUI-SAM3-JSON-Boxes-API"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI helper node that converts JSON rectangle regions into SAM3_BOXES_PROMPT for ComfyUI-SAM3."
+        },
+        {
+            "author": "PsychoLogicAu",
+            "title": "comfyui-unlimited-ocr",
+            "reference": "https://github.com/PsychoLogicAu/ComfyUI-Unlimited-OCR",
+            "files": [
+                "https://github.com/PsychoLogicAu/ComfyUI-Unlimited-OCR"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes for Baidu Unlimited-OCR model"
+        },
+        {
+            "author": "broken-gage",
+            "title": "DGX Nodes",
+            "reference": "https://github.com/broken-gage/ComfyUI-DGX-Nodes",
+            "files": [
+                "https://github.com/broken-gage/ComfyUI-DGX-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Experimental unified-memory-aware DGX Spark / GB10 loader nodes for ComfyUI"
+        },
+        {
+            "author": "steliosot",
+            "title": "GenAsset",
+            "reference": "https://github.com/steliosot/ComfyUI-GenAsset",
+            "files": [
+                "https://github.com/steliosot/ComfyUI-GenAsset"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for saving, loading, and versioning GenAsset generations."
+        },
+        {
+            "author": "agarzon",
+            "title": "Imagent",
+            "reference": "https://github.com/agarzon/ComfyUI-Imagent",
+            "files": [
+                "https://github.com/agarzon/ComfyUI-Imagent"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for OpenAI gpt-image generation and editing"
+        },
+        {
+            "author": "pitch7900",
+            "title": "Pitch Mask Fallback",
+            "reference": "https://github.com/pitch7900/ComfyUI-PitchCustomNodes",
+            "files": [
+                "https://github.com/pitch7900/ComfyUI-PitchCustomNodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom mask utility nodes for ComfyUI - mask fallback and mask area condition."
+        },
+        {
+            "author": "kajan988",
+            "title": "ComfyUI-WorkerKeeper",
+            "reference": "https://github.com/kajan988/ComfyUI-WorkerKeeper",
+            "files": [
+                "https://github.com/kajan988/ComfyUI-WorkerKeeper"
+            ],
+            "install_type": "git-clone",
+            "description": "WorkerKeeper is a background service for ComfyUI that automatically kills idle comfy-env (GeometryPack, GaussianPack, SAM3, MoGe2, Sharp, PanoPack, DepthAnythingV3, etc.) isolation subprocesses. It requires zero workflow changes — install and forget. An optional manual override node is also provided."
+        },
+        {
+            "author": "maque",
+            "title": "sub2api",
+            "reference": "https://github.com/JioJe/comfyui-sub2api",
+            "files": [
+                "https://github.com/JioJe/comfyui-sub2api"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node for sub2api multimodal text, image generation, and image editing workflows."
+        },
+        {
+            "author": "blkot",
+            "title": "comfyui-tgbridge",
+            "reference": "https://github.com/blkot/ComfyUI-tgBridge",
+            "files": [
+                "https://github.com/blkot/ComfyUI-tgBridge"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node for sending generated videos and workflow metadata to Telegram."
+        },
+        {
+            "author": "enigmatice",
+            "title": "Enigmatic Nodes",
+            "reference": "https://github.com/enigmatice/comfyui-enigmatic-nodes",
+            "files": [
+                "https://github.com/enigmatice/comfyui-enigmatic-nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom nodes by enigmatice: mask utilities and analog video effects"
+        },
+        {
+            "author": "lackluster",
+            "title": "ComfyUI Lackluster Nodes",
+            "reference": "https://github.com/LacklusterOpsec/ComfyUI-Lackluster-Nodes",
+            "files": [
+                "https://github.com/LacklusterOpsec/ComfyUI-Lackluster-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Custom ComfyUI nodes for AllTalk TTS integration"
+        },
+        {
+            "author": "federicobuilds",
+            "title": "comfyui-vidia-open-studio-node",
+            "reference": "https://github.com/Vidia-Tools/Vidia-Open-Studio-Nodes",
+            "files": [
+                "https://github.com/Vidia-Tools/Vidia-Open-Studio-Nodes"
+            ],
+            "install_type": "git-clone",
+            "description": "Vidia Open Studio video saver custom node for ComfyUI: watermark, ffmpeg mux, R2 upload, backend notify."
+        },
+        {
+            "author": "kramins",
+            "title": "Power Prompt",
+            "reference": "https://github.com/Kramins/comfyui-power-prompt",
+            "files": [
+                "https://github.com/Kramins/comfyui-power-prompt"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node for building rich, conditional prompts with a variable system, weighted random selection, tag-based filtering, and Jinja2 templating."
+        },
+        {
+            "author": "ezetojo",
+            "title": "Prompt Translator & Enhancer",
+            "reference": "https://github.com/ezetojo/ComfyUI-PromptTranslatorEnhancer",
+            "files": [
+                "https://github.com/ezetojo/ComfyUI-PromptTranslatorEnhancer"
+            ],
+            "install_type": "git-clone",
+            "description": "Translates and enhances prompts from multiple languages to English using local GGUF models."
+        },
+        {
+            "author": "FrostySDXL",
+            "title": "comfyui-tag-rag",
+            "reference": "https://github.com/FrostySDXL/comfyui-tag-rag",
+            "files": [
+                "https://github.com/FrostySDXL/comfyui-tag-rag"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI custom node package for tag-based prompt RAG using CSV datasets and local LLM generation."
+        },
+        {
+            "author": "InfernusIntraMe",
+            "title": "comfyui-local-ollama-translator",
+            "reference": "https://github.com/InfernusIntraMe/ComfyUI-Local-Ollama-Translator",
+            "files": [
+                "https://github.com/InfernusIntraMe/ComfyUI-Local-Ollama-Translator"
+            ],
+            "install_type": "git-clone",
+            "description": "Local Ollama translation node for ComfyUI with English/Simplified Chinese prompt translation and privacy-first localhost defaults."
+        },
+        {
+            "author": "Prohect",
+            "title": "comfyui-sampler-peek",
+            "reference": "https://github.com/Prohect/comfyui-sampler-peek",
+            "files": [
+                "https://github.com/Prohect/comfyui-sampler-peek"
+            ],
+            "install_type": "git-clone",
+            "description": "Peek into ComfyUI sampling loops - decode intermediate latents using a VAE during SamplerCustomAdvanced execution"
+        },
+        {
+            "author": "dreevelle",
+            "title": "ComfyUI-FastImageSequence",
+            "reference": "https://github.com/dreevelle/ComfyUI-FastImageSequence",
+            "files": [
+                "https://github.com/dreevelle/ComfyUI-FastImageSequence"
+            ],
+            "install_type": "git-clone",
+            "description": "Fast parallel PNG image-sequence saver for ComfyUI. Multithreaded 8/16-bit PNG encoding with first-frame-only metadata — a big speedup over Save Image (Advanced) for video/frame dumps."
+        },
+        {
+            "author": "zegami",
+            "title": "ComfyUI-Zegami",
+            "reference": "https://github.com/zegami/comfyui-zegami",
+            "files": [
+                "https://github.com/zegami/comfyui-zegami"
+            ],
+            "install_type": "git-clone",
+            "description": "Push every ComfyUI generation (image or video) into a Zegami collection for visual triage, comparison, and curation."
+        },
+        {
+            "author": "fxd0h",
+            "title": "ComfyUI-mflux-AnyModel",
+            "reference": "https://github.com/fxd0h/ComfyUI-mflux-AnyModel",
+            "files": [
+                "https://github.com/fxd0h/ComfyUI-mflux-AnyModel"
+            ],
+            "install_type": "git-clone",
+            "description": "Run any mflux/MLX model in ComfyUI on Apple Silicon, with a capability registry that forwards only the parameters each model accepts."
+        },
+        {
+            "author": "nujgnem",
+            "title": "comfyui-dream-machine",
+            "reference": "https://github.com/nujgnem/ComfyUI-Dream-Machine",
+            "files": [
+                "https://github.com/nujgnem/ComfyUI-Dream-Machine"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI-native Deforum-inspired feedback animation with global anchoring"
+        },
+        {
+            "author": "collbrogtr",
+            "title": "ComfyUI-Ideogram-Autoprompter",
+            "reference": "https://github.com/collbroGTR/comfyui-ideogram-autoprompter",
+            "files": [
+                "https://github.com/collbroGTR/comfyui-ideogram-autoprompter"
+            ],
+            "install_type": "git-clone",
+            "description": "AI autoprompter for Ideogram 4's structured JSON caption format — local Qwen3-VL or Gemini build the caption, then edit it on a visual bbox canvas."
+        },
+        {
+            "author": "ShiRuYu",
+            "title": "comfyui-shiyu-tools",
+            "reference": "https://github.com/ShiRuYu/comfyui-shiyu-tools",
+            "files": [
+                "https://github.com/ShiRuYu/comfyui-shiyu-tools"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI Enterprise Plugin Framework"
+        },
+        {
+            "author": "solanex",
+            "title": "YOLO-Pose Keypoints",
+            "reference": "https://github.com/solanex/comfyui-yolo-pose",
+            "files": [
+                "https://github.com/solanex/comfyui-yolo-pose"
+            ],
+            "install_type": "git-clone",
+            "description": "Generic YOLO-Pose keypoint detector: IMAGE -> keypoints JSON (also to /history)."
+        },
+        {
+            "author": "adudeguyman",
+            "title": "Fantastic Loras",
+            "reference": "https://github.com/Adudeguyman/comfyui_fantastic-loras",
+            "files": [
+                "https://github.com/Adudeguyman/comfyui_fantastic-loras"
+            ],
+            "install_type": "git-clone",
+            "description": "Quality-of-life Lora suite, including a stack loader with built-in folder filtering, randomization, favorites, dual-model support, lora XY comparison plot stack and interactive viewer, experimental loader-agnostic Lora mimic for set-and-forget dual-model workflows like Wan 2.2 or Ideogram4."
+        },
+        {
+            "author": "AMXELA-Official",
+            "title": "ComfyUI-SeFiImage",
+            "reference": "https://github.com/AMXELA-Official/ComfyUI-SeFiImage",
+            "files": [
+                "https://github.com/AMXELA-Official/ComfyUI-SeFiImage"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI nodes for SeFi-Image (Semantic-First Diffusion) text-to-image."
+        },
+        {
             "author": "JWLHS",
             "title": "TINT4 — INT4 Weight-Only Quantization via torchao",
             "id": "tint4_xpu",
@@ -54246,8 +56093,7 @@
                 "https://github.com/JWLHS/ComfyUI-TINT4"
             ],
             "install_type": "git-clone",
-            "description": "INT4 weight-only quantization (W4A16) for diffusion models via torchao. Activations remain FP16 — zero quantization quality loss. Full LoRA support: standard + LoKr format compatible, multi-LoRA stack (≤5), IS_CHANGED fingerprint skip (0s repeat generation), SHA256 JSON disk cache (<1s hit), GPU pre-hook bake-in. Supports Intel Arc XPU, NVIDIA CUDA, AMD ROCm. Verified on Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu. Includes model analysis CLI. Requires: pip install torchao>=0.17.0"
+            "description": "INT4 weight-only quantization (W4A16) via torchao. Activations remain FP16 — zero quality loss. Full LoRA: standard + LoKr, multi-LoRA stack (≤8), SHA256 JSON cache (<1s hit), GPU pre-hook bake-in. Auto-detects device on startup and installs correct torchao build (Intel XPU / NVIDIA CUDA / AMD ROCm). Verified: Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu, Qwen-Image. Includes model analysis CLI."
         }
-    ]
-}
 
+}

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54241,9 +54241,9 @@
             "author": "JWLHS",
             "title": "TINT4 — INT4 Weight-Only Quantization via torchao",
             "id": "tint4_xpu",
-            "reference": "https://github.com/JWLHS/ComfyUI-TINT4-XPU",
+            "reference": "https://github.com/JWLHS/ComfyUI-TINT4",
             "files": [
-                "https://github.com/JWLHS/ComfyUI-TINT4-XPU"
+                "https://github.com/JWLHS/ComfyUI-TINT4"
             ],
             "install_type": "git-clone",
             "description": "INT4 weight-only quantization (W4A16) for diffusion models via torchao. Activations remain FP16 — zero quantization quality loss. Full LoRA support: standard + LoKr format compatible, multi-LoRA stack (≤5), IS_CHANGED fingerprint skip (0s repeat generation), SHA256 JSON disk cache (<1s hit), GPU pre-hook bake-in. Supports Intel Arc XPU, NVIDIA CUDA, AMD ROCm. Verified on Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu. Includes model analysis CLI. Requires: pip install torchao>=0.17.0"

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -56095,5 +56095,5 @@
             "install_type": "git-clone",
             "description": "INT4 weight-only quantization (W4A16) via torchao. Activations remain FP16 — zero quality loss. Full LoRA: standard + LoKr, multi-LoRA stack (≤8), SHA256 JSON cache (<1s hit), GPU pre-hook bake-in. Auto-detects device on startup and installs correct torchao build (Intel XPU / NVIDIA CUDA / AMD ROCm). Verified: Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu, Qwen-Image. Includes model analysis CLI."
         }
-
+    ]
 }


### PR DESCRIPTION
## TINT4 — torchao INT4 Weight-Only Quantization for ComfyUI

**Repository**: https://github.com/JWLHS/ComfyUI-TINT4

### What it does
INT4 weight-only quantization (W4A16) for diffusion models via torchao. Activations remain FP16 — zero quantization quality loss.

### Nodes
| Node | Function |
|------|----------|
| TINT4 Model Quantizer | Quantize FP16/BF16 models to INT4 safetensors |
| TINT4 Model Loader | Load quantized models |
| TINT4 LoRA Loader | Single LoRA injection (standard + LoKr, QKV fused/independent) |
| TINT4 LoRA Stack | Multi-LoRA stack (≤5) |

### Key features
- **Full LoRA support** — forward-time injection, no kernel modification
- **3-layer acceleration** — IS_CHANGED fingerprint skip (0s repeat), SHA256 JSON cache (<1s hit), GPU pre-hook bake-in
- **Multi-backend** — Intel Arc XPU, NVIDIA CUDA, AMD ROCm
- **12+ model exclusion lists** — Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu, WAN, LTX2, Qwen, Ernie, HiDream, Chroma, Ideogram4

### Performance (Arc A770, Krea2 Turbo)
| LoRA | Layers | First load | Cache hit | IS_CHANGED |
|------|--------|-----------|-----------|:---:|
| BreastSlider | 104 | 0.05s | 0.04s | 0s |
| YFG GPT | 256 | 0.63s | 0.49s | 0s |
| Onyx_V1 | 264 | 4.78s | <1s | 0s |

### Requirements

```bash
# NVIDIA CUDA / AMD ROCm / CPU
pip install torchao>=0.17.0
# Intel XPU (Arc GPU)
pip install torchao --index-url https://download.pytorch.org/whl/xpu
Intel XPU users: after installing torchao, run fix_torchao_xpu.bat (included in the plugin) to patch missing submodules in the XPU fork.