### PR TITLE
Add ComfyUI-Tab-Cycle

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60889,6 +60889,6 @@
             ],
             "install_type": "git-clone",
             "description": "Cycle through the number input fields on a node using Tab / Shift+Tab. Classic UI QoL extension."
-        },
+        }
     ]
 }

--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60878,6 +60878,17 @@
             ],
             "install_type": "git-clone",
             "description": "INT4 weight-only quantization (W4A16) via torchao. Activations remain FP16 — zero quality loss. Full LoRA: standard + LoKr, multi-LoRA stack (≤8), SHA256 JSON cache (<1s hit), GPU pre-hook bake-in. Auto-detects device on startup and installs correct torchao build (Intel XPU / NVIDIA CUDA / AMD ROCm). Verified: Krea2 Turbo, Flux2 Klein 9B, Z-Image, Boogu, Qwen-Image. Includes model analysis CLI."
-        }
+        },
+        {
+            "author": "muerrilla",
+            "title": "ComfyUI Tab Cycle",
+            "id": "ComfyUI-Tab-Cycle",
+            "reference": "https://github.com/muerrilla/ComfyUI-Tab-Cycle",
+            "files": [
+                "https://github.com/muerrilla/ComfyUI-Tab-Cycle"
+            ],
+            "install_type": "git-clone",
+            "description": "Cycle through the number input fields on a node using Tab / Shift+Tab. Classic UI QoL extension."
+        },
     ]
 }


### PR DESCRIPTION
updated node list to add ComfyUI-Tab-Cycle.

This is a QoL extension for classic UI that allows the user to cycle through the number input fields on the selected node using Tab/Shift+Tab. If a number field is not active Tab has the default behavior.