### PR TITLE
Add ITDA to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "designloves2",
+            "title": "ITDA",
+            "id": "itda",
+            "reference": "https://github.com/designloves2/itda",
+            "files": [
+                "https://github.com/designloves2/itda"
+            ],
+            "install_type": "git-clone",
+            "description": "Frame-accurate layered video editor inside ComfyUI for stitching AI-generated clips into one continuous piece. Auto Stitch recommends the best cut point between two clips using frame and motion matching; also scene/beat detection, version stacks, wipe compare, pre-render, and MP4/MOV/WebM export."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Hi, I would like to add my custom node **ITDA** to the list.

**Repository:** https://github.com/designloves2/itda

ITDA is a frame-accurate, layered video editor that runs inside ComfyUI, built for the workflow where you generate video clips with AI and then have to join them into one continuous piece. Its main feature, Auto Stitch, analyses the overlap between two clips and recommends where to cut, scoring candidates on frame similarity and optical-flow motion continuity.

**Nodes:** `ITDA Open Editor` (opens the editor in-graph, outputs the project name), `ITDA Load Export` (loads the latest export as an IMAGE batch + AUDIO).

### Path handling
Aware of the containment requirements from previous reviews, I audited every path surface before submitting — write side, read side, and paths that arrive as data rather than as request arguments:

- All file access is confined to `folder_paths` directories (`input/ITDA`, `input/ITDA-SNAPSHOT`, `output/ITDA`); nothing is written inside the package.
- Containment goes through a single `is_contained()` helper that resolves the path first (collapsing `..` and symlinks) and then checks real parentage via `Path.parents` — never a string prefix, so `/a/bc` is not treated as inside `/a/b`. There are no `startswith()`-based path checks anywhere.
- Project names are sanitised, including rejecting dot-only names (`.` / `..`), which otherwise survive separator stripping and collapse a per-project directory one level up.
- Clip paths read from project files and the export path read from the export manifest are both validated against those roots before reaching ffmpeg or a decoder, since project JSON is data the node does not control.
- ffmpeg is invoked with argument lists (never `shell=True`), and values interpolated into filter strings are type-cast or pattern-validated.

ffmpeg work also runs off the event loop, so a long export does not block the ComfyUI server.

Requires ffmpeg on PATH. OpenCV and librosa are optional and only enable extra analysis features; both degrade gracefully when absent.

Thank you for reviewing!