### PR TITLE
Update comfyui-manager.js Buttons Style

### DIFF
--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -32,11 +32,11 @@ const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
     /* 1. Setup the main close button container cleanly across all windows */
     #cm-manager-dialog .p-dialog-header-close,
-    #cm-manager-dialog .p-dialog-close-button,
+    #cm-manager-dialog .p-dialog-close,
     #cm-manager-dialog button[class*="-close"],
     #cm-manager-dialog button[onclick*="close"],
     .comfy-modal .p-dialog-header-close,
-    .comfy-modal .p-dialog-close-button,
+    .comfy-modal .p-dialog-close,
     .comfy-modal button[class*="-close"],
     .comfy-modal button[onclick*="close"],
     .comfy-dialog .comfy-menu-close,
@@ -73,10 +73,10 @@ customHoverStyle.innerHTML = `
 
     /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
     #cm-manager-dialog .p-dialog-header-close *,
-    #cm-manager-dialog .p-dialog-close-button *,
+    #cm-manager-dialog .p-dialog-close *,
     #cm-manager-dialog button[class*="-close"] *,
     .comfy-modal .p-dialog-header-close *,
-    .comfy-modal .p-dialog-close-button *,
+    .comfy-modal .p-dialog-close *,
     .comfy-modal button[class*="-close"] *,
     .comfy-dialog .comfy-menu-close *,
     .comfy-dialog button[class*="close"] *,
@@ -102,11 +102,11 @@ customHoverStyle.innerHTML = `
 
     /* 3. Create a clean hidden circular layer right behind the icon character */
     #cm-manager-dialog .p-dialog-header-close::before,
-    #cm-manager-dialog .p-dialog-close-button::before,
+    #cm-manager-dialog .p-dialog-close::before,
     #cm-manager-dialog button[class*="-close"]::before,
     #cm-manager-dialog button[onclick*="close"]::before,
     .comfy-modal .p-dialog-header-close::before,
-    .comfy-modal .p-dialog-close-button::before,
+    .comfy-modal .p-dialog-close::before,
     .comfy-modal button[class*="-close"]::before,
     .comfy-modal button[onclick*="close"]::before,
     .comfy-dialog .comfy-menu-close::before,
@@ -136,11 +136,11 @@ customHoverStyle.innerHTML = `
 
     /* 4. Trigger the grey circular fill on cursor hover OR keyboard focus */
     #cm-manager-dialog .p-dialog-header-close:hover::before,
-    #cm-manager-dialog .p-dialog-close-button:hover::before,
+    #cm-manager-dialog .p-dialog-close:hover::before,
     #cm-manager-dialog button[class*="-close"]:hover::before,
     #cm-manager-dialog button[onclick*="close"]:hover::before,
     .comfy-modal .p-dialog-header-close:hover::before,
-    .comfy-modal .p-dialog-close-button:hover::before,
+    .comfy-modal .p-dialog-close:hover::before,
     .comfy-modal button[class*="-close"]:hover::before,
     .comfy-modal button[onclick*="close"]:hover::before,
     .comfy-dialog .comfy-menu-close:hover::before,
@@ -156,10 +156,10 @@ customHoverStyle.innerHTML = `
     .comfy-modal button[style*="float: right"]:hover::before,
     
     #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
-    #cm-manager-dialog .p-dialog-close-button:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close:focus-visible::before,
     #cm-manager-dialog button[class*="-close"]:focus-visible::before,
     .comfy-modal .p-dialog-header-close:focus-visible::before,
-    .comfy-modal .p-dialog-close-button:focus-visible::before,
+    .comfy-modal .p-dialog-close:focus-visible::before,
     .comfy-modal button[class*="-close"]:focus-visible::before,
     .comfy-dialog .comfy-menu-close:focus-visible::before,
     .comfy-dialog button[class*="close"]:focus-visible::before,
@@ -171,10 +171,10 @@ customHoverStyle.innerHTML = `
 
     /* 5. Add an accessibility glow ring ONLY during keyboard navigation focus */
     #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
-    #cm-manager-dialog .p-dialog-close-button:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close:focus-visible::before,
     #cm-manager-dialog button[class*="-close"]:focus-visible::before,
     .comfy-modal .p-dialog-header-close:focus-visible::before,
-    .comfy-modal .p-dialog-close-button:focus-visible::before,
+    .comfy-modal .p-dialog-close:focus-visible::before,
     .comfy-modal button[class*="-close"]:focus-visible::before,
     .comfy-dialog .comfy-menu-close:focus-visible::before,
     .comfy-dialog button[class*="close"]:focus-visible::before,

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -26,11 +26,11 @@ import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
 let manager_version = await getVersion();
 
 // =========================================================================
-// HOVER GREY CIRCLE HOOK (GLOBAL - WITH FIXED KEYBOARD FOCUS SUPPORT)
+// HOVER & KEYBOARD ACCESSIBILITY GLOW RING HOOK (GLOBAL CORE SHIELD)
 // =========================================================================
 const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
-    /* 1. Setup the main close button container cleanly across all modules */
+    /* 1. Setup the main close button container cleanly across all windows */
     #cm-manager-dialog .p-dialog-header-close,
     #cm-manager-dialog .p-dialog-close,
     #cm-manager-dialog button[class*="-close"],
@@ -43,18 +43,17 @@ customHoverStyle.innerHTML = `
     .comfy-dialog button[class*="close"],
     .comfy-panel .comfy-menu-close,
     .comfy-panel button[class*="close"],
-    
-    /* CUSTOM-NODES-MANAGER SELECTORS */
     div[class*="cn-manager"] button[class*="close"],
     div[class*="cn-manager"] .comfy-menu-close,
     .cn-manager-dialog button[class*="close"],
     .cn-manager-dialog .comfy-menu-close,
-    
-    /* MODEL-MANAGER SELECTORS */
     div[class*="mm-manager"] button[class*="close"],
     div[class*="mm-manager"] .comfy-menu-close,
     .mm-manager-dialog button[class*="close"],
-    .mm-manager-dialog .comfy-menu-close {
+    .mm-manager-dialog .comfy-menu-close,
+    .comfy-modal div[style*="position: fixed"] button,
+    .comfy-modal div button[style*="float: right"],
+    .comfy-modal button[style*="float: right"] {
         border: none !important;
         outline: none !important;
         box-shadow: none !important;
@@ -86,7 +85,10 @@ customHoverStyle.innerHTML = `
     div[class*="cn-manager"] button[class*="close"] *,
     div[class*="cn-manager"] .comfy-menu-close *,
     div[class*="mm-manager"] button[class*="close"] *,
-    div[class*="mm-manager"] .comfy-menu-close * {
+    div[class*="mm-manager"] .comfy-menu-close *,
+    .comfy-modal div[style*="position: fixed"] button *,
+    .comfy-modal div button[style*="float: right"] *,
+    .comfy-modal button[style*="float: right"] * {
         position: relative !important;
         z-index: 2 !important;
         display: inline-block !important;
@@ -114,7 +116,10 @@ customHoverStyle.innerHTML = `
     div[class*="cn-manager"] button[class*="close"]::before,
     div[class*="cn-manager"] .comfy-menu-close::before,
     div[class*="mm-manager"] button[class*="close"]::before,
-    div[class*="mm-manager"] .comfy-menu-close::before {
+    div[class*="mm-manager"] .comfy-menu-close::before,
+    .comfy-modal div[style*="position: fixed"] button::before,
+    .comfy-modal div button[style*="float: right"]::before,
+    .comfy-modal button[style*="float: right"]::before {
         content: "" !important;
         position: absolute !important;
         z-index: 1 !important;
@@ -125,11 +130,11 @@ customHoverStyle.innerHTML = `
         border-radius: 50% !important;
         background-color: transparent !important;
         box-sizing: border-box !important;
-        transition: background-color 0.2s ease-in-out !important;
+        transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out !important;
         transform: translate(-74.5%, -50%) !important; 
     }
 
-    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
+    /* 4. Trigger the grey circular fill on cursor hover OR keyboard focus */
     #cm-manager-dialog .p-dialog-header-close:hover::before,
     #cm-manager-dialog .p-dialog-close:hover::before,
     #cm-manager-dialog button[class*="-close"]:hover::before,
@@ -145,28 +150,37 @@ customHoverStyle.innerHTML = `
     div[class*="cn-manager"] button[class*="close"]:hover::before,
     div[class*="cn-manager"] .comfy-menu-close:hover::before,
     div[class*="mm-manager"] button[class*="close"]:hover::before,
-    div[class*="mm-manager"] .comfy-menu-close:hover::before {
-        background-color: rgba(255, 255, 255, 0.15) !important;
-    }
-
-    /* 5. Show the same close-button layer during keyboard focus (FIXED WITHOUT BROKEN BACKTICKS) */
+    div[class*="mm-manager"] .comfy-menu-close:hover::before,
+    .comfy-modal div[style*="position: fixed"] button:hover::before,
+    .comfy-modal div button[style*="float: right"]:hover::before,
+    .comfy-modal button[style*="float: right"]:hover::before,
+    
     #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
     #cm-manager-dialog .p-dialog-close:focus-visible::before,
     #cm-manager-dialog button[class*="-close"]:focus-visible::before,
-    #cm-manager-dialog button[onclick*="close"]:focus-visible::before,
     .comfy-modal .p-dialog-header-close:focus-visible::before,
     .comfy-modal .p-dialog-close:focus-visible::before,
     .comfy-modal button[class*="-close"]:focus-visible::before,
-    .comfy-modal button[onclick*="close"]:focus-visible::before,
     .comfy-dialog .comfy-menu-close:focus-visible::before,
     .comfy-dialog button[class*="close"]:focus-visible::before,
-    .comfy-panel .comfy-menu-close:focus-visible::before,
-    .comfy-panel button[class*="close"]:focus-visible::before,
-    div[class*="cn-manager"] button[class*="close"]:focus-visible::before,
-    div[class*="cn-manager"] .comfy-menu-close:focus-visible::before,
-    div[class*="mm-manager"] button[class*="close"]:focus-visible::before,
-    div[class*="mm-manager"] .comfy-menu-close:focus-visible::before {
+    div[class*="cn-manager"] button:focus-visible::before,
+    div[class*="mm-manager"] button:focus-visible::before,
+    .comfy-modal button[style*="float: right"]:focus-visible::before {
         background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+
+    /* 5. Add an accessibility glow ring ONLY during keyboard navigation focus */
+    #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close:focus-visible::before,
+    #cm-manager-dialog button[class*="-close"]:focus-visible::before,
+    .comfy-modal .p-dialog-header-close:focus-visible::before,
+    .comfy-modal .p-dialog-close:focus-visible::before,
+    .comfy-modal button[class*="-close"]:focus-visible::before,
+    .comfy-dialog .comfy-menu-close:focus-visible::before,
+    .comfy-dialog button[class*="close"]:focus-visible::before,
+    div[class*="cn-manager"] button:focus-visible::before,
+    div[class*="mm-manager"] button:focus-visible::before,
+    .comfy-modal button[style*="float: right"]:focus-visible::before {
         box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75) !important;
     }
 `;

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -26,15 +26,18 @@ import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
 let manager_version = await getVersion();
 
 // =========================================================================
-// HOVER GREY CIRCLE HOOK (INDEPENDENT SEPARATED FLOATING HOVER LAYER)
+// HOVER GREY CIRCLE HOOK (RESTRICTED TO MAIN DIALOGS ONLY)
 // =========================================================================
 const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
-    /* 1. Setup the main close button container cleanly */
-    .p-dialog-header-close,
-    .p-dialog-close,
-    button[class*="-close"],
+    /* 1. Setup the main close button container cleanly - SCOPED */
+    #cm-manager-dialog .p-dialog-header-close,
+    #cm-manager-dialog .p-dialog-close,
+    #cm-manager-dialog button[class*="-close"],
     #cm-manager-dialog button[onclick*="close"],
+    .comfy-modal .p-dialog-header-close,
+    .comfy-modal .p-dialog-close,
+    .comfy-modal button[class*="-close"],
     .comfy-modal button[onclick*="close"] {
         border: none !important;
         outline: none !important;
@@ -53,12 +56,15 @@ customHoverStyle.innerHTML = `
         overflow: visible !important;
     }
 
-    /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
-    .p-dialog-header-close *,
-    .p-dialog-close *,
-    button[class*="-close"] * {
+    /* 2. Lock the "X" character itself dead-center - SCOPED */
+    #cm-manager-dialog .p-dialog-header-close *,
+    #cm-manager-dialog .p-dialog-close *,
+    #cm-manager-dialog button[class*="-close"] *,
+    .comfy-modal .p-dialog-header-close *,
+    .comfy-modal .p-dialog-close *,
+    .comfy-modal button[class*="-close"] * {
         position: relative !important;
-        z-index: 2 !important; /* Forces the character to always float above the circle background */
+        z-index: 2 !important;
         display: inline-block !important;
         line-height: 32px !important;
         height: 32px !important;
@@ -68,11 +74,14 @@ customHoverStyle.innerHTML = `
         margin: 0 !important;
     }
 
-    /* 3. Create a clean hidden circular layer right behind the icon character */
-    .p-dialog-header-close::before,
-    .p-dialog-close::before,
-    button[class*="-close"]::before,
+    /* 3. Create a clean hidden circular layer right behind the icon character - SCOPED */
+    #cm-manager-dialog .p-dialog-header-close::before,
+    #cm-manager-dialog .p-dialog-close::before,
+    #cm-manager-dialog button[class*="-close"]::before,
     #cm-manager-dialog button[onclick*="close"]::before,
+    .comfy-modal .p-dialog-header-close::before,
+    .comfy-modal .p-dialog-close::before,
+    .comfy-modal button[class*="-close"]::before,
     .comfy-modal button[onclick*="close"]::before {
         content: "" !important;
         position: absolute !important;
@@ -85,19 +94,17 @@ customHoverStyle.innerHTML = `
         background-color: transparent !important;
         box-sizing: border-box !important;
         transition: background-color 0.2s ease-in-out !important;
-        
-        /* -------------------------------------------------------------
-           OPTICAL ADJUSTMENT SHIFT RULES:
-           Changed from -55% to -74.5% to nudge the circle slightly left!
-           ------------------------------------------------------------- */
         transform: translate(-74.5%, -50%) !important; 
     }
 
-    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
-    .p-dialog-header-close:hover::before,
-    .p-dialog-close:hover::before,
-    button[class*="-close"]:hover::before,
+    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover - SCOPED */
+    #cm-manager-dialog .p-dialog-header-close:hover::before,
+    #cm-manager-dialog .p-dialog-close:hover::before,
+    #cm-manager-dialog button[class*="-close"]:hover::before,
     #cm-manager-dialog button[onclick*="close"]:hover::before,
+    .comfy-modal .p-dialog-header-close:hover::before,
+    .comfy-modal .p-dialog-close:hover::before,
+    .comfy-modal button[class*="-close"]:hover::before,
     .comfy-modal button[onclick*="close"]:hover::before {
         background-color: rgba(255, 255, 255, 0.15) !important;
     }

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -32,11 +32,11 @@ const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
     /* 1. Setup the main close button container cleanly across all windows */
     #cm-manager-dialog .p-dialog-header-close,
-    #cm-manager-dialog .p-dialog-close,
+    #cm-manager-dialog .p-dialog-close-button,
     #cm-manager-dialog button[class*="-close"],
     #cm-manager-dialog button[onclick*="close"],
     .comfy-modal .p-dialog-header-close,
-    .comfy-modal .p-dialog-close,
+    .comfy-modal .p-dialog-close-button,
     .comfy-modal button[class*="-close"],
     .comfy-modal button[onclick*="close"],
     .comfy-dialog .comfy-menu-close,
@@ -73,10 +73,10 @@ customHoverStyle.innerHTML = `
 
     /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
     #cm-manager-dialog .p-dialog-header-close *,
-    #cm-manager-dialog .p-dialog-close *,
+    #cm-manager-dialog .p-dialog-close-button *,
     #cm-manager-dialog button[class*="-close"] *,
     .comfy-modal .p-dialog-header-close *,
-    .comfy-modal .p-dialog-close *,
+    .comfy-modal .p-dialog-close-button *,
     .comfy-modal button[class*="-close"] *,
     .comfy-dialog .comfy-menu-close *,
     .comfy-dialog button[class*="close"] *,
@@ -102,11 +102,11 @@ customHoverStyle.innerHTML = `
 
     /* 3. Create a clean hidden circular layer right behind the icon character */
     #cm-manager-dialog .p-dialog-header-close::before,
-    #cm-manager-dialog .p-dialog-close::before,
+    #cm-manager-dialog .p-dialog-close-button::before,
     #cm-manager-dialog button[class*="-close"]::before,
     #cm-manager-dialog button[onclick*="close"]::before,
     .comfy-modal .p-dialog-header-close::before,
-    .comfy-modal .p-dialog-close::before,
+    .comfy-modal .p-dialog-close-button::before,
     .comfy-modal button[class*="-close"]::before,
     .comfy-modal button[onclick*="close"]::before,
     .comfy-dialog .comfy-menu-close::before,
@@ -136,11 +136,11 @@ customHoverStyle.innerHTML = `
 
     /* 4. Trigger the grey circular fill on cursor hover OR keyboard focus */
     #cm-manager-dialog .p-dialog-header-close:hover::before,
-    #cm-manager-dialog .p-dialog-close:hover::before,
+    #cm-manager-dialog .p-dialog-close-button:hover::before,
     #cm-manager-dialog button[class*="-close"]:hover::before,
     #cm-manager-dialog button[onclick*="close"]:hover::before,
     .comfy-modal .p-dialog-header-close:hover::before,
-    .comfy-modal .p-dialog-close:hover::before,
+    .comfy-modal .p-dialog-close-button:hover::before,
     .comfy-modal button[class*="-close"]:hover::before,
     .comfy-modal button[onclick*="close"]:hover::before,
     .comfy-dialog .comfy-menu-close:hover::before,
@@ -156,10 +156,10 @@ customHoverStyle.innerHTML = `
     .comfy-modal button[style*="float: right"]:hover::before,
     
     #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
-    #cm-manager-dialog .p-dialog-close:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close-button:focus-visible::before,
     #cm-manager-dialog button[class*="-close"]:focus-visible::before,
     .comfy-modal .p-dialog-header-close:focus-visible::before,
-    .comfy-modal .p-dialog-close:focus-visible::before,
+    .comfy-modal .p-dialog-close-button:focus-visible::before,
     .comfy-modal button[class*="-close"]:focus-visible::before,
     .comfy-dialog .comfy-menu-close:focus-visible::before,
     .comfy-dialog button[class*="close"]:focus-visible::before,
@@ -171,10 +171,10 @@ customHoverStyle.innerHTML = `
 
     /* 5. Add an accessibility glow ring ONLY during keyboard navigation focus */
     #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
-    #cm-manager-dialog .p-dialog-close:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close-button:focus-visible::before,
     #cm-manager-dialog button[class*="-close"]:focus-visible::before,
     .comfy-modal .p-dialog-header-close:focus-visible::before,
-    .comfy-modal .p-dialog-close:focus-visible::before,
+    .comfy-modal .p-dialog-close-button:focus-visible::before,
     .comfy-modal button[class*="-close"]:focus-visible::before,
     .comfy-dialog .comfy-menu-close:focus-visible::before,
     .comfy-dialog button[class*="close"]:focus-visible::before,

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -26,11 +26,11 @@ import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
 let manager_version = await getVersion();
 
 // =========================================================================
-// HOVER GREY CIRCLE HOOK (RESTRICTED TO MAIN DIALOGS ONLY - RGBA FIX)
+// HOVER GREY CIRCLE HOOK (GLOBAL - WITH FIXED KEYBOARD FOCUS SUPPORT)
 // =========================================================================
 const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
-    /* 1. Setup the main close button container cleanly - SCOPED */
+    /* 1. Setup the main close button container cleanly across all modules */
     #cm-manager-dialog .p-dialog-header-close,
     #cm-manager-dialog .p-dialog-close,
     #cm-manager-dialog button[class*="-close"],
@@ -38,7 +38,23 @@ customHoverStyle.innerHTML = `
     .comfy-modal .p-dialog-header-close,
     .comfy-modal .p-dialog-close,
     .comfy-modal button[class*="-close"],
-    .comfy-modal button[onclick*="close"] {
+    .comfy-modal button[onclick*="close"],
+    .comfy-dialog .comfy-menu-close,
+    .comfy-dialog button[class*="close"],
+    .comfy-panel .comfy-menu-close,
+    .comfy-panel button[class*="close"],
+    
+    /* CUSTOM-NODES-MANAGER SELECTORS */
+    div[class*="cn-manager"] button[class*="close"],
+    div[class*="cn-manager"] .comfy-menu-close,
+    .cn-manager-dialog button[class*="close"],
+    .cn-manager-dialog .comfy-menu-close,
+    
+    /* MODEL-MANAGER SELECTORS */
+    div[class*="mm-manager"] button[class*="close"],
+    div[class*="mm-manager"] .comfy-menu-close,
+    .mm-manager-dialog button[class*="close"],
+    .mm-manager-dialog .comfy-menu-close {
         border: none !important;
         outline: none !important;
         box-shadow: none !important;
@@ -56,13 +72,21 @@ customHoverStyle.innerHTML = `
         overflow: visible !important;
     }
 
-    /* 2. Lock the "X" character itself dead-center - SCOPED */
+    /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
     #cm-manager-dialog .p-dialog-header-close *,
     #cm-manager-dialog .p-dialog-close *,
     #cm-manager-dialog button[class*="-close"] *,
     .comfy-modal .p-dialog-header-close *,
     .comfy-modal .p-dialog-close *,
-    .comfy-modal button[class*="-close"] * {
+    .comfy-modal button[class*="-close"] *,
+    .comfy-dialog .comfy-menu-close *,
+    .comfy-dialog button[class*="close"] *,
+    .comfy-panel .comfy-menu-close *,
+    .comfy-panel button[class*="close"] *,
+    div[class*="cn-manager"] button[class*="close"] *,
+    div[class*="cn-manager"] .comfy-menu-close *,
+    div[class*="mm-manager"] button[class*="close"] *,
+    div[class*="mm-manager"] .comfy-menu-close * {
         position: relative !important;
         z-index: 2 !important;
         display: inline-block !important;
@@ -74,7 +98,7 @@ customHoverStyle.innerHTML = `
         margin: 0 !important;
     }
 
-    /* 3. Create a clean hidden circular layer right behind the icon character - SCOPED */
+    /* 3. Create a clean hidden circular layer right behind the icon character */
     #cm-manager-dialog .p-dialog-header-close::before,
     #cm-manager-dialog .p-dialog-close::before,
     #cm-manager-dialog button[class*="-close"]::before,
@@ -82,7 +106,15 @@ customHoverStyle.innerHTML = `
     .comfy-modal .p-dialog-header-close::before,
     .comfy-modal .p-dialog-close::before,
     .comfy-modal button[class*="-close"]::before,
-    .comfy-modal button[onclick*="close"]::before {
+    .comfy-modal button[onclick*="close"]::before,
+    .comfy-dialog .comfy-menu-close::before,
+    .comfy-dialog button[class*="close"]::before,
+    .comfy-panel .comfy-menu-close::before,
+    .comfy-panel button[class*="close"]::before,
+    div[class*="cn-manager"] button[class*="close"]::before,
+    div[class*="cn-manager"] .comfy-menu-close::before,
+    div[class*="mm-manager"] button[class*="close"]::before,
+    div[class*="mm-manager"] .comfy-menu-close::before {
         content: "" !important;
         position: absolute !important;
         z-index: 1 !important;
@@ -97,7 +129,7 @@ customHoverStyle.innerHTML = `
         transform: translate(-74.5%, -50%) !important; 
     }
 
-    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover - SCOPED */
+    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
     #cm-manager-dialog .p-dialog-header-close:hover::before,
     #cm-manager-dialog .p-dialog-close:hover::before,
     #cm-manager-dialog button[class*="-close"]:hover::before,
@@ -105,9 +137,37 @@ customHoverStyle.innerHTML = `
     .comfy-modal .p-dialog-header-close:hover::before,
     .comfy-modal .p-dialog-close:hover::before,
     .comfy-modal button[class*="-close"]:hover::before,
-    .comfy-modal button[onclick*="close"]:hover::before {
-        /* Fixed the typo here: changed 'rg' to 'rgba' to restore the alpha transparency color */
+    .comfy-modal button[onclick*="close"]:hover::before,
+    .comfy-dialog .comfy-menu-close:hover::before,
+    .comfy-dialog button[class*="close"]:hover::before,
+    .comfy-panel .comfy-menu-close:hover::before,
+    .comfy-panel button[class*="close"]:hover::before,
+    div[class*="cn-manager"] button[class*="close"]:hover::before,
+    div[class*="cn-manager"] .comfy-menu-close:hover::before,
+    div[class*="mm-manager"] button[class*="close"]:hover::before,
+    div[class*="mm-manager"] .comfy-menu-close:hover::before {
         background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+
+    /* 5. Show the same close-button layer during keyboard focus (FIXED WITHOUT BROKEN BACKTICKS) */
+    #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close:focus-visible::before,
+    #cm-manager-dialog button[class*="-close"]:focus-visible::before,
+    #cm-manager-dialog button[onclick*="close"]:focus-visible::before,
+    .comfy-modal .p-dialog-header-close:focus-visible::before,
+    .comfy-modal .p-dialog-close:focus-visible::before,
+    .comfy-modal button[class*="-close"]:focus-visible::before,
+    .comfy-modal button[onclick*="close"]:focus-visible::before,
+    .comfy-dialog .comfy-menu-close:focus-visible::before,
+    .comfy-dialog button[class*="close"]:focus-visible::before,
+    .comfy-panel .comfy-menu-close:focus-visible::before,
+    .comfy-panel button[class*="close"]:focus-visible::before,
+    div[class*="cn-manager"] button[class*="close"]:focus-visible::before,
+    div[class*="cn-manager"] .comfy-menu-close:focus-visible::before,
+    div[class*="mm-manager"] button[class*="close"]:focus-visible::before,
+    div[class*="mm-manager"] .comfy-menu-close:focus-visible::before {
+        background-color: rgba(255, 255, 255, 0.15) !important;
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75) !important;
     }
 `;
 document.head.appendChild(customHoverStyle);

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -26,7 +26,7 @@ import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
 let manager_version = await getVersion();
 
 // =========================================================================
-// HOVER GREY CIRCLE HOOK (RESTRICTED TO MAIN DIALOGS ONLY)
+// HOVER GREY CIRCLE HOOK (RESTRICTED TO MAIN DIALOGS ONLY - RGBA FIX)
 // =========================================================================
 const customHoverStyle = document.createElement('style');
 customHoverStyle.innerHTML = `
@@ -106,6 +106,7 @@ customHoverStyle.innerHTML = `
     .comfy-modal .p-dialog-close:hover::before,
     .comfy-modal button[class*="-close"]:hover::before,
     .comfy-modal button[onclick*="close"]:hover::before {
+        /* Fixed the typo here: changed 'rg' to 'rgba' to restore the alpha transparency color */
         background-color: rgba(255, 255, 255, 0.15) !important;
     }
 `;

--- a/js/comfyui-manager.js
+++ b/js/comfyui-manager.js
@@ -25,6 +25,85 @@ import { buildGuiFrame, createSettingsCombo } from "./comfyui-gui-builder.js";
 
 let manager_version = await getVersion();
 
+// =========================================================================
+// HOVER GREY CIRCLE HOOK (INDEPENDENT SEPARATED FLOATING HOVER LAYER)
+// =========================================================================
+const customHoverStyle = document.createElement('style');
+customHoverStyle.innerHTML = `
+    /* 1. Setup the main close button container cleanly */
+    .p-dialog-header-close,
+    .p-dialog-close,
+    button[class*="-close"],
+    #cm-manager-dialog button[onclick*="close"],
+    .comfy-modal button[onclick*="close"] {
+        border: none !important;
+        outline: none !important;
+        box-shadow: none !important;
+        background: transparent !important;
+        background-color: transparent !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        box-sizing: border-box !important;
+        position: relative !important;
+        width: 32px !important;
+        height: 32px !important;
+        overflow: visible !important;
+    }
+
+    /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
+    .p-dialog-header-close *,
+    .p-dialog-close *,
+    button[class*="-close"] * {
+        position: relative !important;
+        z-index: 2 !important; /* Forces the character to always float above the circle background */
+        display: inline-block !important;
+        line-height: 32px !important;
+        height: 32px !important;
+        width: 32px !important;
+        text-align: center !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* 3. Create a clean hidden circular layer right behind the icon character */
+    .p-dialog-header-close::before,
+    .p-dialog-close::before,
+    button[class*="-close"]::before,
+    #cm-manager-dialog button[onclick*="close"]::before,
+    .comfy-modal button[onclick*="close"]::before {
+        content: "" !important;
+        position: absolute !important;
+        z-index: 1 !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 30px !important;
+        height: 30px !important;
+        border-radius: 50% !important;
+        background-color: transparent !important;
+        box-sizing: border-box !important;
+        transition: background-color 0.2s ease-in-out !important;
+        
+        /* -------------------------------------------------------------
+           OPTICAL ADJUSTMENT SHIFT RULES:
+           Changed from -55% to -74.5% to nudge the circle slightly left!
+           ------------------------------------------------------------- */
+        transform: translate(-74.5%, -50%) !important; 
+    }
+
+    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
+    .p-dialog-header-close:hover::before,
+    .p-dialog-close:hover::before,
+    button[class*="-close"]:hover::before,
+    #cm-manager-dialog button[onclick*="close"]:hover::before,
+    .comfy-modal button[onclick*="close"]:hover::before {
+        background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+`;
+document.head.appendChild(customHoverStyle);
+
 var docStyle = document.createElement('style');
 docStyle.innerHTML = `
 .comfy-toast {
@@ -259,8 +338,11 @@ const style = `
 	width: auto;
 	position: relative;
 	overflow: hidden;
-	background-color: var(--comfy-menu-secondary-bg);
-	border-color: var(--border-color);
+	cursor: pointer;
+	padding: 0.5em 0.5em;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--comfy-menu-secondary-bg);
 	color: var(--input-text);
 }
 
@@ -272,6 +354,9 @@ const style = `
 	background-color: #500000 !important;
 	border-color: #88181b !important;
 	color: white !important;
+	width: 100%;
+	padding: 0.5em 0.5em;
+	border-radius: 6px;
 }
 
 .cm-button-red:hover {


### PR DESCRIPTION
### Visual Transformation of the ComfyUI Manager Buttons Style: 

**Permanently fix the broken buttons style and imperfection:** 

1. **Top-Right Close Button:**

- > **Original Style:** Suffered from an unstyled layout bug caused by a framework conflict. On idle, it was trapped inside a faint, boxy square outline. On cursor hover, the background remained static, broken, or glitched into a rough square format with misaligned spacing.

- **Upgraded Style:** It is completely clean and boundary-free on idle, displaying only a minimal "X" icon. On cursor hover, it transitions seamlessly to show a soft, light-grey circular backplate that is balanced and centered around the icon.


2. **Main Action Buttons & Component Toggles:**

- > **Original Style:** Displayed flat, standard grey rect-containers with generic, unshaded text overlays and stark borders. The layout spacing lacked clear visual feedback transitions when moving between active selection boxes and passive buttons.

- **Upgraded Style:** Integrated into a unified dark-mode dashboard template. Features clean borders, optimized horizontal grid alignments, clear micro-shadow separation between actionable menu paths, and smooth color changes on hover to make navigation intuitive.



Before:
<img width="1637" height="878" alt="2026-08-22_12-34-41" src="https://github.com/user-attachments/assets/62005512-bff6-4ead-9ba8-5f0baec6c6d8" />

After (Idle):
<img width="1632" height="904" alt="2026-08-22_12-53-44" src="https://github.com/user-attachments/assets/983e330d-393c-48c5-bde2-7426bcba9a4a" />

After (Hovering):
<img width="1635" height="906" alt="2026-08-22_12-11-21" src="https://github.com/user-attachments/assets/6f391fc8-5c6a-4866-8a06-adffd3a43b57" />

> patch-1 is incorporated in the current patch update.