### PR TITLE
Add SenseNova U1.5 (T8) to custom node list

### DIFF
--- a/custom-node-list.json
+++ b/custom-node-list.json
@@ -61154,6 +61154,16 @@
             ],
             "install_type": "git-clone",
             "description": "ComfyUI nodes for Krea 2 AnyPaint arbitrary-mask inpainting and outpainting"
+        },
+        {
+            "author": "T8mars",
+            "title": "SenseNova U1.5 (T8)",
+            "reference": "https://github.com/T8mars/Comfyui-SenseNova-U1.5-Wrapper-T8",
+            "files": [
+                "https://github.com/T8mars/Comfyui-SenseNova-U1.5-Wrapper-T8"
+            ],
+            "install_type": "git-clone",
+            "description": "Native ComfyUI nodes for SenseNova U1.5 text-to-image generation and multi-reference image editing, with Final/SFT checkpoint loading, official 8-step LoRA support, batch generation, structured edit prompts, and advanced guidance controls."
         }
     ]
 }


### PR DESCRIPTION
## Summary

Add SenseNova U1.5 (T8) to the ComfyUI-Manager custom node list.

The package provides native ComfyUI V3 nodes for:
- SenseNova U1.5 Final and SFT text-to-image generation
- one to ten reference images for image editing
- official 8-step LoRA acceleration
- batch generation, structured edit prompts, CFG controls, and prefix caching

## Project readiness

- Published on the official Comfy Registry as sensenova-u15-t8 (v1.3.6)
- Registry publishing validation and security checks pass
- Includes node_list.json for all eight V3 schema IDs so Install Missing Custom Nodes can identify the package
- CI covers Ruff and ComfyUI 0.31 / 0.34.0 on Python 3.10 / 3.12 / 3.13 / 3.14
- Model weights are downloaded separately from the documented Hugging Face repository

## Validation

- python json-checker.py custom-node-list.json
- python -m json.tool custom-node-list.json
- confirmed the repository reference appears exactly once