### PR TITLE
fix(ui): hide Share button in new menu when share_option is none

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -1618,7 +1618,7 @@ app.registerExtension({
 					},
 					tooltip: "Free model and node cache"
 				}).element,
-				new(await import("../../scripts/ui/components/button.js")).ComfyButton({
+				...(share_option !== 'none' ? [new(await import("../../scripts/ui/components/button.js")).ComfyButton({
 					icon: "share",
 					action: () => {
 						if (share_option === 'openart') {
@@ -1638,7 +1638,7 @@ app.registerExtension({
 						ShareDialogChooser.instance.show();
 					},
 					tooltip: "Share"
-				}).element
+				}).element] : [])
 			);
 
 			app.menu?.settingsGroup.element.before(cmGroup.element);


### PR DESCRIPTION
## Summary

- Hide the Share button in the new-style `ComfyButtonGroup` menu when `share_option` is `none`
- Use conditional array spread so the button is omitted instead of rendered and left non-functional

## Motivation

The share settings combo documents that `none` should hide the Share button in the main menu. The legacy menu already implements this (`shareButton.style.display = "none"`), but the new-style menu always included the Share `ComfyButton`.

This change makes both UI paths respect the same setting.

## Test plan

- [x] Set share option to `none` in Manager settings: Share button hidden in new-style menu
- [x] Set share option to `openart` / `all` / etc.: Share button visible and works as before
- [x] Legacy menu Share button behavior unchanged