### PR TITLE
Add ComfyUI-ModelPathManager to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -2723,6 +2723,16 @@
             "description": "Manage models: browsing, download and delete."
         },
         {
+            "author": "lztango",
+            "title": "ComfyUI-ModelPathManager",
+            "reference": "https://github.com/lztango/ComfyUI-ModelPathManager",
+            "files": [
+                "https://github.com/lztango/ComfyUI-ModelPathManager"
+            ],
+            "install_type": "git-clone",
+            "description": "Unified model path manager: dynamically add model paths at runtime (no restart), auto-dedup, Junction-based path merge (solves duplicate model storage from hardcoded-path plugins, zero file copy), automatic startup checks."
+        },
+        {
             "author": "ali1234",
             "title": "comfyui-job-iterator",
             "id": "job-iterator",


### PR DESCRIPTION
Adding my custom node **ComfyUI-ModelPathManager** to the registry.

**Features:**
- Dynamically add model search paths at runtime (no restart needed)
- Auto-deduplicate paths pointing to the same physical directory
- **Junction-based path merge**: solves duplicate model storage for plugins that hardcode `os.path.join(folder_paths.models_dir, "xxx")` paths, without copying files (Windows Junction, no admin rights needed)
- Automatic startup check for mergeable directories (dry-run report only)
- Web UI panel with scan/apply buttons (Ctrl+Shift+M)

**Repo:** https://github.com/lztango/ComfyUI-ModelPathManager
**License:** MIT

Verified: JSON syntax valid, list loads without issues (5880 entries).