### PR TITLE
Add StyleRef nodes for ComfyUI to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60909,6 +60909,17 @@
             ],
             "install_type": "git-clone",
             "description": "Cycle through the number input fields on a node using Tab / Shift+Tab. Classic UI QoL extension."
+        },
+        {
+            "author": "StyleRef",
+            "title": "StyleRef nodes for ComfyUI",
+            "id": "styleref-comfyui",
+            "reference": "https://github.com/StyleRef/styleref-comfyui",
+            "files": [
+                "https://github.com/StyleRef/styleref-comfyui"
+            ],
+            "install_type": "git-clone",
+            "description": "Load a StyleRef creative style once, reuse it across your workflows. Five nodes: Load, Apply, Facets, Reference Images, Login. Zero Python dependencies; the style is compiled server-side at styleref.io so improvements reach you without an update. Also on the Comfy Registry as styleref-comfyui."
         }
     ]
 }


### PR DESCRIPTION
## Summary
Adds an entry for **StyleRef nodes for ComfyUI** — five nodes (Load, Apply, Facets, Reference Images, Login) that fetch a StyleRef creative style and compile it into model-appropriate prompts server-side. Zero Python dependencies.

- Repo: https://github.com/StyleRef/styleref-comfyui (MIT, public)
- Also on the Comfy Registry as [`styleref-comfyui`](https://registry.comfy.org/nodes/styleref-comfyui), currently `v1.0.4`, active
- CI green on all pushes; 244 tests

## Test plan
- [x] Validated `custom-node-list.json` still parses as valid JSON after the edit
- [x] Checked the new entry's `id` doesn't collide with any existing entry
- [x] Matched the field set and formatting of neighboring entries
- [x] Loaded with `Use local DB` in a running ComfyUI-Manager to confirm the entry renders in the Install Custom Nodes dialog (per the CONTRIBUTING note — I don't have a local Manager instance handy tonight; happy to do this if a maintainer can't verify it faster than I can set one up)
