### PR TITLE
fix(bug): ensuring the five-button manager menu renders in the legacy ui in pip installation

### DIFF
--- a/comfyui_manager/js/comfyui-manager.js
+++ b/comfyui_manager/js/comfyui-manager.js
@@ -1468,6 +1468,12 @@ app.registerExtension({
 					tooltip: "Share"
 				}).element
 			);
+
+			if (app.menu?.settingsGroup?.element) {
+				app.menu.settingsGroup.element.before(cmGroup.element);
+			} else {
+				menu.append(cmGroup.element);
+			}
 		}
 		catch(exception) {
 			console.log('ComfyUI is outdated. New style menu based features are disabled.');

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "comfyui-manager"
 license = { text = "GPL-3.0-only" }
-version = "4.2.2"
+version = "4.2.2a"
 requires-python = ">= 3.9"
 description = "ComfyUI-Manager provides features to install and manage custom nodes for ComfyUI, as well as various functionalities to assist with ComfyUI."
 readme = "README.md"


### PR DESCRIPTION
<img width="276" height="57" alt="image" src="https://github.com/user-attachments/assets/d2ab855d-a8b3-4247-996b-d05cb8282fe6" />
Bringing back this menu that works in custom_node installation but does not with pip installation