### PR TITLE
Register PNG Info for ComfyUI

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54470,6 +54470,17 @@
             ],
             "install_type": "git-clone",
             "description": "Slerp model merging node specifically for Cosmos Predict 2B. Supports layer-wise ratio adjustment."
+        },
+        {
+            "author": "Gerbesh",
+            "title": "PNG Info for ComfyUI",
+            "id": "png-info",
+            "reference": "https://github.com/Gerbesh/png-info-for-comfyui",
+            "files": [
+                "https://github.com/Gerbesh/png-info-for-comfyui"
+            ],
+            "install_type": "git-clone",
+            "description": "Reads A1111 and ComfyUI PNG metadata and applies editable generation settings to bound checkpoint, LoRA, CLIP text encode, and KSampler nodes."
         }
     ]
 }


### PR DESCRIPTION
## What changed

- Added PNG Info for ComfyUI to `custom-node-list.json`.
- Linked the public GitHub repository and Registry ID `png-info`.

## Why

This makes the node pack discoverable and installable through the legacy ComfyUI-Manager catalog in addition to the Comfy Registry.

## Validation

- Parsed `custom-node-list.json` successfully.
- Confirmed exactly one matching Registry ID/repository entry.
- Ran `git diff --check`.
