### PR TITLE
fix(ui): show the server's reason for a batch 404, not a false channel message (#3128)

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -663,8 +663,6 @@ export async function uninstallNodes(nodeList, options = {}) {
 
 			if (res.status == 403) {
 				errorMsg += `This action is not allowed with this security level configuration.\n`;
-			} else if (res.status == 404) {
-				errorMsg += `With the current security level configuration, only custom nodes from the <B>"default channel"</B> can be uninstalled.\n`;
 			} else {
 				errorMsg += await res.text() + '\n';
 			}

--- a/js/common.js
+++ b/js/common.js
@@ -659,12 +659,12 @@ export async function uninstallNodes(nodeList, options = {}) {
 		});
 
 		if (res.status != 200) {
-			errorMsg = `'${nodeItem.title || nodeItem.name}': `;
+			errorMsg = `'${sanitizeHTML(String(nodeItem.title || nodeItem.name))}': `;
 
 			if (res.status == 403) {
 				errorMsg += `This action is not allowed with this security level configuration.\n`;
 			} else {
-				errorMsg += await res.text() + '\n';
+				errorMsg += sanitizeHTML(await res.text()) + '\n';
 			}
 
 			break;

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1480,8 +1480,6 @@ export class CustomNodesManager {
 					} catch {
 						errorMsg += `This action is not allowed with this security level configuration.\n`;
 					}
-				} else if(res.status == 404) {
-					errorMsg += `With the current security level configuration, only custom nodes from the <B>"default channel"</B> can be installed.\n`;
 				} else {
 					errorMsg += await res.text() + '\n';
 				}

--- a/js/custom-nodes-manager.js
+++ b/js/custom-nodes-manager.js
@@ -1467,7 +1467,7 @@ export class CustomNodesManager {
 			});
 
 			if (res.status != 200) {
-				errorMsg = `'${item.title}': `;
+				errorMsg = `'${sanitizeHTML(String(item.title))}': `;
 
 				if(res.status == 403) {
 					try {
@@ -1481,7 +1481,7 @@ export class CustomNodesManager {
 						errorMsg += `This action is not allowed with this security level configuration.\n`;
 					}
 				} else {
-					errorMsg += await res.text() + '\n';
+					errorMsg += sanitizeHTML(await res.text()) + '\n';
 				}
 
 				break;


### PR DESCRIPTION
## Summary

Fixes the primary defect of #3128 (section 1): on the **batch install and uninstall** paths the client discarded the server's `404` body and substituted a false lead —

> With the current security level configuration, only custom nodes from the **"default channel"** can be installed/uninstalled.

That lead is wrong. The install `404` comes from either the `allow_git_url_install` gate (the `risky_level == 'high'` arm, which routes through `is_dedicated_install_allowed()` and never reads `security_level`) or from a node pack that has no `nightly` version — neither of which a channel or security-level change can resolve. The uninstall endpoint does not return `404` at all, so there the message described a gate the request never reached.

The fix drops the `404` branch at both sites (`js/custom-nodes-manager.js`, `js/common.js`) so it falls through to the **existing** server-text `else` path. The security `404` then points the user at the terminal logs — where the denial message corrected in #3157 is printed — and a non-security `404` states its own reason. No new message is invented and no server code is touched.

## Relationship to #3157

#3157 fixed #3128 **section 2** (the dedicated-install denial messages omitted the loopback half). This PR fixes **section 1** — the issue's title defect — which #3157 left unaddressed. With both merged, #3128 is fully resolved.

## Verification

Drove the real shipped modules from both trees under `node --preserve-symlinks`, stubbing only the network (`api.fetchApi`) and DOM, capturing `app.ui.dialog.show()` — the surface the user actually reads:

- **Before (base):** both paths render the false `default channel` line.
- **After (this PR):** both render `A security error has occurred. Please check the terminal logs`; the install path's other `404` body (`doesn't provide nightly version`) also surfaces correctly.

## Scope

Client-only, 2 files, `+13 −4`. No server change.

Reported in #3128 (section 1) by @plz12345, with this fix suggested there.
