### PR TITLE
Fix Anomalous Model Browser metadata matching all missing nodes

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -55406,8 +55406,7 @@
                 "https://github.com/DemonGatanjieu/Anomalous_Model_Browser"
             ],
             "install_type": "git-clone",
-            "description": "Auto-injects model hashes and auto-fixes missing nodes or renamed models paths when sharing workflows.",
-            "nodename_pattern": ".*"
+            "description": "UI-only extension for model library management and workflow authoring. Features visual model/LoRA insertion, prompt notebooks, gallery, and safe file management. Includes 'Model Doctor' to auto-restore broken model paths using metadata previously injected by this plugin."
         },
         {
             "author": "Pikselkroken",


### PR DESCRIPTION
Hi! This PR updates the metadata for `Anomalous_Model_Browser` to fix a false-positive matching issue.

**Changes:**
1. **Removed `"nodename_pattern": ".*"`**: This wildcard was causing ComfyUI-Manager to incorrectly suggest our extension for any unrelated missing custom nodes (leading to user confusion and invalid bug reports). Our extension is primarily UI-based and does not provide general custom nodes.
2. **Updated `"description"`**: Clarified that the "Model Doctor" feature restores model paths using injected metadata, not missing nodes.

Here is the updated entry for reference:

```json
{
    "author": "DemonGatanjieu",
    "title": "Anomalous Model Browser",
    "reference": "https://github.com/DemonGatanjieu/Anomalous_Model_Browser",
    "files": [
        "https://github.com/DemonGatanjieu/Anomalous_Model_Browser"
    ],
    "install_type": "git-clone",
    "description": "UI-only extension for model library management and workflow authoring. Features visual model/LoRA insertion, prompt notebooks, gallery, and safe file management. Includes 'Model Doctor' to auto-restore broken model paths using metadata previously injected by this plugin."
}
```

Thanks for maintaining the manager!