### PR TITLE
Add ComfyUI Comic Creator node

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47268,6 +47268,17 @@
             "description": "A layer-based modal mask editor for ComfyUI with Photoshop-like controls. Features paint, color selection, alpha extraction, vector (Catmull-Rom spline), shape, and text tools, SAM3 AI segmentation, BiRefNet background removal, layer management with Undo/Redo (30 levels), ABR brush import, brush library, and multilingual UI (en/ja/zh)."
         },
         {
+            "author": "ketle-man",
+            "title": "ComfyUI Comic Creator",
+            "id": "comfyui-comic-creater",
+            "reference": "https://github.com/ketle-man/comfyui-comic-creater",
+            "files": [
+                "https://github.com/ketle-man/comfyui-comic-creater"
+            ],
+            "install_type": "git-clone",
+            "description": "A manga page creation SPA running on top of ComfyUI. Manage pages by 'works' (page groups), create pages from templates, and place images, speech balloons, text, shapes, and 3D poses into panels. Includes a layer-based image editor (layers, masks, adjustment layers), font manager with reusable style/preset system, AI image generation (Nanobanana/Gemini), script/storyboard management, and export to JPEG/PNG/WebP/PDF/EPUB. Multi-language UI (ja/en/zh)."
+        },
+        {
             "author": "senjinthedragon",
             "title": "ComfyUI Gender Tag Filter",
             "reference": "https://github.com/senjinthedragon/comfyui-gender-tag-filter",

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47270,10 +47270,10 @@
         {
             "author": "ketle-man",
             "title": "ComfyUI Comic Creator",
-            "id": "comfyui-comic-creater",
-            "reference": "https://github.com/ketle-man/comfyui-comic-creater",
+            "id": "comfyui-comic-creator",
+            "reference": "https://github.com/ketle-man/comfyui-comic-creator",
             "files": [
-                "https://github.com/ketle-man/comfyui-comic-creater"
+                "https://github.com/ketle-man/comfyui-comic-creator"
             ],
             "install_type": "git-clone",
             "description": "A manga page creation SPA running on top of ComfyUI. Manage pages by 'works' (page groups), create pages from templates, and place images, speech balloons, text, shapes, and 3D poses into panels. Includes a layer-based image editor (layers, masks, adjustment layers), font manager with reusable style/preset system, AI image generation (Nanobanana/Gemini), script/storyboard management, and export to JPEG/PNG/WebP/PDF/EPUB. Multi-language UI (ja/en/zh)."


### PR DESCRIPTION
## Summary
Adds an entry for [comfyui-comic-creater](https://github.com/ketle-man/comfyui-comic-creater) — a manga page creation SPA running on top of ComfyUI.

Pages are managed in units of "works" (page groups); users create pages from templates, place images, speech balloons, text, shapes, and 3D poses into panels, and export as JPEG/PNG/WebP/PDF/EPUB. It includes a layer-based image editor (layers/masks/adjustment layers), a font manager with a reusable style/preset system, AI image generation (Nanobanana/Gemini), and script/storyboard management. UI is available in Japanese, English, and Chinese.

## Test plan
- [x] Verified `custom-node-list.json` remains valid JSON after the change
- [x] Confirmed the new entry follows the same field structure/style as other entries in the file