### PR TITLE
Add ComfyUI-Distilled-ResShift

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+            "author": "sorryhyun",
+            "title": "Distilled ResShift SR",
+            "reference": "https://github.com/sorryhyun/ComfyUI-Distilled-ResShift",
+            "files": [
+                "https://github.com/sorryhyun/ComfyUI-Distilled-ResShift"
+            ],
+            "install_type": "git-clone",
+            "description": "Distilled 1-step ResShift super-resolution (×4 or ×2) as a pixel-space IMAGE to IMAGE node. A ResShift student distilled from a 15-step teacher upsamples any RGB image in one stochastic step (scale dropdown). Self-contained vendored ResShift net (no xformers needed on any GPU); student + vq-f4 VQGAN auto-download on first use."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds a `custom-node-list.json` entry for [ComfyUI-Distilled-ResShift](https://github.com/sorryhyun/ComfyUI-Distilled-ResShift).

**What it is:** a distilled 1-step ResShift super-resolution node (×4 or ×2) operating in pixel space as an `IMAGE` -> `IMAGE` node. A ResShift student distilled from a 15-step teacher upsamples any RGB image in a single stochastic step, so there is no multi-step sampling loop.

**Nodes provided:**
- `ResShift SR Loader (distilled ×4/×2)` — loads the student + vq-f4 VQGAN, with scale and dtype options
- `ResShift SR Upscale (1-step)` — the single-step upscale, with seed and tiling (`chop`) for large images

**Notes:**
- Repo ships a `pyproject.toml` with a `[tool.comfy]` section (PublisherId `sorryhyun`).
- The ResShift network is vendored under `_vendor/resshift/` (S-Lab license), so no xformers dependency on any GPU.
- Student + VQGAN weights auto-download on first use.

Validated with `python json-checker.py custom-node-list.json` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
