### PR TITLE
Add ComfyUI_QBB_LoadHighlight to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60823,6 +60823,17 @@
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI custom node that randomly selects one input from multiple inputs of the same type."
+        },
+        {
+            "author": "rhinoflavored",
+            "title": "QBB LoadHighlight",
+            "id": "qbb-loadhighlight",
+            "reference": "https://github.com/rhinoflavored/ComfyUI_QBB_LoadHighlight",
+            "files": [
+                "https://github.com/rhinoflavored/ComfyUI_QBB_LoadHighlight"
+            ],
+            "install_type": "git-clone",
+            "description": "Highlight each custom node load in the terminal, and show hard/partial import failures in a ComfyUI popup with export tools."
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add `ComfyUI_QBB_LoadHighlight` so it can be found and installed via ComfyUI-Manager's default channel list.

## Node
- Repo: https://github.com/rhinoflavored/ComfyUI_QBB_LoadHighlight
- Registry: already published as `qbb-loadhighlight` / DisplayName `QBB LoadHighlight`
- Install type: `git-clone`

## Test plan
- [ ] Search Manager for `QBB LoadHighlight` or `ComfyUI_QBB_LoadHighlight`
- [ ] Install via Manager and confirm plugin loads