### PR TITLE
Add mood.site Upload (kkukshtel/comfyui_mood)

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,18 @@
 {
     "custom_nodes": [
         {
+            "author": "kkukshtel",
+            "title": "mood.site Upload",
+            "id": "mood-site-upload",
+            "reference": "https://github.com/kkukshtel/comfyui_mood",
+            "files": [
+                "https://github.com/kkukshtel/comfyui_mood"
+            ],
+            "install_type": "git-clone",
+            "nodename_pattern": "MoodSiteUpload",
+            "description": "Uploads image(s) to a mood.site board as PNG, replicating the mood.site upload Apple Shortcut."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
Adds an entry to `custom-node-list.json` for **mood.site Upload**.

- Repo: https://github.com/kkukshtel/comfyui_mood
- Node: `MoodSiteUpload` (display name "mood.site Upload")
- Also published to the Comfy Registry as `mood-site-upload` (publisher `kkukshtel`).

Uploads image(s) from a ComfyUI workflow to a mood.site board as PNG.

Single-entry addition at the top of the array; JSON validated.