### PR TITLE
Clarify Git URL install requirements

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -37,7 +37,7 @@ SECURITY_MESSAGE_MIDDLE_OR_BELOW = "ERROR: To use this action, a security_level 
 SECURITY_MESSAGE_NORMAL_MINUS = "ERROR: To use this feature, you must either set '--listen' to a local IP and set the security level to 'normal-' or lower, or set the security level to 'middle' or 'weak'. Please contact the administrator.\nReference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 SECURITY_MESSAGE_GENERAL = "ERROR: This installation is not allowed in this security_level. Please contact the administrator.\nReference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 SECURITY_MESSAGE_NORMAL_MINUS_MODEL = "ERROR: Downloading models that are not in '.safetensors' format is only allowed for models registered in the 'default' channel at this security level. If you want to download this model, set the security level to 'normal-' or lower."
-SECURITY_MESSAGE_FLAG_GIT_URL = "ERROR: This action requires 'allow_git_url_install = true' in config.ini ([default] section). This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
+SECURITY_MESSAGE_FLAG_GIT_URL = "ERROR: This action requires 'allow_git_url_install = true' in config.ini ([default] section). This setting is independent of security_level and also requires ComfyUI to be listening on a loopback address. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 SECURITY_MESSAGE_FLAG_PIP = "ERROR: This action requires 'allow_pip_install = true' in config.ini ([default] section). This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 
 routes = PromptServer.instance.routes

--- a/tests/test_install_flags_gates.py
+++ b/tests/test_install_flags_gates.py
@@ -386,6 +386,7 @@ class DenialConstantsTest(unittest.TestCase):
 
     def test_flag_constants_content(self):
         self._assert_honest_copy(NS["SECURITY_MESSAGE_FLAG_GIT_URL"], "allow_git_url_install")
+        self.assertIn("loopback", NS["SECURITY_MESSAGE_FLAG_GIT_URL"])
         self._assert_honest_copy(NS["SECURITY_MESSAGE_FLAG_PIP"], "allow_pip_install")
 
     def test_security_403_precedence(self):


### PR DESCRIPTION
## Summary

Clarify the Git URL installation security error so it states both requirements: `allow_git_url_install = true` and a loopback listen address.

## Why

The security gate requires both conditions, but the existing message only mentions the configuration flag. Users listening on a non-loopback address can therefore receive misleading remediation guidance even when the flag is enabled.

This change only updates the error copy and its focused assertion. The security behavior and API response remain unchanged.

## Tests

- `python_embeded/python.exe tests/test_install_flags_gates.py`
- `python_embeded/python.exe tests/test_install_flag_predicate.py`
- `python_embeded/python.exe tests/test_install_flags_structural.py`

All 26 focused tests pass.
