### PR TITLE
test: pin the loopback requirement in the install-denial constants

### DIFF
--- a/tests/test_install_flags_gates.py
+++ b/tests/test_install_flags_gates.py
@@ -374,6 +374,10 @@ class DenialConstantsTest(unittest.TestCase):
     def _assert_honest_copy(self, const, flag_name):
         self.assertIn(flag_name, const, "constant must name the responsible flag")
         self.assertIn("config.ini", const, "constant must name config.ini")
+        # The gate is `flag AND loopback` (is_dedicated_install_allowed), so a
+        # message that stops at the flag sends non-loopback users to re-check a
+        # setting they already enabled.
+        self.assertIn("loopback", const, "constant must name the loopback requirement")
         for cause_phrasing in (
             "is not allowed in this security_level",
             "set the security level",


### PR DESCRIPTION
## Problem

`is_dedicated_install_allowed` gates on `flag AND loopback`. ffb2f03 rewrote `SECURITY_MESSAGE_FLAG_GIT_URL` and `SECURITY_MESSAGE_FLAG_PIP` to state both halves, because a message naming only the flag sends a non-loopback user back to re-check a setting they had already enabled.

`_assert_honest_copy` already pins the rest of that copy: the flag name, `config.ini`, and the absence of `security_level` phrasings that would misattribute the cause. The loopback half is not pinned, so a later edit can drop it again without failing a test.

## Fix

One assertion in the existing helper, which covers both constants through `test_flag_constants_content`.

## Evidence

Against `main` at f39cbd5, Python 3.11.9:

```
$ python -m unittest tests.test_install_flags_gates
Ran 11 tests in 0.042s

OK
```

The suite passes unchanged with the assertion added. To confirm it is load-bearing rather than vacuous, removing the loopback clause from `SECURITY_MESSAGE_FLAG_GIT_URL` fails it:

```
AssertionError: 'loopback' not found in "ERROR: This action requires
'allow_git_url_install = true' in config.ini ([default] section). ..."
: constant must name the loopback requirement

Ran 11 tests in 0.038s

FAILED (failures=1)
```

## Note

This is the part of #3136 that still applies. I opened that one before ffb2f03, 4fe65b0 and 98be899 landed, and those cover the behaviour it was proposing and more, so I have closed it as superseded.
