### PR TITLE
Add MiniMax H3 Latent

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61018,6 +61018,17 @@
             ],
             "install_type": "git-clone",
             "description": "A ComfyUI node for image layering, blending, compositing, and batch processing."
+        },
+        {
+            "author": "JerryZRic",
+            "title": "ComfyUI MiniMax H3 Latent",
+            "id": "minimax-h3-latent",
+            "reference": "https://github.com/JerryZRic/comfyui-minimax-h3-latent",
+            "files": [
+                "https://github.com/JerryZRic/comfyui-minimax-h3-latent"
+            ],
+            "install_type": "git-clone",
+            "description": "Save and load MiniMax H3 AV NestedTensor latents, avoiding the built-in Save Latent limitation for H3 video/audio latent pairs."
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyUI MiniMax H3 Latent to custom-node-list.json.\n\nRepository: https://github.com/JerryZRic/comfyui-minimax-h3-latent\n\nThis extension provides Save/Load nodes for MiniMax H3 AV NestedTensor latents, avoiding the built-in Save Latent limitation for H3 video/audio latent pairs.