### PR TITLE
test: fix the install-flags structural guard failing on main

### DIFF
--- a/tests/test_install_flags_structural.py
+++ b/tests/test_install_flags_structural.py
@@ -54,7 +54,7 @@ class JsCopyStructuralTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.common_src = JS_COMMON_PATH.read_text()
+        cls.common_src = JS_COMMON_PATH.read_text(encoding="utf-8")
 
     def test_surface_messages_name_their_flag(self):
         """Both install 403 branches pass a flag-naming defaultMessage."""
@@ -76,14 +76,19 @@ class JsCopyStructuralTest(unittest.TestCase):
         """The generic fallback copy stays (exactly its two occurrences in
         handle403Response), and no other handle403Response caller across
         js/ gains a defaultMessage."""
-        self.assertEqual(self.common_src.count(GENERIC_403_COPY), 2)
+        # Count inside handle403Response rather than file-wide. The same
+        # sentence is legitimately reused elsewhere in common.js to build a
+        # batch-uninstall error message, which is not a caller of
+        # handle403Response and so is outside this guard's contract.
+        handle_block = _js_function_block(self.common_src, "handle403Response")
+        self.assertEqual(handle_block.count(GENERIC_403_COPY), 2)
         surface_blocks = "".join(
             _js_function_block(self.common_src, name)
             for name in ("install_pip", "install_via_git_url")
         )
         allowed_two_arg = {a for a in _handle403_call_args(surface_blocks) if "," in a}
         for js_file in sorted((REPO_ROOT / "js").glob("*.js")):
-            source = js_file.read_text()
+            source = js_file.read_text(encoding="utf-8")
             for args in _handle403_call_args(source):
                 if "," in args:
                     self.assertIn(
@@ -98,7 +103,7 @@ class StructuralSecurityGuardsTest(unittest.TestCase):
 
     def test_no_new_install_route_surface(self):
         """No new HTTP surface for git-URL/pip install."""
-        source = MANAGER_SERVER_PATH.read_text()
+        source = MANAGER_SERVER_PATH.read_text(encoding="utf-8")
         routes = set(re.findall(r"@routes\.post\(\"([^\"]+)\"\)", source))
         expected_surfaces = {
             "/customnode/install/git_url",
@@ -117,14 +122,14 @@ class StructuralSecurityGuardsTest(unittest.TestCase):
 
     def test_cm_cli_ungated(self):
         """cm-cli stays a local operator tool — no gate, no flag lookup."""
-        source = CM_CLI_PATH.read_text()
+        source = CM_CLI_PATH.read_text(encoding="utf-8")
         for token in FLAG_TOKENS + ("is_allowed_security_level", "is_dedicated_install_allowed"):
             self.assertNotIn(token, source, "cm-cli.py must stay ungated")
 
     def test_no_autoseed_in_migration(self):
         """The migration module never references the flags (explicit
         opt-in only — no auto-seed from security_level)."""
-        source = MANAGER_MIGRATION_PATH.read_text()
+        source = MANAGER_MIGRATION_PATH.read_text(encoding="utf-8")
         for token in FLAG_TOKENS:
             self.assertNotIn(
                 token, source,


### PR DESCRIPTION
## Summary

`tests/test_install_flags_structural.py::JsCopyStructuralTest::test_generic_fallback_and_frozen_callers_unchanged` fails on a clean checkout of `main`. Two separate defects, the second hidden behind the first. CI runs `ruff check .` only, so neither is visible there.

## 1. The guard counts file-wide but documents a narrower contract

Its own docstring says the copy has "exactly its two occurrences **in handle403Response**", but the assertion counts the whole file:

```python
self.assertEqual(self.common_src.count(GENERIC_403_COPY), 2)
```

`js/common.js` now contains the sentence three times: twice inside `handle403Response` (lines 109 and 112, the real fallback) and once at line 722, where the batch-uninstall handler builds `errorMsg` for a 403 status. That third use is not a `handle403Response` caller, so it is outside what this guard covers, but the file-wide count still trips on it.

Scoped the count to the `handle403Response` block using the module's existing `_js_function_block` helper, which matches the documented intent. I checked the guard still bites: temporarily changing one of the two in-function occurrences makes the assertion fail as intended.

This one is not platform-specific. The count is 3 on Linux and Windows alike.

## 2. `read_text()` without an encoding fails on Windows

Once the count assertion passes, the test reaches:

```python
for js_file in sorted((REPO_ROOT / "js").glob("*.js")):
    source = js_file.read_text()
```

`Path.read_text()` uses the locale encoding. On a cp1252 Windows install that raises `UnicodeDecodeError` on four files that contain emoji: `comfyui-manager.js`, `comfyui-share-common.js`, `comfyui-share-copus.js`, `comfyui-share-openart.js`.

Measured on both platforms from the same checkout:

```
platform: win32          preferred encoding: cp1252
count file-wide: 3       js files that fail bare read_text(): ['comfyui-manager.js', 'comfyui-share-common.js', 'comfyui-share-copus.js', 'comfyui-share-openart.js']

platform: linux          preferred encoding: UTF-8
count file-wide: 3       js files that fail bare read_text(): (none)
```

Passed `encoding="utf-8"` explicitly. I did the same for the other four `read_text()` calls in this file for consistency: they read `manager_server.py`, `cm-cli.py`, `manager_migration.py` and `common.js`, which are pure ASCII today, so they pass by luck rather than by contract, and would break the same way the first time someone adds a non-ASCII character.

## Scope

Only `tests/test_install_flags_structural.py` changes. No shipped code is touched, and no other file in the repo uses a bare `read_text()`.

## Result

Before, on Windows: `1 failed, 37 passed, 14 skipped`.
After: `38 passed, 14 skipped, 22 subtests passed`.

`ruff check .` is clean.
