### PR TITLE
Fix legacy ComfyUI batch update

### DIFF
--- a/comfyui_manager/legacy/manager_server.py
+++ b/comfyui_manager/legacy/manager_server.py
@@ -798,7 +798,7 @@ async def queue_batch(request):
                     failed.add(x['id'])
 
         elif k == 'update_comfyui':
-            await update_comfyui(None)
+            await _queue_comfyui_update()
 
         elif k == 'disable':
             for x in v:
@@ -1624,6 +1624,10 @@ async def update_comfyui(request):
     rejection = manager_security.reject_simple_form_post(request)
     if rejection is not None:
         return rejection
+    return await _queue_comfyui_update()
+
+
+async def _queue_comfyui_update():
     is_stable = core.get_config()['update_policy'] != 'nightly-comfyui'
     temp_queue_batch.append(("update-comfyui", ('comfyui', is_stable)))
     return web.Response(status=200)

--- a/tests/test_legacy_secgate_other_paths.py
+++ b/tests/test_legacy_secgate_other_paths.py
@@ -145,12 +145,17 @@ def _run(coro):
 
 
 class FakeRequest:
-    """Minimal stand-in for an aiohttp request. ``content_type`` satisfies
-    ``reject_simple_form_post``; nothing else is read on the deny path (the
-    gate returns before any body access)."""
+    """Minimal request exposing ``content_type`` and an optional JSON body.
 
-    def __init__(self, content_type="application/json"):
+    The security gate reads only ``content_type``; batch-handler tests also read
+    the JSON body through ``json``."""
+
+    def __init__(self, content_type="application/json", json_data=None):
         self.content_type = content_type
+        self.json_data = json_data
+
+    async def json(self):
+        return self.json_data
 
 
 # ===========================================================================
@@ -338,3 +343,30 @@ def test_p4_install_model_safetensors_skips_high_plus_gate_200(ms, gate, monkeyp
     json_data = {"filename": "model.safetensors", "url": "http://example/m.safetensors", "ui_id": "u"}
     resp = _run(ms._install_model(dict(json_data)))
     assert resp.status == 200
+
+
+def test_queue_batch_update_comfyui_skips_no_body_content_type_gate(ms, monkeypatch):
+    """Regression for #2843: the body-reading batch handler must queue the
+    update without invoking the Content-Type gate for no-body handlers."""
+    request = FakeRequest(content_type="text/plain", json_data={"update_comfyui": True})
+    config = dict(ms.core.read_config())
+    config["update_policy"] = "stable-comfyui"
+    monkeypatch.setattr(ms.core, "get_config", lambda: dict(config))
+    monkeypatch.setattr(ms, "temp_queue_batch", [])
+    monkeypatch.setattr(ms, "finalize_temp_queue_batch", lambda *a, **k: None)
+    monkeypatch.setattr(ms, "_queue_start", lambda: None)
+
+    resp = _run(ms.queue_batch(request))
+
+    assert resp.status == 200
+    assert ms.temp_queue_batch == [("update-comfyui", ("comfyui", True))]
+
+
+def test_direct_update_comfyui_keeps_simple_form_content_type_gate(ms, monkeypatch):
+    """The direct no-body endpoint must continue rejecting simple-form POSTs."""
+    monkeypatch.setattr(ms, "temp_queue_batch", [])
+
+    resp = _run(ms.update_comfyui(FakeRequest(content_type="text/plain")))
+
+    assert resp.status == 400
+    assert ms.temp_queue_batch == []


### PR DESCRIPTION
## Summary

- Move legacy ComfyUI update queueing into a private helper.
- Call that helper from `/queue/batch` instead of invoking an HTTP handler with `None`.
- Keep the simple-form Content-Type gate on the direct update endpoint.
- Add regression coverage for both the legacy batch request and the direct endpoint.

Fixes #2843.

## Root cause

The legacy batch handler called `update_comfyui(None)`. After the simple-form POST guard was added, that route handler passed `None` to `reject_simple_form_post`, which then tried to read `request.content_type` and raised `AttributeError`.

Passing the outer batch request to the direct endpoint is not safe either: the current legacy frontend sends `JSON.stringify(batch)` without an explicit Content-Type, so browsers use `text/plain;charset=UTF-8`. The direct endpoint's guard would reject it, while the outer batch handler would still return 200 without queueing the update.

This change avoids handler-to-handler calls and keeps the direct route's existing security behavior unchanged.

## Validation

- `venv/bin/python -m pytest -q tests/test_legacy_secgate_other_paths.py` — 46 passed
- `venv/bin/ruff check comfyui_manager/legacy/manager_server.py tests/test_legacy_secgate_other_paths.py` — passed
- `venv/bin/python -m py_compile comfyui_manager/legacy/manager_server.py tests/test_legacy_secgate_other_paths.py` — passed
- `git diff --check` — passed
- `uv build` — sdist and wheel built successfully
- Non-E2E unit suite — 348 passed, 12 skipped, with 3 branch-base failures in `tests/common/test_git_helper.py` where the fake repo exposes `.heads` while the implementation calls `.list_heads()`

## Security scope

This fixes the `None` request crash without weakening `reject_simple_form_post`. It does not claim to change the broader existing Content-Type policy of the body-reading batch endpoint.
