### PR TITLE
Fix workflow dependency detection

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -2791,11 +2791,31 @@ def lookup_installed_custom_nodes_legacy(repo_name):
 
 def simple_check_custom_node(url):
     dir_name = os.path.splitext(os.path.basename(url))[0].replace(".git", "")
-    dir_path = os.path.join(get_default_custom_nodes_path(), dir_name)
-    if os.path.exists(dir_path):
-        return 'installed'
-    elif os.path.exists(dir_path+'.disabled'):
-        return 'disabled'
+    custom_nodes_path = get_default_custom_nodes_path()
+    normalized_name = dir_name.casefold()
+
+    try:
+        entries = os.listdir(custom_nodes_path)
+    except OSError:
+        return 'not-installed'
+
+    for entry in entries:
+        if entry.casefold() == normalized_name and os.path.isdir(os.path.join(custom_nodes_path, entry)):
+            return 'installed'
+
+    for entry in entries:
+        if entry.casefold() == f'{normalized_name}.disabled' and os.path.isdir(os.path.join(custom_nodes_path, entry)):
+            return 'disabled'
+
+    disabled_path = os.path.join(custom_nodes_path, '.disabled')
+    try:
+        disabled_entries = os.listdir(disabled_path)
+    except OSError:
+        return 'not-installed'
+
+    for entry in disabled_entries:
+        if entry.casefold() == normalized_name and os.path.isdir(os.path.join(disabled_path, entry)):
+            return 'disabled'
 
     return 'not-installed'
 
@@ -2973,27 +2993,7 @@ async def extract_nodes_from_workflow(filepath, mode='local', channel_url='defau
         print(f"Invalid workflow file: {filepath}")
         exit(-1)
 
-    # extract nodes
-    used_nodes = set()
-
-    def extract_nodes(sub_workflow):
-        for x in sub_workflow['nodes']:
-            node_name = x.get('type')
-
-            # skip virtual nodes
-            if node_name in ['Reroute', 'Note']:
-                continue
-
-            if node_name is not None and not (node_name.startswith('workflow/') or node_name.startswith('workflow>')):
-                used_nodes.add(node_name)
-
-    if 'nodes' in workflow:
-        extract_nodes(workflow)
-
-        if 'extra' in workflow:
-            if 'groupNodes' in workflow['extra']:
-                for x in workflow['extra']['groupNodes'].values():
-                    extract_nodes(x)
+    used_nodes = collect_nodes_from_workflow(workflow)
 
     # lookup dependent custom nodes
     ext_map = await get_data_by_mode(mode, 'extension-node-map.json', channel_url)
@@ -3052,6 +3052,52 @@ async def extract_nodes_from_workflow(filepath, mode='local', channel_url='defau
             unknown_nodes.add(node_name)
 
     return used_exts, unknown_nodes
+
+
+def collect_nodes_from_workflow(workflow):
+    used_nodes = set()
+    definitions = workflow.get('definitions', {})
+    subgraphs = definitions.get('subgraphs', []) if isinstance(definitions, dict) else []
+    if isinstance(subgraphs, dict):
+        subgraphs = [dict(subgraph, id=subgraph.get('id', subgraph_id))
+                     for subgraph_id, subgraph in subgraphs.items() if isinstance(subgraph, dict)]
+    elif not isinstance(subgraphs, list):
+        subgraphs = []
+
+    subgraph_ids = {subgraph.get('id') for subgraph in subgraphs if subgraph.get('id') is not None}
+
+    def extract_nodes(sub_workflow):
+        if not isinstance(sub_workflow, dict):
+            return
+
+        for node in sub_workflow.get('nodes', []):
+            add_node(node)
+
+    def add_node(node):
+        if not isinstance(node, dict):
+            return
+
+        node_name = node.get('class_type') or node.get('type')
+        if not isinstance(node_name, str) or node_name in subgraph_ids:
+            return
+
+        if node_name not in ['Reroute', 'Note'] and not (node_name.startswith('workflow/') or node_name.startswith('workflow>')):
+            used_nodes.add(node_name)
+
+    extract_nodes(workflow)
+
+    group_nodes = workflow.get('extra', {}).get('groupNodes', {})
+    if isinstance(group_nodes, dict):
+        for group_node in group_nodes.values():
+            extract_nodes(group_node)
+
+    for subgraph in subgraphs:
+        extract_nodes(subgraph)
+
+    for node in workflow.values():
+        add_node(node)
+
+    return used_nodes
 
 
 def unzip(model_path):

--- a/tests/test_workflow_deps.py
+++ b/tests/test_workflow_deps.py
@@ -1,0 +1,133 @@
+"""Regression tests for workflow dependency discovery."""
+import ast
+import asyncio
+import json
+import os
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANAGER_CORE_PATH = REPO_ROOT / "glob" / "manager_core.py"
+
+
+def load_functions():
+    tree = ast.parse(MANAGER_CORE_PATH.read_text())
+    functions = [
+        node for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in {
+            "collect_nodes_from_workflow",
+            "extract_nodes_from_workflow",
+            "simple_check_custom_node",
+        }
+    ]
+    namespace = {"json": json, "os": os, "re": re}
+    exec(compile(ast.Module(body=functions, type_ignores=[]), str(MANAGER_CORE_PATH), "exec"), namespace)
+    return namespace
+
+
+FUNCTIONS = load_functions()
+COLLECT_NODES = FUNCTIONS["collect_nodes_from_workflow"]
+EXTRACT_NODES = FUNCTIONS["extract_nodes_from_workflow"]
+SIMPLE_CHECK = FUNCTIONS["simple_check_custom_node"]
+
+
+class WorkflowNodeCollectionTest(unittest.TestCase):
+    def test_collects_ui_api_group_and_subgraph_nodes(self):
+        workflow = {
+            "nodes": [
+                {"type": "TopLevelNode"},
+                {"type": "subgraph-uuid"},
+                {"type": "Reroute"},
+                {"type": "workflow/VirtualNode"},
+            ],
+            "extra": {"groupNodes": {"group": {"nodes": [{"type": "GroupNode"}]}}},
+            "definitions": {"subgraphs": [{
+                "id": "subgraph-uuid",
+                "nodes": [{"type": "SubgraphNode"}, {"type": "Note"}],
+            }]},
+            "1": {"class_type": "ApiNode", "inputs": {}},
+            "2": {"class_type": "workflow>VirtualApiNode", "inputs": {}},
+        }
+
+        self.assertEqual(
+            COLLECT_NODES(workflow),
+            {"TopLevelNode", "GroupNode", "SubgraphNode", "ApiNode"},
+        )
+
+    def test_collects_mapping_subgraphs(self):
+        workflow = {
+            "definitions": {"subgraphs": {
+                "subgraph-uuid": {"nodes": [{"type": "SubgraphNode"}]},
+            }},
+            "nodes": [{"type": "subgraph-uuid"}],
+        }
+
+        self.assertEqual(COLLECT_NODES(workflow), {"SubgraphNode"})
+
+    def test_extracts_dependencies_from_all_workflow_formats(self):
+        async def get_data_by_mode(*_args):
+            return {
+                "https://github.com/comfyanonymous/ComfyUI": [["TopLevelNode"], {}],
+                "https://github.com/example/custom-pack": [
+                    ["GroupNode", "SubgraphNode", "ApiNode"],
+                    {},
+                ],
+            }
+
+        EXTRACT_NODES.__globals__["get_data_by_mode"] = get_data_by_mode
+        workflow = {
+            "nodes": [{"type": "TopLevelNode"}, {"type": "subgraph-uuid"}],
+            "extra": {"groupNodes": {"group": {"nodes": [{"type": "GroupNode"}]}}},
+            "definitions": {"subgraphs": [{
+                "id": "subgraph-uuid",
+                "nodes": [{"type": "SubgraphNode"}],
+            }]},
+            "1": {"class_type": "ApiNode", "inputs": {}},
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as workflow_file:
+            json.dump(workflow, workflow_file)
+            workflow_file.flush()
+            used_extensions, unknown_nodes = asyncio.run(EXTRACT_NODES(workflow_file.name))
+
+        self.assertEqual(used_extensions, {"https://github.com/example/custom-pack"})
+        self.assertEqual(unknown_nodes, set())
+
+
+class CustomNodeStateTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.custom_nodes = Path(self.temp_dir.name)
+        SIMPLE_CHECK.__globals__["get_default_custom_nodes_path"] = lambda: str(self.custom_nodes)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_matches_installed_directory_case_insensitively(self):
+        (self.custom_nodes / "FooPack").mkdir()
+
+        self.assertEqual(
+            SIMPLE_CHECK("https://github.com/example/foopack"),
+            "installed",
+        )
+
+    def test_detects_disabled_directory_layouts(self):
+        (self.custom_nodes / ".disabled").mkdir()
+        (self.custom_nodes / ".disabled" / "FooPack").mkdir()
+
+        self.assertEqual(
+            SIMPLE_CHECK("https://github.com/example/foopack"),
+            "disabled",
+        )
+
+        (self.custom_nodes / ".disabled" / "FooPack").rmdir()
+        (self.custom_nodes / "FooPack.disabled").mkdir()
+
+        self.assertEqual(
+            SIMPLE_CHECK("https://github.com/example/foopack"),
+            "disabled",
+        )


### PR DESCRIPTION
## Summary
- collect node classes from API prompts and UI workflows, including group nodes and `definitions.subgraphs`
- exclude subgraph UUID placeholders from dependency resolution
- match installed and disabled custom-node directories case-insensitively

## Tests
- `python -m unittest tests/test_workflow_deps.py`
- `/home/hosono/repos/localgaki/comfyui-venv/bin/python -m unittest discover -s tests`