### PR TITLE
Update VULCA ComfyUI repository URL

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -47752,9 +47752,9 @@
             "author": "yhryzy",
             "title": "ComfyUI-VULCA",
             "id": "comfyui-vulca",
-            "reference": "https://github.com/vulca-org/comfyui-vulca",
+            "reference": "https://github.com/vulca-org/vulca-comfyui-visual-nodes",
             "files": [
-                "https://github.com/vulca-org/comfyui-vulca"
+                "https://github.com/vulca-org/vulca-comfyui-visual-nodes"
             ],
             "install_type": "git-clone",
             "description": "Cultural art evaluation nodes — L1-L5 scoring across 13 traditions, Layered Generation + Inpainting, Brief-driven creative workflows. Evaluate AI-generated art for cultural accuracy and get actionable improvement suggestions. Requires: pip install vulca",


### PR DESCRIPTION
## What changed

- Updated the `comfyui-vulca` entry `reference` URL.
- Updated its git-clone URL in `files`.

## Why

The canonical VULCA ComfyUI repository was renamed from `vulca-org/comfyui-vulca` to `vulca-org/vulca-comfyui-visual-nodes`. Pointing the registry entry at the canonical URL avoids relying on GitHub redirect behavior.

## Impact

The node ID, install type, and package description are unchanged. New installs resolve directly to the canonical repository.

## Validation

- `python3 -m json.tool custom-node-list.json`
- Verified both updated fields for `id: comfyui-vulca`
- `git ls-remote https://github.com/vulca-org/vulca-comfyui-visual-nodes.git HEAD`