### PR TITLE
Add ComfyUI_EasySize to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -45041,7 +45041,7 @@
             "install_type": "git-clone",
             "description": "Prompt Style Selector with Preview, Multiple Selecting, Search and Local Base."
         },
-		{
+        {
             "author": "DemonAlone",
             "title": "DemonAlone-JS_Addon-ComfyUI",
             "reference": "https://github.com/DemonAlone/DemonAlone-JS_Addon-ComfyUI",
@@ -61006,7 +61006,10 @@
             ],
             "install_type": "git-clone",
             "description": "Professional ACES and EXR workflow nodes with OCIO 2.1 support and sequence loading.",
-            "pip": ["opencolorio>=2.2.0", "openexr>=3.2.0"]
+            "pip": [
+                "opencolorio>=2.2.0",
+                "openexr>=3.2.0"
+            ]
         },
         {
             "author": "Neurad",
@@ -61017,6 +61020,16 @@
             ],
             "install_type": "git-clone",
             "description": "Visual interface for LoRA management with tabs, drag-and-drop, and automatic CivitAI metadata fetching."
+        },
+        {
+            "author": "hadesybil-hub",
+            "title": "ComfyUI_EasySize",
+            "reference": "https://github.com/hadesybil-hub/ComfyUI_EasySize",
+            "files": [
+                "https://github.com/hadesybil-hub/ComfyUI_EasySize"
+            ],
+            "install_type": "git-clone",
+            "description": "A lightweight ComfyUI node for size selection and size routing with Preset, Image and Custom modes."
         }
     ]
 }


### PR DESCRIPTION
Add ComfyUI_EasySize to the ComfyUI-Manager custom node list.

Repository:
https://github.com/hadesybil-hub/ComfyUI_EasySize

Features:
- Single node size routing
- Preset / Image / Custom modes
- Family → Ratio → Resolution preset system
- Automatic ratio classification
- Width and height INT outputs

Design:
EasySize focuses on size selection and routing only.
It does not create LATENT, resize images, process MASK, or perform model detection.