### PR TITLE
fix: report the real reason a batch install or uninstall is denied

### DIFF
--- a/glob/manager_server.py
+++ b/glob/manager_server.py
@@ -37,8 +37,8 @@ SECURITY_MESSAGE_MIDDLE_OR_BELOW = "ERROR: To use this action, a security_level 
 SECURITY_MESSAGE_NORMAL_MINUS = "ERROR: To use this feature, you must either set '--listen' to a local IP and set the security level to 'normal-' or lower, or set the security level to 'middle' or 'weak'. Please contact the administrator.\nReference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 SECURITY_MESSAGE_GENERAL = "ERROR: This installation is not allowed in this security_level. Please contact the administrator.\nReference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 SECURITY_MESSAGE_NORMAL_MINUS_MODEL = "ERROR: Downloading models that are not in '.safetensors' format is only allowed for models registered in the 'default' channel at this security level. If you want to download this model, set the security level to 'normal-' or lower."
-SECURITY_MESSAGE_FLAG_GIT_URL = "ERROR: This action requires 'allow_git_url_install = true' in config.ini ([default] section). This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
-SECURITY_MESSAGE_FLAG_PIP = "ERROR: This action requires 'allow_pip_install = true' in config.ini ([default] section). This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
+SECURITY_MESSAGE_FLAG_GIT_URL = "ERROR: This action requires 'allow_git_url_install = true' in config.ini ([default] section) AND ComfyUI listening on a loopback address (e.g. --listen 127.0.0.1). The flag alone has no effect when ComfyUI listens on any other address. This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
+SECURITY_MESSAGE_FLAG_PIP = "ERROR: This action requires 'allow_pip_install = true' in config.ini ([default] section) AND ComfyUI listening on a loopback address (e.g. --listen 127.0.0.1). The flag alone has no effect when ComfyUI listens on any other address. This setting is independent of security_level. Reference: https://github.com/ltdrdata/ComfyUI-Manager#security-policy"
 
 routes = PromptServer.instance.routes
 

--- a/js/common.js
+++ b/js/common.js
@@ -663,8 +663,6 @@ export async function uninstallNodes(nodeList, options = {}) {
 
 			if (res.status == 403) {
 				errorMsg += `This action is not allowed with this security level configuration.\n`;
-			} else if (res.status == 404) {
-				errorMsg += `With the current security level configuration, only custom nodes from the <B>"default channel"</B> can be uninstalled.\n`;
 			} else {
 				errorMsg += await res.text() + '\n';
 			}

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1480,8 +1480,6 @@ export class CustomNodesManager {
 					} catch {
 						errorMsg += `This action is not allowed with this security level configuration.\n`;
 					}
-				} else if(res.status == 404) {
-					errorMsg += `With the current security level configuration, only custom nodes from the <B>"default channel"</B> can be installed.\n`;
 				} else {
 					errorMsg += await res.text() + '\n';
 				}

--- a/tests/test_install_flags_gates.py
+++ b/tests/test_install_flags_gates.py
@@ -374,6 +374,10 @@ class DenialConstantsTest(unittest.TestCase):
     def _assert_honest_copy(self, const, flag_name):
         self.assertIn(flag_name, const, "constant must name the responsible flag")
         self.assertIn("config.ini", const, "constant must name config.ini")
+        # The gate is `flag AND loopback` (is_dedicated_install_allowed), so a
+        # message that stops at the flag sends non-loopback users to re-check a
+        # setting they already enabled.
+        self.assertIn("loopback", const, "constant must name the loopback requirement")
         for cause_phrasing in (
             "is not allowed in this security_level",
             "set the security level",


### PR DESCRIPTION
Fixes #3128.

## Problem

**1. The batch install path throws away the server's 404 body.**

`js/custom-nodes-manager.js` replaced every 404 with a message about the `"default channel"` and the security level. The denial it fires on most often cannot be resolved by either. In `install_custom_node`, the `risky_level == 'high'` arm goes through `is_dedicated_install_allowed(core.get_config()['allow_git_url_install'], args.listen)`, which is `flag AND loopback` and never reads `security_level`. Setting `security_level = weak` changes nothing, so the message is a false lead that users do follow.

The same branch also swallowed the informative 404s on that route, for example ``Following node pack doesn't provide `nightly` version``, which the user never got to see.

**2. The uninstall path carried the same substitution for a status it never returns.**

`uninstall_custom_node` returns 403 or 200 only. The 404 arm in `js/common.js` could therefore only be reached when the endpoint itself was missing (an outdated or partly-installed Manager), where a note about channel configuration points in exactly the wrong direction.

**3. `SECURITY_MESSAGE_FLAG_GIT_URL` omits half the gate.**

The message asks for `allow_git_url_install = true` and adds that the setting is independent of `security_level`, but `is_dedicated_install_allowed` also requires a loopback listen address. Anyone on `--listen 0.0.0.0` is told to enable a flag they already enabled, with no hint about the real bound. `SECURITY_MESSAGE_FLAG_PIP` has the identical gap.

## Fix

- Drop the 404 special case in both JS paths so the existing `else` arm surfaces the server's own body. This is what the 403 path already does, and the dedicated `/customnode/install/git_url` surface already names the responsible flag through `js/common.js`.
- Name the loopback requirement in both flag messages.

The loopback bound itself is deliberate per #2991 and is unchanged here. This is diagnostics only: no gate, status code, or policy moves.

## Evidence

`python -m pytest tests -q` on a clean 3.12 venv:

```
38 passed, 14 skipped, 22 subtests passed in 36.09s
```

`ruff check .` (the CI gate) passes.

The denial-copy guard in `tests/test_install_flags_gates.py` now asserts the loopback requirement. Reverting only `glob/manager_server.py` and re-running it fails as expected:

```
E   AssertionError: 'loopback' not found in "ERROR: This action requires
    'allow_git_url_install = true' in config.ini ([default] section).
    This setting is independent of security_level. ..."
    : constant must name the loopback requirement
FAILED tests/test_install_flags_gates.py::DenialConstantsTest::test_flag_constants_content
```

The JS side has no test harness in this repo, so those two changes are deletions that fall through to the existing `else` branch rather than new logic.