### PR TITLE
Add ComfyUI RDNA35 Attention

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54337,6 +54337,17 @@
             ],
             "install_type": "git-clone",
             "description": "A1111-style PNG Info for ComfyUI: load an image, read its generation metadata as human-readable text (A1111 parameters and ComfyUI embedded workflows), and reuse positive/negative/seed/steps/cfg as typed outputs."
+        },
+        {
+            "author": "Yasei-no-otoko",
+            "title": "ComfyUI RDNA35 Attention",
+            "id": "rdna35-attention",
+            "reference": "https://github.com/Yasei-no-otoko/ComfyUI-RDNA35-Attention",
+            "files": [
+                "https://github.com/Yasei-no-otoko/ComfyUI-RDNA35-Attention"
+            ],
+            "install_type": "git-clone",
+            "description": "RDNA 3.5 attention research nodes for ComfyUI, including fixed-block, exact Triton, FlexAttention, and PISA paths with model-local fallback handling."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Add ComfyUI RDNA35 Attention to the custom node list.

The repository provides model-local RDNA 3.5 attention backends for fixed-block, exact Triton, FlexAttention, and PISA research paths. It is public, includes English documentation and MIT licensing, and has passed its 35 Python tests plus 11 native-extension tests on gfx1151.

## Validation

- parsed `custom-node-list.json` successfully
- confirmed one unique `rdna35-attention` id and repository URL entry
- verified the public repository and default `main` branch