### PR TITLE
Add ComfyUI Local Run Receipts

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -54459,6 +54459,17 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for selecting, generating, and compositing rectangular manga panels"
+        },
+        {
+            "author": "AI Embedded Systems",
+            "title": "ComfyUI Local Run Receipts",
+            "id": "local-run-receipts",
+            "reference": "https://github.com/nawnie/ComfyUI-Local-Run-Receipts",
+            "files": [
+                "https://github.com/nawnie/ComfyUI-Local-Run-Receipts"
+            ],
+            "install_type": "git-clone",
+            "description": "Local-only output nodes that derive a stable run key, save image hashes, and write a receipt beside ComfyUI images. Repeated identical outputs are reported without overwriting the completed receipt."
         }
     ]
 }


### PR DESCRIPTION
Adds Local Run Receipts to the Manager list.\n\nThis small, local-only node pair derives a stable run key, saves image hashes, and writes a compact receipt beside ComfyUI output images. Repeating an identical completed result reports ALREADY_IDENTICAL instead of overwriting it.\n\nThe package has no dependencies, no network behavior, no model downloads, and no runtime package installation.\n\nValidation: custom-node-list.json passes the repository JSON checker.\n\nSource and v1.0.0 release: https://github.com/nawnie/ComfyUI-Local-Run-Receipts/releases/tag/v1.0.0