### PR TITLE
Remove paid-unlock pricing from the Copus share dialog

### DIFF
--- a/js/comfyui-share-copus.js
+++ b/js/comfyui-share-copus.js
@@ -63,7 +63,6 @@ export class CopusShareDialog extends ComfyDialog {
       [$el("div.comfy-modal-content", {}, [...this.createButtons()])]
     );
     this.selectedOutputIndex = 0;
-    this.selectedOutput_lock = 0;
     this.selectedNodeId = null;
     this.uploadedImages = [];
     this.allFilesImages = [];
@@ -199,34 +198,6 @@ export class CopusShareDialog extends ComfyDialog {
         subTitleNumDom.textContent = `${titleNum}/350`;
       },
     });
-    this.LockInput = $el("input", {
-      type: "text",
-      placeholder: "0",
-      style: {
-        width: "100px",
-        padding: "7px",
-        paddingLeft: "30px",
-        borderRadius: "4px",
-        border: "1px solid #ddd",
-        boxSizing: "border-box",
-        position: "relative",
-      },
-      oninput: (event) => {
-        let input = event.target.value;
-        // Use a regular expression to match a number with up to two decimal places
-        const regex = /^\d*\.?\d{0,2}$/;
-        if (!regex.test(input)) {
-          // If the input doesn't match, remove the last entered character
-          event.target.value = input.slice(0, -1);
-        }
-        const numericValue = parseFloat(input);
-        if (numericValue > 9999) {
-          input = "9999";
-        }
-        // Update the input field with the valid value
-        event.target.value = input;
-      },
-    });
     this.descriptionInput = $el("textarea", {
       placeholder: "Content (Optional)",
       style: {
@@ -360,101 +331,6 @@ export class CopusShareDialog extends ComfyDialog {
       // descriptionNumDom,
     ]);
     // switch  between outputs section and additional inputs section
-    this.radioButtons_lock = [];
-
-    this.radioButtonsCheck_lock = $el("input", {
-      type: "radio",
-      name: "output_type_lock",
-      value: "0",
-      id: "blockchain1_lock",
-      checked: true,
-    });
-    this.radioButtonsCheckOff_lock = $el("input", {
-      type: "radio",
-      name: "output_type_lock",
-      value: "1",
-      id: "blockchain_lock",
-    });
-
-    const blockChainSection_lock = $el("div", { style: sectionStyle }, [
-      $el("label", { style: labelStyle }, ["6️⃣ Download threshold"]),
-      $el(
-        "label",
-        {
-          style: {
-            marginTop: "10px",
-            display: "flex",
-            alignItems: "center",
-            cursor: "pointer",
-          },
-        },
-        [
-          this.radioButtonsCheck_lock,
-          $el(
-            "div",
-            {
-              style: {
-                marginLeft: "5px",
-                display: "flex",
-                alignItems: "center",
-                position: "relative",
-              },
-            },
-            [
-              $el("span", { style: { marginLeft: "5px" } }, ["ON"]),
-              $el(
-                "span",
-                {
-                  style: {
-                    marginLeft: "20px",
-                    marginRight: "10px",
-                    color: "#fff",
-                  },
-                },
-                ["Unlock with"]
-              ),
-              $el("img", {
-                style: {
-                  width: "16px",
-                  height: "16px",
-                  position: "absolute",
-                  right: "75px",
-                  zIndex: "100",
-                },
-                src: "https://static.copus.io/images/admin/202507/prod/e2919a1d8f3c2d99d3b8fe27ff94b841.png",
-              }),
-              this.LockInput,
-            ]
-          ),
-        ]
-      ),
-      $el(
-        "label",
-        { style: { display: "flex", alignItems: "center", cursor: "pointer" } },
-        [
-          this.radioButtonsCheckOff_lock,
-          $el(
-            "div",
-            {
-              style: {
-                marginLeft: "5px",
-                display: "flex",
-                alignItems: "center",
-              },
-            },
-            [$el("span", { style: { marginLeft: "5px" } }, ["OFF"])]
-          ),
-        ]
-      ),
-
-      $el(
-        "p",
-        { style: { fontSize: "16px", color: "#fff", margin: "10px 0 0 0" } },
-        [
-        ]
-      ),
-    ]);
-
     this.radioButtons = [];
 
     this.radioButtonsCheck = $el("input", {
@@ -472,7 +348,7 @@ export class CopusShareDialog extends ComfyDialog {
     });
 
     const blockChainSection = $el("div", { style: sectionStyle }, [
-      $el("label", { style: labelStyle }, ["8️⃣ Store on blockchain "]),
+      $el("label", { style: labelStyle }, ["7️⃣ Store on blockchain "]),
       $el(
         "label",
         {
@@ -531,7 +407,7 @@ export class CopusShareDialog extends ComfyDialog {
 
     // content rating
     const contentRatingSection = $el("div", { style: sectionStyle }, [
-      $el("label", { style: labelStyle }, ["7️⃣ Content rating "]),
+      $el("label", { style: labelStyle }, ["6️⃣ Content rating "]),
       $el(
         "label",
         {
@@ -698,7 +574,6 @@ export class CopusShareDialog extends ComfyDialog {
       SubtitleSection,
       DescriptionSection,
       // contestSection,
-      blockChainSection_lock,
       contentRatingSection,
       blockChainSection,
       this.message,
@@ -804,8 +679,6 @@ export class CopusShareDialog extends ComfyDialog {
       subTitle: this.SubTitleInput.value,
       content: this.descriptionInput.value,
       storeOnChain: this.radioButtonsCheck.checked ? true : false,
-      lockState: this.radioButtonsCheck_lock.checked ? 2 : 0,
-      unlockPrice: this.LockInput.value,
       rating: this.ratingRadioButtonsCheck0.checked
         ? 0
         : this.ratingRadioButtonsCheck1.checked
@@ -825,12 +698,6 @@ export class CopusShareDialog extends ComfyDialog {
 
     if (!form_values.title) {
       throw new Error("Title is required");
-    }
-
-    if (this.radioButtonsCheck_lock.checked) {
-      if (!this.LockInput.value) {
-        throw new Error("Price is required");
-      }
     }
 
     if (!this.uploadedImages.length) {


### PR DESCRIPTION
Copus has retired paid unlocks. The server side now ignores `lockState` / `unlockPrice` and publishes every shared workflow for free, so the **6️⃣ Download threshold** section in the Copus share dialog no longer maps to anything.

Leaving it in place is actively harmful today: the `ON` radio is `checked: true` by default, so anyone who doesn't notice the section gets `Price is required` thrown on submit and has to explicitly opt out of a feature that no longer exists.

**Changes** — all confined to `js/comfyui-share-copus.js`:

- remove the "Download threshold" section, its ON/OFF radios and the price input
- stop sending `lockState` / `unlockPrice` in the share payload
- drop the now-unreachable `Price is required` validation
- renumber the remaining two sections so the labels match render order (rating was labelled 7️⃣ but rendered before the 8️⃣ blockchain section — they are now 6️⃣ and 7️⃣)

No other share targets are touched, and nothing outside this dialog references the removed fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)