### PR TITLE
Add Wildcard Pipeline to custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60988,6 +60988,16 @@
             ],
             "install_type": "git-clone",
             "description": "Multi-point white balance and exposure correction for e-commerce product images."
+        },
+        {
+            "author": "DumiFlex",
+            "title": "Wildcard Pipeline",
+            "reference": "https://github.com/DumiFlex/ComfyUI-Wildcard-Pipeline",
+            "files": [
+                "https://github.com/DumiFlex/ComfyUI-Wildcard-Pipeline"
+            ],
+            "install_type": "git-clone",
+            "description": "Modular procedural prompt generation — wildcards, fixed values, combines, derivations and constraints resolved in a context pipeline, with a manager UI for a reusable module library."
         }
     ]
 }


### PR DESCRIPTION
Adds one entry for [Wildcard Pipeline](https://github.com/DumiFlex/ComfyUI-Wildcard-Pipeline) — modular procedural prompt generation (wildcards, fixed values, combines, derivations, constraints) with a manager UI.

Already on the Comfy Registry as `comfyui-wildcard-pipeline`, but registry-only nodes get no stars or last-updated in the Manager list, since those come from `github-stats.json` via this file (#2936).

Surface, for review:
- Registers HTTP routes under `/wp/api/*` (SQLite CRUD for the module library) and serves the manager SPA at `/wp`. Static serving is confined to the plugin's `web/` dir.
- No outbound network calls, no subprocess, no eval/pickle, no archive extraction, no file uploads.
- Filesystem writes are the SQLite database only, restricted to three known locations.
- Nodes themselves touch no files.