### PR TITLE
Add ComfyUI MiniMax H3 Hybrid

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -1,6 +1,17 @@
 {
     "custom_nodes": [
         {
+            "author": "ANe5s",
+            "title": "ComfyUI MiniMax H3 Hybrid",
+            "id": "comfyui-minimax-h3-hybrid",
+            "reference": "https://github.com/ANe5s/ComfyUI-MiniMax-H3-Hybrid",
+            "files": [
+                "https://github.com/ANe5s/ComfyUI-MiniMax-H3-Hybrid"
+            ],
+            "install_type": "git-clone",
+            "description": "ComfyUI node for loading a MiniMax H3 FL2VA/Ref2VA hybrid model with ComfyUI DynamicVRAM/AIMDO-aware loading and matched checkpoint memory behavior."
+        },
+        {
             "author": "Carasibana",
             "title": "ComfyUI-SimpleFloatSlider",
             "reference": "https://github.com/Carasibana/ComfyUI-SimplayboyleFloatSlider",


### PR DESCRIPTION
## Summary
- Add ComfyUI MiniMax H3 Hybrid to the custom node list.
- Provide the GitHub repository and git-clone installation metadata.

Repository: https://github.com/ANe5s/ComfyUI-MiniMax-H3-Hybrid

The node loads a MiniMax H3 FL2VA/Ref2VA hybrid model and uses ComfyUI DynamicVRAM/AIMDO-aware loading.