### PR TITLE
Update Universal Model Loader listing for MiniMax Music3

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -60871,7 +60871,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "StyleRef",

--- a/node_db/new/custom-node-list.json
+++ b/node_db/new/custom-node-list.json
@@ -176,7 +176,7 @@
                 "https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader"
             ],
             "install_type": "git-clone",
-            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families."
+            "description": "Universal ComfyUI model loader for checkpoints, diffusers, diffusion models, UNet, GGUF, dual CLIP outputs and dual VAE outputs with dynamic UI, Registry Node Pack Info previews, and auto CLIP type detection for latest model families including MiniMax Music3/MM3."
         },
         {
             "author": "kkukshtel",


### PR DESCRIPTION
## Summary

- Update ComfyUI Universal Model Loader listing for the v1.0.6 MiniMax Music3 compatibility release
- Mention MiniMax Music3/MM3 support alongside dual CLIP/VAE outputs and Registry Node Pack Info metadata

## Context

GitHub release: https://github.com/Zoltar358-ComfyUI/ComfyUI-Universal-Model-Loader/releases/tag/v1.0.6

Registry package/API: https://api.comfy.org/nodes/universal-model-loader

Changes in v1.0.6:
- Auto-selects ComfyUI CLIP type `minimax` for `MM3`, `Music3`, `RVQ`, `qwen-rvq`, and `qwen_rvq` file/folder hints.
- Documents pairing the loader outputs with ComfyUI's built-in MiniMax Music3 Text Encode and Empty MiniMax Music3 Latent Audio nodes.
- Registry v1.0.6 is uploaded through GitHub Actions and pending Registry activation.

## Validation

- JSON syntax validated for `custom-node-list.json`
- JSON syntax validated for `node_db/new/custom-node-list.json`
- Nodepack validation passed: JS syntax, Python compile, `comfy node validate`, MiniMax Music3/MM3/RVQ detection tests, and local `/object_info/UniversalModelLoader`
