### PR TITLE
add ComfyUI DeviantArt Sender to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,16 @@
 {
     "custom_nodes": [
         {
+          "author": "sni10",
+          "title": "ComfyUI DeviantArt Sender",
+          "reference": "https://github.com/sni10/DWA",
+          "files": [
+            "https://github.com/sni10/DWA"
+          ],
+          "install_type": "git-clone",
+          "description": "Automated workflow tool for scheduling and publishing AI artwork directly to DeviantArt with full mature content controls."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
This pull request adds a new custom node entry to the `custom-node-list.json` file. The new entry provides details for the "ComfyUI DeviantArt Sender" tool, which automates the scheduling and publishing of AI artwork to DeviantArt with mature content controls.

New custom node added:

* Added the "ComfyUI DeviantArt Sender" node by `sni10`, including metadata such as author, title, reference link, installation method, and description.