### PR TITLE
Add ComfyGotchi to custom-node-list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61029,6 +61029,16 @@
             ],
             "install_type": "git-clone",
             "description": "OpenAI API based prompt rewriting agents for MiniMax H3 T2VA/I2VA/L2VA/FL2VA and Ref2VA workflows, using the official H3 skill files."
+        },
+        {
+            "author": "DenRakEiw",
+            "title": "ComfyGotchi",
+            "reference": "https://github.com/DenRakEiw/ComfyGotchi",
+            "files": [
+                "https://github.com/DenRakEiw/ComfyGotchi"
+            ],
+            "install_type": "git-clone",
+            "description": "A Tamagotchi that lives inside ComfyUI — feeds on your AI slop, evolves, feels love from API nodes."
         }
     ]
 }


### PR DESCRIPTION
Adds ComfyGotchi (https://github.com/DenRakEiw/ComfyGotchi) to the custom-node-list.

**ComfyGotchi** is a Tamagotchi that lives inside ComfyUI and feeds on your AI slop. It eats generated images, evolves, feels love from API nodes, and has personality-driven commentary.

- **Author:** DenRakEiw
- **Repository:** https://github.com/DenRakEiw/ComfyGotchi
- **Install type:** git-clone
- **Category:** Utility