### PR TITLE
Update custom-nodes-manager.css old close button override

### DIFF
--- a/js/custom-nodes-manager.css
+++ b/js/custom-nodes-manager.css
@@ -727,3 +727,85 @@
 .cn-manager-light .cn-btn-install {
 	background-color: #333;
 }
+/* =========================================================================
+   UNIVERSAL ZERO-FLASH CLOSE BUTTON FACTORY OVERRIDE
+   ========================================================================= */
+
+/* 1. Base button layout setup */
+#cm-manager-dialog .p-dialog-header-close,
+#cm-manager-dialog .p-dialog-close,
+.comfy-modal .p-dialog-header-close,
+.comfy-modal .p-dialog-close,
+.comfy-dialog .comfy-menu-close,
+.comfy-panel .comfy-menu-close,
+.comfy-close-btn {
+    float: none !important;
+    position: absolute !important;
+    top: 12px !important;
+    right: 12px !important; 
+    left: auto !important;
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
+    background: transparent !important;
+    background-color: transparent !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    box-sizing: border-box !important;
+    width: 32px !important;
+    height: 32px !important;
+    overflow: visible !important;
+}
+
+/* 2. Dead-center text icon alignments */
+#cm-manager-dialog .p-dialog-header-close *,
+.comfy-modal .p-dialog-header-close *,
+.comfy-close-btn * {
+    position: relative !important;
+    z-index: 2 !important;
+    display: inline-block !important;
+    line-height: 32px !important;
+    height: 32px !important;
+    width: 32px !important;
+    text-align: center !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+/* 3. Pre-create the hidden circular vector layer behind the icon */
+#cm-manager-dialog .p-dialog-header-close::before,
+.comfy-modal .p-dialog-header-close::before,
+.comfy-close-btn::before {
+    content: "" !important;
+    position: absolute !important;
+    z-index: 1 !important;
+    top: 50% !important;
+    left: 50% !important;
+    width: 30px !important;
+    height: 30px !important;
+    border-radius: 50% !important;
+    background-color: transparent !important;
+    box-sizing: border-box !important;
+    transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out !important;
+    transform: translate(-74.5%, -50%) !important; 
+}
+
+/* 4. Smooth gray circle activation on mouse hover OR keyboard tab selection */
+#cm-manager-dialog .p-dialog-header-close:hover::before,
+.comfy-modal .p-dialog-header-close:hover::before,
+.comfy-close-btn:hover::before,
+#cm-manager-dialog .p-dialog-header-close:focus-visible::before,
+.comfy-modal .p-dialog-header-close:focus-visible::before,
+.comfy-close-btn:focus-visible::before {
+    background-color: rgba(255, 255, 255, 0.15) !important;
+}
+
+/* 5. Add an accessibility glow ring ONLY during keyboard focus navigation loops */
+#cm-manager-dialog .p-dialog-header-close:focus-visible::before,
+.comfy-modal .p-dialog-header-close:focus-visible::before,
+.comfy-close-btn:focus-visible::before {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.75) !important;
+}

--- a/js/custom-nodes-manager.css
+++ b/js/custom-nodes-manager.css
@@ -733,9 +733,9 @@
 
 /* 1. Base button layout setup */
 #cm-manager-dialog .p-dialog-header-close,
-#cm-manager-dialog .p-dialog-close,
+#cm-manager-dialog .p-dialog-close-button,
 .comfy-modal .p-dialog-header-close,
-.comfy-modal .p-dialog-close,
+.comfy-modal .p-dialog-close-button,
 .comfy-dialog .comfy-menu-close,
 .comfy-panel .comfy-menu-close,
 .comfy-close-btn {

--- a/js/custom-nodes-manager.css
+++ b/js/custom-nodes-manager.css
@@ -733,9 +733,9 @@
 
 /* 1. Base button layout setup */
 #cm-manager-dialog .p-dialog-header-close,
-#cm-manager-dialog .p-dialog-close-button,
+#cm-manager-dialog .p-dialog-close,
 .comfy-modal .p-dialog-header-close,
-.comfy-modal .p-dialog-close-button,
+.comfy-modal .p-dialog-close,
 .comfy-dialog .comfy-menu-close,
 .comfy-panel .comfy-menu-close,
 .comfy-close-btn {


### PR DESCRIPTION

### UI/UX Optimization of the ComfyUI Manager Dashboard1. Core Framework Overrides & Layout Synchronization:
**Maintain the same style as the main UI while loading and after.**
ZERO-FLASH CLOSE BUTTON FACTORY OVERRIDE

**1. Core Framework Overrides & Layout Synchronization**

- > **Original Style:** The top-right close button (×) suffered from an unstyled layout flash glitch caused by a structural style race condition across comfyui-manager.js, custom-nodes-manager.js, and model-manager.js. On startup and during active database loading states (Loading custom nodes (cache) ...), the close icon was trapped inside an unstyled boxy outline, completely losing its alignment metrics and scaling proportions.

-  **Updated Style:** Wiped out all inherited border boundaries, tracking boxes, and box-shadow outlines, shifting the button container into a clean, transparent, boundary-free profile on idle. The script was modified using a localized <style> block to capture the asynchronous loading sequences natively, enforcing crisp, unwarped structural dimensions from the very first frame the DOM node initializes.

**2. Optical Alignment Calibration & Hover Feedback**

- > **Original Style:** The native font glyph calculations for the letter X forced a mathematical center layout that created an optical illusion, making the icon look pushed off-center and tilted to the right. When moving the cursor pointer over the target button, the background remained static, unshaded, or glitched into a rough square frame.

- **Updated Style:** Separated the close character layer from the background container to allow independent spatial manipulation. The X character remains securely center-locked using precise text padding metrics, while an isolated, floating pseudo-element (::before) layer generates an elegant, light-grey circular backplate (rgba(255, 255, 255, 0.15)) exclusively on cursor hover.

- **Precision Tuning:** Fine-tuned the horizontal coordinate alignment metrics across the separate panel scripts (calibrating the main dialogs to transform: translate(-74.5%, -50%) and the sub-manager loading sheets to transform: translate(-55%, -50%)) to completely eliminate the optical illusion, ensuring a visually perfect, eye-centered layout across all dashboard modules.

This patch depends on #3188

Before:
<img width="2160" height="1179" alt="2026-08-22_16-04-11" src="https://github.com/user-attachments/assets/dad31d08-fe8d-47a5-ba1f-00cdd5fa836c" />

After:
<img width="2162" height="1172" alt="2026-08-22_16-15-53" src="https://github.com/user-attachments/assets/28f2dcdb-8c74-4372-97c7-d914821ae9bf" />

After (Hovering/Loading):
<img width="2150" height="1172" alt="2026-08-22_16-52-44" src="https://github.com/user-attachments/assets/99e372c1-9824-4012-bbdb-26210715c9cd" />