### PR TITLE
Update snapshot.js Close Button

### DIFF
--- a/js/snapshot.js
+++ b/js/snapshot.js
@@ -4,6 +4,76 @@ import { ComfyDialog, $el } from "../../scripts/ui.js";
 import { manager_instance, rebootAPI, show_message, handle403Response, loadCss } from  "./common.js";
 import { buildGuiFrame } from "./comfyui-gui-builder.js";
 
+// =========================================================================
+// PERMANENT FIX FOR SNAPSHOT MANAGER CLOSE BUTTON (LOCAL SOURCE HOOK)
+// =========================================================================
+const snapshotCustomStyle = document.createElement('style');
+snapshotCustomStyle.innerHTML = `
+    /* 1. Clear out the unstyled bounding box and borders on idle */
+    [id*="snapshot"] button[class*="close"],
+    [id*="snapshot"] .p-dialog-header-close,
+    [id*="snapshot"] .comfy-menu-close,
+    .snapshot-dialog button[class*="close"],
+    .snapshot-dialog .comfy-menu-close {
+        border: none !important;
+        outline: none !important;
+        box-shadow: none !important;
+        background: transparent !important;
+        background-color: transparent !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        box-sizing: border-box !important;
+        position: relative !important;
+        width: 32px !important;
+        height: 32px !important;
+        overflow: visible !important;
+    }
+
+    /* 2. Dead-center the inner font "X" text element inside the layout box */
+    [id*="snapshot"] button[class*="close"] *,
+    [id*="snapshot"] .comfy-menu-close * {
+        position: relative !important;
+        z-index: 2 !important;
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        width: auto !important;
+        height: auto !important;
+        line-height: 1 !important;
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+
+    /* 3. Pre-create the hidden circular layer right behind the icon character */
+    [id*="snapshot"] button[class*="close"]::before,
+    [id*="snapshot"] .comfy-menu-close::before {
+        content: "" !important;
+        position: absolute !important;
+        z-index: 1 !important;
+        top: 50% !important;
+        left: 50% !important;
+        width: 30px !important;
+        height: 30px !important;
+        border-radius: 50% !important;
+        background-color: transparent !important;
+        box-sizing: border-box !important;
+        transition: background-color 0.2s ease-in-out !important;
+        
+        /* Applied your verified eye-centered sub-manager ratio alignment lock */
+        transform: translate(-55%, -50%) !important; 
+    }
+
+    /* 4. Trigger the grey circular fill exclusively on cursor hover */
+    [id*="snapshot"] button[class*="close"]:hover::before,
+    [id*="snapshot"] .comfy-menu-close:hover::before {
+        background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+`;
+document.head.appendChild(snapshotCustomStyle);
+
 loadCss("./snapshot.css");
 
 async function restore_snapshot(target) {

--- a/js/snapshot.js
+++ b/js/snapshot.js
@@ -66,10 +66,18 @@ snapshotCustomStyle.innerHTML = `
         transform: translate(-55%, -50%) !important; 
     }
 
-    /* 4. Trigger the grey circular fill exclusively on cursor hover */
+    /* 4. Trigger the grey circular fill on cursor hover OR keyboard focus */
     [id*="snapshot"] button[class*="close"]:hover::before,
-    [id*="snapshot"] .comfy-menu-close:hover::before {
+    [id*="snapshot"] .comfy-menu-close:hover::before,
+    [id*="snapshot"] button[class*="close"]:focus-visible::before,
+    [id*="snapshot"] .comfy-menu-close:focus-visible::before {
         background-color: rgba(255, 255, 255, 0.15) !important;
+    }
+
+    /* 5. Add an accessibility glow ring ONLY during keyboard navigation focus */
+    [id*="snapshot"] button[class*="close"]:focus-visible::before,
+    [id*="snapshot"] .comfy-menu-close:focus-visible::before {
+        box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75) !important;
     }
 `;
 document.head.appendChild(snapshotCustomStyle);


### PR DESCRIPTION
### Component-Specific Style Refinement of the ComfyUI Manager Dashboard

**Maintain the same style as the main UI**

**1. Snapshot Manager Interface Harmonization:**

- > **Original Style:** The top-right close icon (×) inside the Snapshot Manager dialog panel suffered from a layout styling exclusion bug. On idle, it was enclosed by a prominent, unstyled square framework box outline that broken the visual continuity of the interface. On cursor hover, the component remained completely transparent and lacked tactile response or alignment properties.

- **Updated Style:** Fully stripped away all inherited container borders, default box outlines, and edge tracking constraints to establish a transparent, boundary-free profile on idle. The button layout logic was corrected locally at the file entrypoint by embedding a dedicated, non-blocking <style> hook right at the top of snapshot.js to ensure the layout parameters register instantaneously when the popup script initializes.

**2. Localized Spatial Alignment Calibration**

- > **Original Style:** Standard browser formatting rules applied a rigid geometric center calculation to the font glyph character X. This technical alignment generated an optical illusion, making the close cross icon appear pushed out of bounds and visually unbalanced to the right of its relative interactive frame.

- **Updated Style:** Isolated the internal text character metrics from the background container layout layers to enable precision tuning across asynchronous framework modules. The character font bounds were scaled and center-locked cleanly, while an independent, floating pseudo-element (::before) layer generates an elegant, light-grey circular backplate (rgba(255, 255, 255, 0.15)) exclusively during interactive mouse hover states.

- **Precision Tuning:** Calibrated the horizontal transformation mapping specifically for the sub-manager panel layers to an eye-centered ratio lock (transform: translate(-55%, -50%)). This manual offset adjustment neutralizes the font rendering illusion, ensuring a visually balanced, pixel-perfect close button configuration across all sub-manager layout dialogs.

Before:
<img width="2158" height="1237" alt="2026-08-22_17-45-20" src="https://github.com/user-attachments/assets/d0e03e47-7ed9-47be-a045-4697d45ea48f" />

After (Hovering):
<img width="2145" height="1231" alt="2026-08-22_18-07-05" src="https://github.com/user-attachments/assets/6feef039-5471-4a88-a322-f0665ff10e70" />
