### PR TITLE
Add Multi Bool Panel to custom node registry

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61017,6 +61017,16 @@
             ],
             "install_type": "git-clone",
             "description": "Visual interface for LoRA management with tabs, drag-and-drop, and automatic CivitAI metadata fetching."
+        },
+        {
+            "author": "solidlime",
+            "title": "Multi Bool Panel",
+            "reference": "https://github.com/solidlime/ComfyUI-MultiBoolPanel",
+            "files": [
+                "https://github.com/solidlime/ComfyUI-MultiBoolPanel"
+            ],
+            "install_type": "git-clone",
+            "description": "Multiple named boolean toggle switches in a single node, each with an independent BOOLEAN output. Adjustable toggle count (1-20) and labels; batch-apply to other nodes by name filter (widgets/bypass/mute)."
         }
     ]
 }


### PR DESCRIPTION
Adds the Multi Bool Panel custom node (https://github.com/solidlime/ComfyUI-MultiBoolPanel) to the registry.

- Single node with up to 20 named boolean toggle switches, each with an independent BOOLEAN output socket.
- Toggle count adjustable (slot_count 1-20), per-toggle labels, all-switch master.
- Batch operation: name_filter + broadcast_mode (widgets/bypass/mute) applies to matching nodes by name.