### PR TITLE
Update model-manager.js Close Button

### DIFF
--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -131,7 +131,7 @@ customHoverStyle.innerHTML = `
         transition: background-color 0.2s ease-in-out !important;
         
         /* Your exact calibrated optical visual balance */
-        transform: translate(-55%, -50%) !important; 
+        transform: translate(-74.5%, -50%) !important; 
     }
 
     /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -135,23 +135,24 @@ customHoverStyle.innerHTML = `
     }
 
     /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
-    #cm-manager-dialog .p-dialog-header-close:hover::before,
-    #cm-manager-dialog .p-dialog-close:hover::before,
-    #cm-manager-dialog button[class*="-close"]:hover::before,
-    #cm-manager-dialog button[onclick*="close"]:hover::before,
-    .comfy-modal .p-dialog-header-close:hover::before,
-    .comfy-modal .p-dialog-close:hover::before,
-    .comfy-modal button[class*="-close"]:hover::before,
-    .comfy-modal button[onclick*="close"]:hover::before,
-    .comfy-dialog .comfy-menu-close:hover::before,
-    .comfy-dialog button[class*="close"]:hover::before,
-    .comfy-panel .comfy-menu-close:hover::before,
-    .comfy-panel button[class*="close"]:hover::before,
-    div[class*="cn-manager"] button[class*="close"]:hover::before,
-    div[class*="cn-manager"] .comfy-menu-close:hover::before,
-    div[class*="mm-manager"] button[class*="close"]:hover::before,
-    div[class*="mm-manager"] .comfy-menu-close:hover::before {
+    #cm-manager-dialog .p-dialog-header-close:focus-visible::before,
+    #cm-manager-dialog .p-dialog-close:focus-visible::before,
+    #cm-manager-dialog button[class*="-close"]:focus-visible::before,
+    #cm-manager-dialog button[onclick*="close"]:focus-visible::before,
+    .comfy-modal .p-dialog-header-close:focus-visible::before,
+    .comfy-modal .p-dialog-close:focus-visible::before,
+    .comfy-modal button[class*="-close"]:focus-visible::before,
+    .comfy-modal button[onclick*="close"]:focus-visible::before,
+    .comfy-dialog .comfy-menu-close:focus-visible::before,
+    .comfy-dialog button[class*="close"]:focus-visible::before,
+    .comfy-panel .comfy-menu-close:focus-visible::before,
+    .comfy-panel button[class*="close"]:focus-visible::before,
+    div[class*="cn-manager"] button[class*="close"]:focus-visible::before,
+    div[class*="cn-manager"] .comfy-menu-close:focus-visible::before,
+    div[class*="mm-manager"] button[class*="close"]:focus-visible::before,
+    div[class*="mm-manager"] .comfy-menu-close:focus-visible::before {
         background-color: rgba(255, 255, 255, 0.15) !important;
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75) !important;
     }
 `;
 document.head.appendChild(customHoverStyle);

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -28,6 +28,134 @@ const pageHtml = `
 </div>
 `;
 
+// =========================================================================
+// HOVER GREY CIRCLE HOOK (GLOBAL - DIALOGS, CUSTOM-NODES, & MODEL MANAGER)
+// =========================================================================
+const customHoverStyle = document.createElement('style');
+customHoverStyle.innerHTML = `
+    /* 1. Setup the main close button container cleanly across all dialogs and panels */
+    #cm-manager-dialog .p-dialog-header-close,
+    #cm-manager-dialog .p-dialog-close,
+    #cm-manager-dialog button[class*="-close"],
+    #cm-manager-dialog button[onclick*="close"],
+    .comfy-modal .p-dialog-header-close,
+    .comfy-modal .p-dialog-close,
+    .comfy-modal button[class*="-close"],
+    .comfy-modal button[onclick*="close"],
+    .comfy-dialog .comfy-menu-close,
+    .comfy-dialog button[class*="close"],
+    .comfy-panel .comfy-menu-close,
+    .comfy-panel button[class*="close"],
+    
+    /* CUSTOM-NODES-MANAGER SELECTORS */
+    div[class*="cn-manager"] button[class*="close"],
+    div[class*="cn-manager"] .comfy-menu-close,
+    .cn-manager-dialog button[class*="close"],
+    .cn-manager-dialog .comfy-menu-close,
+    
+    /* TARGETS THE MODEL-MANAGER.JS DIALOG LAYOUT CLASSES */
+    div[class*="mm-manager"] button[class*="close"],
+    div[class*="mm-manager"] .comfy-menu-close,
+    .mm-manager-dialog button[class*="close"],
+    .mm-manager-dialog .comfy-menu-close {
+        border: none !important;
+        outline: none !important;
+        box-shadow: none !important;
+        background: transparent !important;
+        background-color: transparent !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        box-sizing: border-box !important;
+        position: relative !important;
+        width: 32px !important;
+        height: 32px !important;
+        overflow: visible !important;
+    }
+
+    /* 2. Lock the "X" character itself dead-center using perfect structural text metrics */
+    #cm-manager-dialog .p-dialog-header-close *,
+    #cm-manager-dialog .p-dialog-close *,
+    #cm-manager-dialog button[class*="-close"] *,
+    .comfy-modal .p-dialog-header-close *,
+    .comfy-modal .p-dialog-close *,
+    .comfy-modal button[class*="-close"] *,
+    .comfy-dialog .comfy-menu-close *,
+    .comfy-dialog button[class*="close"] *,
+    .comfy-panel .comfy-menu-close *,
+    .comfy-panel button[class*="close"] *,
+    div[class*="cn-manager"] button[class*="close"] *,
+    div[class*="cn-manager"] .comfy-menu-close *,
+    div[class*="mm-manager"] button[class*="close"] *,
+    div[class*="mm-manager"] .comfy-menu-close * {
+        position: relative !important;
+        z-index: 2 !important;
+        display: inline-block !important;
+        line-height: 32px !important;
+        height: 32px !important;
+        width: 32px !important;
+        text-align: center !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* 3. Create a clean hidden circular layer right behind the icon character */
+    #cm-manager-dialog .p-dialog-header-close::before,
+    #cm-manager-dialog .p-dialog-close::before,
+    #cm-manager-dialog button[class*="-close"]::before,
+    #cm-manager-dialog button[onclick*="close"]::before,
+    .comfy-modal .p-dialog-header-close::before,
+    .comfy-modal .p-dialog-close::before,
+    .comfy-modal button[class*="-close"]::before,
+    .comfy-modal button[onclick*="close"]::before,
+    .comfy-dialog .comfy-menu-close::before,
+    .comfy-dialog button[class*="close"]::before,
+    .comfy-panel .comfy-menu-close::before,
+    .comfy-panel button[class*="close"]::before,
+    div[class*="cn-manager"] button[class*="close"]::before,
+    div[class*="cn-manager"] .comfy-menu-close::before,
+    div[class*="mm-manager"] button[class*="close"]::before,
+    div[class*="mm-manager"] .comfy-menu-close::before {
+        content: "" !important;
+        position: absolute !important;
+        z-index: 1 !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 30px !important;
+        height: 30px !important;
+        border-radius: 50% !important;
+        background-color: transparent !important;
+        box-sizing: border-box !important;
+        transition: background-color 0.2s ease-in-out !important;
+        
+        /* Your exact calibrated optical visual balance */
+        transform: translate(-74.5%, -50%) !important; 
+    }
+
+    /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */
+    #cm-manager-dialog .p-dialog-header-close:hover::before,
+    #cm-manager-dialog .p-dialog-close:hover::before,
+    #cm-manager-dialog button[class*="-close"]:hover::before,
+    #cm-manager-dialog button[onclick*="close"]:hover::before,
+    .comfy-modal .p-dialog-header-close:hover::before,
+    .comfy-modal .p-dialog-close:hover::before,
+    .comfy-modal button[class*="-close"]:hover::before,
+    .comfy-modal button[onclick*="close"]:hover::before,
+    .comfy-dialog .comfy-menu-close:hover::before,
+    .comfy-dialog button[class*="close"]:hover::before,
+    .comfy-panel .comfy-menu-close:hover::before,
+    .comfy-panel button[class*="close"]:hover::before,
+    div[class*="cn-manager"] button[class*="close"]:hover::before,
+    div[class*="cn-manager"] .comfy-menu-close:hover::before,
+    div[class*="mm-manager"] button[class*="close"]:hover::before,
+    div[class*="mm-manager"] .comfy-menu-close:hover::before {
+        background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+`;
+document.head.appendChild(customHoverStyle);
+
 export class ModelManager {
 	static instance = null;
 

--- a/js/model-manager.js
+++ b/js/model-manager.js
@@ -131,7 +131,7 @@ customHoverStyle.innerHTML = `
         transition: background-color 0.2s ease-in-out !important;
         
         /* Your exact calibrated optical visual balance */
-        transform: translate(-74.5%, -50%) !important; 
+        transform: translate(-55%, -50%) !important; 
     }
 
     /* 4. Trigger the gray coloration ONLY onto our floating background layer on cursor hover */


### PR DESCRIPTION
### UI/UX Optimization of the ComfyUI Manager Dashboard1. Core Framework Overrides & Layout Synchronization:
**Maintain the same style as the main UI**

**1. Core Framework Overrides & Layout Synchronization**

- > **Original Style:** The top-right close button (×) suffered from an unstyled layout flash glitch caused by a structural style race condition across comfyui-manager.js, custom-nodes-manager.js, and model-manager.js. On startup and during active database loading states (Loading custom nodes (cache) ...), the close icon was trapped inside an unstyled boxy outline, completely losing its alignment metrics and scaling proportions.

-  **Updated Style:** Wiped out all inherited border boundaries, tracking boxes, and box-shadow outlines, shifting the button container into a clean, transparent, boundary-free profile on idle. The script was modified using a localized <style> block to capture the asynchronous loading sequences natively, enforcing crisp, unwarped structural dimensions from the very first frame the DOM node initializes.

**2. Optical Alignment Calibration & Hover Feedback**

- > **Original Style:** The native font glyph calculations for the letter X forced a mathematical center layout that created an optical illusion, making the icon look pushed off-center and tilted to the right. When moving the cursor pointer over the target button, the background remained static, unshaded, or glitched into a rough square frame.

- **Updated Style:** Separated the close character layer from the background container to allow independent spatial manipulation. The X character remains securely center-locked using precise text padding metrics, while an isolated, floating pseudo-element (::before) layer generates an elegant, light-grey circular backplate (rgba(255, 255, 255, 0.15)) exclusively on cursor hover.

- **Precision Tuning:** Fine-tuned the horizontal coordinate alignment metrics across the separate panel scripts (calibrating the main dialogs to transform: translate(-74.5%, -50%) and the sub-manager loading sheets to transform: translate(-55%, -50%)) to completely eliminate the optical illusion, ensuring a visually perfect, eye-centered layout across all dashboard modules.

Before:
<img width="2153" height="1159" alt="2026-08-22_16-16-57" src="https://github.com/user-attachments/assets/f5ad4b2b-70a6-4869-8150-9ea2a9970422" />

After:
<img width="2151" height="1174" alt="2026-08-22_16-19-09" src="https://github.com/user-attachments/assets/34b8dc6d-469f-4f2a-b5de-31a32155fe40" />
