### PR TITLE
Remove ComfyUI-SuperNodes from custom-node-list.json

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -37930,17 +37930,6 @@
             "description": "Frequency-Decoupled Guidance (FDG) for ComfyUI and ComfyUI-LTXVideo that improves upon standard Classifier-Free Guidance by applying separate guidance scales to different frequency components."
         },
         {
-            "author": "sonnybox",
-            "title": "ComfyUI-SuperNodes",
-            "id": "supernodes",
-            "reference": "https://github.com/sonnybox/ComfyUI-SuperNodes",
-            "files": [
-                "https://github.com/sonnybox/ComfyUI-SuperNodes"
-            ],
-            "install_type": "git-clone",
-            "description": "A miscellaneous node pack of custom implementations needed for workflows released by my SuperComfy YouTube channel."
-        },
-        {
             "author": "heyburns",
             "title": "PortraitUtils",
             "id": "portraitutils",


### PR DESCRIPTION
ComfyUI-SuperNodes is also published on the Comfy Registry as `comfyui-supernodes` (publisher: sonnybox). The manual entry here uses the id `supernodes`, so Manager sees two distinct packs that both target the `ComfyUI-SuperNodes` directory. I am having trouble with version management / registry issues so I am hoping removing it here would fix it.