### PR TITLE
Re-add ComfyUI-Pixaroma to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61017,6 +61017,17 @@
             ],
             "install_type": "git-clone",
             "description": "Visual interface for LoRA management with tabs, drag-and-drop, and automatic CivitAI metadata fetching."
+        },
+        {
+            "author": "pixaroma",
+            "title": "ComfyUI-Pixaroma",
+            "id": "comfyui-pixaroma",
+            "reference": "https://github.com/pixaroma/ComfyUI-Pixaroma",
+            "files": [
+                "https://github.com/pixaroma/ComfyUI-Pixaroma"
+            ],
+            "install_type": "git-clone",
+            "description": "Creative suite for ComfyUI: fullscreen Image Composer, Paint, 3D Builder, Image Crop and AudioReact editors, plus Load/Save Image, Save Mp4, Load Video, Inpaint Crop and Stitch, Outpaint, XY Plot, Prompt library, LoRA Loader, Control Panel, Notes, Labels, and canvas tools for aligning and grouping nodes."
         }
     ]
 }


### PR DESCRIPTION
The entry was merged in #2821 (May 2026) but is no longer in the list. The most likely reason is that my GitHub account was suspended for over a week, so the repository would have returned 404 to the scanner during that window. The account and the repository are fully restored.

Placed after the last git-clone block, matching the placement fix in 6ffead7b.