### PR TITLE
Update comfyui-gui-builder.js Universal close button override

### DIFF
--- a/js/comfyui-gui-builder.js
+++ b/js/comfyui-gui-builder.js
@@ -176,6 +176,34 @@ export function buildGuiFrameCustomHeader(dialogId, customHeader, content, owner
 		}
 	);
 
+    // =========================================================================
+    // UNIVERSAL ZERO-FLASH CLOSE BUTTON FACTORY OVERRIDE
+    // =========================================================================
+    if (close_button) {
+        close_button.className += " comfy-close-btn"; // Hooks cleanly into your global hover circle sheet
+
+        // Instantly strips the default layout styles before the browser can draw them
+        close_button.style.setProperty("float", "none", "important");
+        close_button.style.setProperty("position", "absolute", "important");
+        close_button.style.setProperty("top", "12px", "important");
+        close_button.style.setProperty("right", "12px", "important");
+        close_button.style.setProperty("border", "none", "important");
+        close_button.style.setProperty("outline", "none", "important");
+        close_button.style.setProperty("box-shadow", "none", "important");
+        close_button.style.setProperty("background", "transparent", "important");
+        close_button.style.setProperty("background-color", "transparent", "important");
+        close_button.style.setProperty("padding", "0", "important");
+        close_button.style.setProperty("margin", "0", "important");
+        close_button.style.setProperty("width", "32px", "important");
+        close_button.style.setProperty("height", "32px", "important");
+        close_button.style.setProperty("display", "inline-flex", "important");
+        close_button.style.setProperty("align-items", "center", "important");
+        close_button.style.setProperty("justify-content", "center", "important");
+        close_button.style.setProperty("overflow", "visible", "important");
+        close_button.style.setProperty("line-height", "1", "important");
+        close_button.style.setProperty("cursor", "pointer", "important");
+    }	
+	
 	const _customHeader = normalizeContent(customHeader);
 	const dialog_header = $el("div.p-dialog-header",
 		[


### PR DESCRIPTION
### Visual Shield Blueprint: Close Button Factory Override

This code patch serves as an immediate style enforcement override block inside comfyui-gui-builder.js to eliminate browser layout delay. By intercepting the close button at its source, it rewrites the button properties directly in memory before the first frame paints onto your screen.

- > **Original Style Structural Layout:** In the native setup, the button was created using standard inline layout commands (style.float = "right"). It featured default solid browser background colors, visible borders, default margins, and unconstrained padding. This framework made the button completely dependent on the parent container width. Because of this, an unstyled square box flashed on the screen every time a menu opened, and the button would jump or wiggle to the left when asynchronous data loading triggered vertical scrollbars.

- **Updated Style Structural Layout:** The new code block strips away the layout properties by assigning the custom comfy-close-btn class tag and forcing aggressive layout properties via style.setProperty(..., "important"). It completely removes the element from the shifting document layout flow using position: absolute, anchoring it into a static position at top: 12px and right: 12px. All background colors, borders, and outlines are set to transparent. Finally, it creates a rigid 32px by 32px flexbox collision wrapper (display: inline-flex). This ensures that the close icon stays centered and locked in place, while seamlessly adopting your custom gray hover circles and keyboard accessibility glow rings.

This patch depends on #3188

Before (loading):
<img width="2171" height="1178" alt="2026-08-22_16-20-04" src="https://github.com/user-attachments/assets/ce50455f-f4de-4a7f-84ce-f70ecaecc7cc" />

After:
<img width="2151" height="1174" alt="2026-08-22_16-19-09" src="https://github.com/user-attachments/assets/403a4a2e-e2bd-4115-9e18-99fa7fc9edab" />

After (loading/hovering):
<img width="2150" height="1172" alt="2026-08-22_16-52-44" src="https://github.com/user-attachments/assets/fba11497-15f5-4624-884b-8b3f42e186f8" />
