### PR TITLE
fix(restore-snapshot): report failures and honor the pinned commit in the git fallback

### DIFF
--- a/glob/manager_core.py
+++ b/glob/manager_core.py
@@ -3479,13 +3479,24 @@ async def restore_snapshot(snapshot_path, git_helper_extras=None):
         if x in git_info:
             del git_info[x]
 
-    for repo_url in git_info.keys():
+    for repo_url, repo_info in git_info.items():
         repo_name = os.path.basename(repo_url)
         if repo_name.endswith('.git'):
             repo_name = repo_name[:-4]
 
         to_path = os.path.join(get_default_custom_nodes_path(), repo_name)
-        unified_manager.repo_install(repo_url, to_path, instant_execution=True, no_deps=False, return_postinstall=False)
+        res = unified_manager.repo_install(repo_url, to_path, instant_execution=True, no_deps=False, return_postinstall=False)
+        if not res.result:
+            print(f"[ComfyUI-Manager] Failed to restore '{repo_url}': {res.msg}")
+            failed.append(repo_name)
+            continue
+
+        commit_hash = repo_info.get('hash')
+        if commit_hash and repo_switch_commit(to_path, commit_hash) is None:
+            print(f"[ComfyUI-Manager] Failed to check out '{commit_hash}' for '{repo_url}'")
+            failed.append(f"{repo_name}@{commit_hash}")
+            continue
+
         cloned_repos.append(repo_name)
 
     manager_util.restore_pip_snapshot(pips, git_helper_extras)


### PR DESCRIPTION
Summary
The last loop in restore_snapshot() — the one that installs whatever git_custom_nodes entries are left after the CNR and unknown-node passes — has two problems:

It throws away the return value of repo_install() and appends the repo to cloned_repos unconditionally. A repo that failed to clone still gets printed as [ INSTALLED ] in the summary, and nothing shows up in failed.
It never checks out the commit stored in the snapshot. repo_install() clones the remote's default branch, so the restored node ends up on whatever HEAD happens to be, not the revision the snapshot pinned. Every other restore path in this function goes through repo_switch_commit(); this one doesn't.
The second one is the more annoying of the two in practice — you restore a snapshot expecting a specific revision and silently get a different one.

Fix
Check res.result before reporting success, and call repo_switch_commit() with the hash from git_info after a successful clone. Failures in either step are reported in failed with a message instead of being swallowed.

Test plan
 Snapshot with a git entry not matched by the CNR/unknown passes, repo reachable — confirm it's cloned and checked out at the pinned hash
 Same, but with an unreachable URL — confirm it lands in failed instead of [ INSTALLED ]
 Same, but with a hash that doesn't exist in the repo — confirm the checkout failure is reported
 Snapshot where everything resolves through CNR — confirm no behavior change